### PR TITLE
Expose SLF4J Logger interface in LoggingFacade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,7 @@ project.ext {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
-    gradlePluginPortal()
 }
 
 dependencies {
@@ -108,7 +106,7 @@ apply from: 'gradle/staticCodeCheck.gradle'
 apply from: 'gradle/changelog.gradle'
 
 task initWrapper(type: Wrapper) {
-    gradleVersion = '6.8.2'
+    gradleVersion = '6.8.3'
 }
 
 // ############ Test Phase

--- a/gradle/staticCodeCheck.gradle
+++ b/gradle/staticCodeCheck.gradle
@@ -80,7 +80,7 @@ pmd {
     ignoreFailures = true
     sourceSets = [sourceSets.main, sourceSets.test]
     ruleSets = []
-    toolVersion = '6.31.0'
+    toolVersion = '6.32.0'
 }
 
 pmdMain {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,1 @@
-pluginManagement {
-    repositories {
-        mavenLocal()
-        gradlePluginPortal()
-    }
-}
-
 rootProject.name = 'neonbee-core'

--- a/src/main/java/io/neonbee/NeonBee.java
+++ b/src/main/java/io/neonbee/NeonBee.java
@@ -169,7 +169,7 @@ public class NeonBee {
             }
             Vertx.clusteredVertx(vertxOptions, result -> {
                 if (result.failed()) {
-                    logger.error("Failed to start Vertx cluster '{}'", result.cause().getMessage());
+                    logger.error("Failed to start Vertx cluster", result.cause()); // NOPMD slf4j
                     promise.fail(result.cause());
                 } else {
                     promise.complete(result.result());
@@ -483,11 +483,8 @@ public class NeonBee {
                 handler.handle(getHookRegistry().executeHooks(HookType.BEFORE_SHUTDOWN)
                         .compose(shutdownHooksExecutionOutcomes -> {
                             if (shutdownHooksExecutionOutcomes.failed()) {
-                                shutdownHooksExecutionOutcomes.<Future>list().stream().filter(Future::failed)
-                                        .forEach(future -> {
-                                            logger.error(// NOPMD slf4j
-                                                    "Shutdown hook execution failed.", future.cause());
-                                        });
+                                shutdownHooksExecutionOutcomes.<Future>list().stream().filter(Future::failed).forEach(
+                                        future -> logger.error("Shutdown hook execution failed", future.cause())); // NOPMD
                             }
                             NEONBEE_INSTANCES.remove(vertx);
                             return succeededFuture();

--- a/src/main/java/io/neonbee/NeonBeeConfig.java
+++ b/src/main/java/io/neonbee/NeonBeeConfig.java
@@ -62,9 +62,9 @@ public class NeonBeeConfig {
                     if (o instanceof String) {
                         return (String) o;
                     } else {
-                        String msg =
-                                "The attribute \"platformClasses\" of the NeonBee config must only contain Strings. Because of this value {} will be ignored.";
-                        LOGGER.warn(msg, String.valueOf(o));
+                        LOGGER.warn(
+                                "The attribute \"platformClasses\" of the NeonBee config must only contain Strings. Because of this value {} will be ignored.",
+                                String.valueOf(o));
                         return null;
                     }
                 }).filter(Objects::nonNull).collect(Collectors.toList())).orElse(List.of());

--- a/src/main/java/io/neonbee/data/DataVerticle.java
+++ b/src/main/java/io/neonbee/data/DataVerticle.java
@@ -170,9 +170,9 @@ public abstract class DataVerticle<T> extends AbstractVerticle implements DataAd
                         } else {
                             Throwable cause = asyncResult.cause();
                             if (LOGGER.isWarnEnabled()) {
-                                LOGGER.correlateWith(context).warn("Data verticle {} routine execution failed {}",
+                                LOGGER.correlateWith(context).warn("Data verticle {} routine execution failed",
                                         getQualifiedName(), cause instanceof DataException ? cause.toString() : EMPTY,
-                                        cause.getStackTrace().length != 0 ? cause : null);
+                                        cause);
                             }
 
                             if (cause instanceof DataException) {
@@ -183,7 +183,7 @@ public abstract class DataVerticle<T> extends AbstractVerticle implements DataAd
                             }
                         }
                     } catch (Exception e) {
-                        LOGGER.correlateWith(context).error(e.getMessage(), e);
+                        LOGGER.correlateWith(context).error("Processing of message failed", e);
                         message.fail(FAILURE_CODE_PROCESSING_FAILED, e.getMessage());
                     }
                 });
@@ -193,7 +193,7 @@ public abstract class DataVerticle<T> extends AbstractVerticle implements DataAd
                 return;
             } catch (DataException e) {
                 // the routine can either fail the future, or throw the DataException, if so propagate the failure
-                LOGGER.correlateWith(context).error(e.getMessage(), e);
+                LOGGER.correlateWith(context).error("Processing of message failed", e);
                 message.fail(e.failureCode(), e.getMessage());
             }
         }).completionHandler(registerDataVerticlePromise);
@@ -307,8 +307,8 @@ public abstract class DataVerticle<T> extends AbstractVerticle implements DataAd
                             } else {
                                 Throwable cause = asyncReply.cause();
                                 if (LOGGER.isWarnEnabled()) {
-                                    LOGGER.correlateWith(context).warn("Failed to receive event bus reply from {} {}",
-                                            qualifiedName, cause.toString());
+                                    LOGGER.correlateWith(context).warn("Failed to receive event bus reply from {}",
+                                            qualifiedName, cause);
                                 }
 
                                 doneHandler.fail(mapException(cause));

--- a/src/main/java/io/neonbee/data/internal/DataContextImpl.java
+++ b/src/main/java/io/neonbee/data/internal/DataContextImpl.java
@@ -256,7 +256,7 @@ public class DataContextImpl implements DataContext {
         if (!pathStack.isEmpty()) {
             DataVerticleCoordinate topVerticle = pathStack.peek();
             if (name.equalsIgnoreCase(topVerticle.getQualifiedName())) {
-                LOGGER.error("A DataVerticle {} is sending message to itself, which could lead to a dead loop.", name);
+                LOGGER.error("A DataVerticle {} is sending message to itself, which could lead to a dead loop", name);
                 throw new DataException(String.format("DataVerticle %s is sending message to itself.", name));
             }
         }

--- a/src/main/java/io/neonbee/entity/EntityVerticle.java
+++ b/src/main/java/io/neonbee/entity/EntityVerticle.java
@@ -223,8 +223,8 @@ public abstract class EntityVerticle extends DataVerticle<EntityWrapper> {
         vertx.eventBus().consumer(EVENT_BUS_MODELS_LOADED_ADDRESS, message -> {
             announceEntityVerticle(vertx, asyncResult -> {
                 if (asyncResult.failed()) {
-                    LOGGER.error("Updating announcements of entity verticle {} failed", asyncResult.cause(),
-                            getQualifiedName());
+                    LOGGER.error("Updating announcements of entity verticle {} failed", getQualifiedName(),
+                            asyncResult.cause());
                 }
             });
         });

--- a/src/main/java/io/neonbee/hook/HookRegistry.java
+++ b/src/main/java/io/neonbee/hook/HookRegistry.java
@@ -26,7 +26,7 @@ public interface HookRegistry {
             return registerInstanceHooks(hookClass.getConstructor().newInstance(), correlationId);
         } catch (Exception e) {
             LoggingFacade.create().correlateWith(correlationId)
-                    .error("Could not initialize object for class {} containing hook.", e, hookClass.getName());
+                    .error("Could not initialize object for class {} containing hook.", hookClass.getName(), e);
             return Future.failedFuture(e);
         }
     }

--- a/src/main/java/io/neonbee/internal/deploy/Deployment.java
+++ b/src/main/java/io/neonbee/internal/deploy/Deployment.java
@@ -48,8 +48,8 @@ public abstract class Deployment {
             LOGGER.correlateWith(correlationId).info("Start to undeploy: {}", identifier);
             vertx.undeploy(getDeploymentId(), asyncUndeploy -> {
                 if (asyncUndeploy.failed()) {
-                    LOGGER.correlateWith(correlationId).error("Undeployment of {} failed", asyncUndeploy.cause(),
-                            identifier);
+                    LOGGER.correlateWith(correlationId).error("Undeployment of {} failed", identifier,
+                            asyncUndeploy.cause());
                     promise.fail(asyncUndeploy.cause());
                 } else {
                     LOGGER.correlateWith(correlationId).info("Undeployment of {} succeeded", identifier);

--- a/src/main/java/io/neonbee/internal/deploy/NeonBeeModule.java
+++ b/src/main/java/io/neonbee/internal/deploy/NeonBeeModule.java
@@ -185,7 +185,7 @@ public class NeonBeeModule {
                     .collect(Collectors.toList());
             if (compositedDeployments.failed()) {
                 // Some Verticles weren't deployed successfully. -> Undeploy all successfully deployed Verticles
-                getCorrelatedLogger().error("Not all deployables of jar file ({}) deployed successfully. \n",
+                getCorrelatedLogger().error("Not all deployables of jar file ({}) deployed successfully",
                         jarPath.toAbsolutePath());
                 return failedFuture(compositedDeployments.cause());
             } else {

--- a/src/main/java/io/neonbee/internal/handler/HooksHandler.java
+++ b/src/main/java/io/neonbee/internal/handler/HooksHandler.java
@@ -35,7 +35,7 @@ public final class HooksHandler implements Handler<RoutingContext> {
                 .onComplete(asyncResult -> {
                     if (asyncResult.failed()) {
                         Throwable cause = asyncResult.cause();
-                        LOGGER.error("An error has occurred while executing the request hook.", cause);
+                        LOGGER.error("An error has occurred while executing the request hook", cause);
                         if (cause instanceof DataException) {
                             routingContext.fail(((DataException) cause).failureCode());
                         } else {

--- a/src/main/java/io/neonbee/internal/verticle/DeployerVerticle.java
+++ b/src/main/java/io/neonbee/internal/verticle/DeployerVerticle.java
@@ -60,8 +60,8 @@ public class DeployerVerticle extends WatchVerticle {
                 affectedPath.toAbsolutePath());
         NeonBeeModule.fromJar(vertx, affectedPath, correlationId).recover(t -> {
             // Log errors from inside of method Deployable.fromJarFile
-            LOGGER.correlateWith(correlationId).error("An error occurred while parsing jar file {}", t,
-                    affectedPath.toAbsolutePath());
+            LOGGER.correlateWith(correlationId).error("An error occurred while parsing jar file {}",
+                    affectedPath.toAbsolutePath(), t);
             return Future.failedFuture(t);
         }).compose(neonBeeModule ->
         // The deploy method automatically cleans up in case of failure.

--- a/src/main/java/io/neonbee/internal/verticle/ServerVerticle.java
+++ b/src/main/java/io/neonbee/internal/verticle/ServerVerticle.java
@@ -223,7 +223,7 @@ public class ServerVerticle extends AbstractVerticle {
                         }
                         startPromise.complete();
                     } else {
-                        LOGGER.error("HTTP server could not be started on port {}", port);
+                        LOGGER.error("HTTP server could not be started on port {}", port, asyncResult.cause()); // NOPMD
                         startPromise.fail(asyncResult.cause());
                     }
                 });

--- a/src/main/java/io/neonbee/job/JobVerticle.java
+++ b/src/main/java/io/neonbee/job/JobVerticle.java
@@ -129,8 +129,8 @@ public abstract class JobVerticle extends AbstractVerticle {
                 if (result.succeeded()) {
                     LOGGER.correlateWith(context).info("Job execution of {} ended successfully", getName());
                 } else {
-                    LOGGER.correlateWith(context).warn("Job execution of {} ended with failure", result.cause(),
-                            getName());
+                    LOGGER.correlateWith(context).warn("Job execution of {} ended with failure", getName(),
+                            result.cause());
                 }
 
                 // if it is a periodic schedule, schedule the next job run, otherwise finalize and end the execution

--- a/src/main/java/io/neonbee/logging/internal/LoggingFacadeImpl.java
+++ b/src/main/java/io/neonbee/logging/internal/LoggingFacadeImpl.java
@@ -8,9 +8,14 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import io.neonbee.logging.LoggingFacade;
 
+@SuppressWarnings({ "PMD.ExcessivePublicCount", "PMD.CyclomaticComplexity", "PMD.TooManyMethods" })
 public class LoggingFacadeImpl implements LoggingFacade {
     @VisibleForTesting
-    static final Marker DEFAULT_MARKER = MarkerFactory.getDetachedMarker("noCorrelationIDAvailable");
+    static final Marker DEFAULT_MARKER = MarkerFactory.getDetachedMarker("noCorrelationIdAvailable");
+
+    @VisibleForTesting
+    static final UnsupportedOperationException UNSUPPORTED_OPERATION_EXCEPTION = new UnsupportedOperationException(
+            "Using masqueraded log messages on this facade supplying an own marker is not supported");
 
     private final Logger logger;
 
@@ -38,7 +43,27 @@ public class LoggingFacadeImpl implements LoggingFacade {
 
     @Override
     public boolean isTraceEnabled() {
-        return logger.isTraceEnabled();
+        return logger.isTraceEnabled(currentMarker);
+    }
+
+    @Override
+    public boolean isTraceEnabled(Marker marker) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void trace(String msg) {
+        logger.trace(currentMarker, msg);
+    }
+
+    @Override
+    public void trace(String format, Object arg) {
+        logger.trace(currentMarker, format, arg);
+    }
+
+    @Override
+    public void trace(String format, Object arg1, Object arg2) {
+        logger.trace(currentMarker, format, arg1, arg2);
     }
 
     @Override
@@ -47,8 +72,58 @@ public class LoggingFacadeImpl implements LoggingFacade {
     }
 
     @Override
+    public void trace(String msg, Throwable t) {
+        logger.trace(currentMarker, msg, t);
+    }
+
+    @Override
+    public void trace(Marker marker, String msg) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object arg) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object arg1, Object arg2) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object... argArray) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void trace(Marker marker, String msg, Throwable t) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
     public boolean isDebugEnabled() {
-        return logger.isDebugEnabled();
+        return logger.isDebugEnabled(currentMarker);
+    }
+
+    @Override
+    public boolean isDebugEnabled(Marker marker) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void debug(String msg) {
+        logger.debug(currentMarker, msg);
+    }
+
+    @Override
+    public void debug(String format, Object arg) {
+        logger.debug(currentMarker, format, arg);
+    }
+
+    @Override
+    public void debug(String format, Object arg1, Object arg2) {
+        logger.debug(currentMarker, format, arg1, arg2);
     }
 
     @Override
@@ -57,8 +132,58 @@ public class LoggingFacadeImpl implements LoggingFacade {
     }
 
     @Override
+    public void debug(String msg, Throwable t) {
+        logger.debug(currentMarker, msg, t);
+    }
+
+    @Override
+    public void debug(Marker marker, String msg) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object arg) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object arg1, Object arg2) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object... arguments) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void debug(Marker marker, String msg, Throwable t) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
     public boolean isInfoEnabled() {
-        return logger.isInfoEnabled();
+        return logger.isInfoEnabled(currentMarker);
+    }
+
+    @Override
+    public boolean isInfoEnabled(Marker marker) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void info(String msg) {
+        logger.info(currentMarker, msg);
+    }
+
+    @Override
+    public void info(String format, Object arg) {
+        logger.info(currentMarker, format, arg);
+    }
+
+    @Override
+    public void info(String format, Object arg1, Object arg2) {
+        logger.info(currentMarker, format, arg1, arg2);
     }
 
     @Override
@@ -67,8 +192,58 @@ public class LoggingFacadeImpl implements LoggingFacade {
     }
 
     @Override
+    public void info(String msg, Throwable t) {
+        logger.info(currentMarker, msg, t);
+    }
+
+    @Override
+    public void info(Marker marker, String msg) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object arg) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object arg1, Object arg2) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object... arguments) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void info(Marker marker, String msg, Throwable t) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
     public boolean isWarnEnabled() {
-        return logger.isWarnEnabled();
+        return logger.isWarnEnabled(currentMarker);
+    }
+
+    @Override
+    public boolean isWarnEnabled(Marker marker) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void warn(String msg) {
+        logger.warn(currentMarker, msg);
+    }
+
+    @Override
+    public void warn(String format, Object arg) {
+        logger.warn(currentMarker, format, arg);
+    }
+
+    @Override
+    public void warn(String format, Object arg1, Object arg2) {
+        logger.warn(currentMarker, format, arg1, arg2);
     }
 
     @Override
@@ -77,12 +252,93 @@ public class LoggingFacadeImpl implements LoggingFacade {
     }
 
     @Override
+    public void warn(String msg, Throwable t) {
+        logger.warn(currentMarker, msg, t);
+
+    }
+
+    @Override
+    public void warn(Marker marker, String msg) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object arg) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object arg1, Object arg2) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object... arguments) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void warn(Marker marker, String msg, Throwable t) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
     public boolean isErrorEnabled() {
-        return logger.isErrorEnabled();
+        return logger.isErrorEnabled(currentMarker);
+    }
+
+    @Override
+    public boolean isErrorEnabled(Marker marker) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void error(String msg) {
+        logger.error(currentMarker, msg);
+    }
+
+    @Override
+    public void error(String format, Object arg) {
+        logger.error(currentMarker, format, arg);
+    }
+
+    @Override
+    public void error(String format, Object arg1, Object arg2) {
+        logger.error(currentMarker, format, arg1, arg2);
     }
 
     @Override
     public void error(String format, Object... arguments) {
         logger.error(currentMarker, format, arguments);
+    }
+
+    @Override
+    public void error(String msg, Throwable t) {
+        logger.error(currentMarker, msg, t);
+    }
+
+    @Override
+    public void error(Marker marker, String msg) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object arg) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object arg1, Object arg2) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object... arguments) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
+    }
+
+    @Override
+    public void error(Marker marker, String msg, Throwable t) {
+        throw UNSUPPORTED_OPERATION_EXCEPTION;
     }
 }

--- a/src/test/java/io/neonbee/logging/LoggingFacadeTest.java
+++ b/src/test/java/io/neonbee/logging/LoggingFacadeTest.java
@@ -2,6 +2,7 @@ package io.neonbee.logging;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.neonbee.internal.handler.CorrelationIdHandler.CORRELATION_ID;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
@@ -15,11 +16,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
 
 import io.neonbee.data.DataContext;
 import io.neonbee.data.internal.DataContextImpl;
 import io.vertx.ext.web.RoutingContext;
 
+@SuppressWarnings("PMD.MoreThanOneLogger")
 public class LoggingFacadeTest {
     private static final String DUMMY_LOG_MSG = "HODOR";
 
@@ -103,5 +107,47 @@ public class LoggingFacadeTest {
 
         verify(MOCKED_LOGGING_FACADE, times(1)).error(eq(DUMMY_LOG_MSG));
         verify(MOCKED_LOGGING_FACADE, times(1)).error(eq(DUMMY_LOG_MSG), eq(DUMMY_THROWABLE));
+    }
+
+    @Test
+    void testUnsupportedOperations() {
+        Logger logger = LoggingFacade.masqueradeLogger(LoggerFactory.getLogger("wololo"));
+        Marker marker = MarkerFactory.getDetachedMarker("anymarker");
+
+        assertThrows(UnsupportedOperationException.class, () -> logger.info(marker, "test"));
+        assertThrows(UnsupportedOperationException.class, () -> logger.error(marker, "test"));
+        assertThrows(UnsupportedOperationException.class, () -> logger.warn(marker, "test"));
+        assertThrows(UnsupportedOperationException.class, () -> logger.debug(marker, "test"));
+        assertThrows(UnsupportedOperationException.class, () -> logger.trace(marker, "test"));
+
+        assertThrows(UnsupportedOperationException.class, () -> logger.info(marker, "test1 {}", "test2"));
+        assertThrows(UnsupportedOperationException.class, () -> logger.error(marker, "test1 {}", "test2"));
+        assertThrows(UnsupportedOperationException.class, () -> logger.warn(marker, "test1 {}", "test2"));
+        assertThrows(UnsupportedOperationException.class, () -> logger.debug(marker, "test1 {}", "test2"));
+        assertThrows(UnsupportedOperationException.class, () -> logger.trace(marker, "test1 {}", "test2"));
+
+        assertThrows(UnsupportedOperationException.class, () -> logger.info(marker, "test1 {} {}", "test2", "test3"));
+        assertThrows(UnsupportedOperationException.class, () -> logger.error(marker, "test1 {} {}", "test2", "test3"));
+        assertThrows(UnsupportedOperationException.class, () -> logger.warn(marker, "test1 {} {}", "test2", "test3"));
+        assertThrows(UnsupportedOperationException.class, () -> logger.debug(marker, "test1 {} {}", "test2", "test3"));
+        assertThrows(UnsupportedOperationException.class, () -> logger.trace(marker, "test1 {} {}", "test2", "test3"));
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> logger.info(marker, "test1 {} {} {}", "test2", "test3", "test4"));
+        assertThrows(UnsupportedOperationException.class,
+                () -> logger.error(marker, "test1 {} {} {}", "test2", "test3", "test4"));
+        assertThrows(UnsupportedOperationException.class,
+                () -> logger.warn(marker, "test1 {} {} {}", "test2", "test3", "test4"));
+        assertThrows(UnsupportedOperationException.class,
+                () -> logger.debug(marker, "test1 {} {} {}", "test2", "test3", "test4"));
+        assertThrows(UnsupportedOperationException.class,
+                () -> logger.trace(marker, "test1 {} {} {}", "test2", "test3", "test4"));
+
+        Exception anyException = new Exception();
+        assertThrows(UnsupportedOperationException.class, () -> logger.info(marker, "test1", anyException));
+        assertThrows(UnsupportedOperationException.class, () -> logger.error(marker, "test1", anyException));
+        assertThrows(UnsupportedOperationException.class, () -> logger.warn(marker, "test1", anyException));
+        assertThrows(UnsupportedOperationException.class, () -> logger.debug(marker, "test1", anyException));
+        assertThrows(UnsupportedOperationException.class, () -> logger.trace(marker, "test1", anyException));
     }
 }

--- a/src/test/java/io/neonbee/logging/internal/LoggingFacadeImplTest.java
+++ b/src/test/java/io/neonbee/logging/internal/LoggingFacadeImplTest.java
@@ -2,6 +2,10 @@ package io.neonbee.logging.internal;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.neonbee.logging.internal.LoggingFacadeImpl.DEFAULT_MARKER;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -12,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 
+@SuppressWarnings("PMD.MoreThanOneLogger")
 public class LoggingFacadeImplTest {
     private static final String DUMMY_LOG_MSG = "HODOR {}";
 
@@ -55,45 +60,85 @@ public class LoggingFacadeImplTest {
     @Test
     void testTrace() {
         facade.isTraceEnabled();
-        verify(mockedLogger, times(1)).isTraceEnabled();
+        verify(mockedLogger, times(1)).isTraceEnabled(DEFAULT_MARKER);
 
         facade.trace(DUMMY_LOG_MSG, DUMMY_ARGUMENTS);
         verify(mockedLogger, times(1)).trace(DEFAULT_MARKER, DUMMY_LOG_MSG, DUMMY_ARGUMENTS);
+
+        reset(mockedLogger);
+        facade.correlateWith("anyid").trace(DUMMY_LOG_MSG);
+        verify(mockedLogger, times(1)).trace((Marker) argThat(marker -> "anyid".equals(marker.toString())),
+                eq(DUMMY_LOG_MSG));
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> facade.trace(DEFAULT_MARKER, DUMMY_LOG_MSG, DUMMY_ARGUMENTS));
     }
 
     @Test
     void testDebug() {
         facade.isDebugEnabled();
-        verify(mockedLogger, times(1)).isDebugEnabled();
+        verify(mockedLogger, times(1)).isDebugEnabled(DEFAULT_MARKER);
 
         facade.debug(DUMMY_LOG_MSG, DUMMY_ARGUMENTS);
         verify(mockedLogger, times(1)).debug(DEFAULT_MARKER, DUMMY_LOG_MSG, DUMMY_ARGUMENTS);
+
+        reset(mockedLogger);
+        facade.correlateWith("anyid").debug(DUMMY_LOG_MSG);
+        verify(mockedLogger, times(1)).debug((Marker) argThat(marker -> "anyid".equals(marker.toString())),
+                eq(DUMMY_LOG_MSG));
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> facade.debug(DEFAULT_MARKER, DUMMY_LOG_MSG, DUMMY_ARGUMENTS));
     }
 
     @Test
     void testInfo() {
         facade.isInfoEnabled();
-        verify(mockedLogger, times(1)).isInfoEnabled();
+        verify(mockedLogger, times(1)).isInfoEnabled(DEFAULT_MARKER);
 
         facade.info(DUMMY_LOG_MSG, DUMMY_ARGUMENTS);
         verify(mockedLogger, times(1)).info(DEFAULT_MARKER, DUMMY_LOG_MSG, DUMMY_ARGUMENTS);
+
+        reset(mockedLogger);
+        facade.correlateWith("anyid").info(DUMMY_LOG_MSG);
+        verify(mockedLogger, times(1)).info((Marker) argThat(marker -> "anyid".equals(marker.toString())),
+                eq(DUMMY_LOG_MSG));
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> facade.info(DEFAULT_MARKER, DUMMY_LOG_MSG, DUMMY_ARGUMENTS));
     }
 
     @Test
     void testWarn() {
         facade.isWarnEnabled();
-        verify(mockedLogger, times(1)).isWarnEnabled();
+        verify(mockedLogger, times(1)).isWarnEnabled(DEFAULT_MARKER);
 
         facade.warn(DUMMY_LOG_MSG, DUMMY_ARGUMENTS);
         verify(mockedLogger, times(1)).warn(DEFAULT_MARKER, DUMMY_LOG_MSG, DUMMY_ARGUMENTS);
+
+        reset(mockedLogger);
+        facade.correlateWith("anyid").warn(DUMMY_LOG_MSG);
+        verify(mockedLogger, times(1)).warn((Marker) argThat(marker -> "anyid".equals(marker.toString())),
+                eq(DUMMY_LOG_MSG));
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> facade.warn(DEFAULT_MARKER, DUMMY_LOG_MSG, DUMMY_ARGUMENTS));
     }
 
     @Test
     void testError() {
         facade.isErrorEnabled();
-        verify(mockedLogger, times(1)).isErrorEnabled();
+        verify(mockedLogger, times(1)).isErrorEnabled(DEFAULT_MARKER);
 
         facade.error(DUMMY_LOG_MSG, DUMMY_ARGUMENTS);
         verify(mockedLogger, times(1)).error(DEFAULT_MARKER, DUMMY_LOG_MSG, DUMMY_ARGUMENTS);
+
+        reset(mockedLogger);
+        facade.correlateWith("anyid").error(DUMMY_LOG_MSG);
+        verify(mockedLogger, times(1)).error((Marker) argThat(marker -> "anyid".equals(marker.toString())),
+                eq(DUMMY_LOG_MSG));
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> facade.error(DEFAULT_MARKER, DUMMY_LOG_MSG, DUMMY_ARGUMENTS));
     }
 }


### PR DESCRIPTION
Similar to other examples in NeonBee, NeonBee is trying to make the best / state of the art choice, when it comes to be choosing certain underlying frameworks. When it comes to a logging facade and backend, SLF4J / Logback was chosen by NeonBee. Previously NeonBee had its own implementation for the LoggingFacade, possibly making wrong assumtions when converting arguments into an array before passing it down to the masqueraded logger.

This change reduces the logging facade to be making as less as possible assumptions and clearly indicating that the underlying logger follows the SLF4J rules, by exposing its interface. The JavaDoc was changed to indicate that masquarading the logger will loose its ability to deal with markers, also indicated by a UnsupportedOperationExeption thrown when anyways trying.

As with the pre Vert.x 4 implementation the Vert.x logger did in fact reorder arguments before forwarding it to the underlying logger implementation, the plain SLF4J logger and LoggingFacade is no longer reording arguments. Thus also NeonBee has to follow the SLF4J convention [1] of putting the throwable as a last parameter into the format list. This change adapts all calls to any longer.

[1] http://www.slf4j.org/faq.html#paramException