### PR TITLE
build: add required configuration for publishing to maven central

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,7 @@
 .idea
 .iml
 
-# XMake              #
 ######################
-/.xmake/
 /gen/
 /import/
 

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -21,7 +21,7 @@ License: EPL-2.0
 
 #### NeonBee Build
 
-Files: Dockerfile  gradle.properties  *.gradle  gradle/spotless/* gradle/pmd/* gradle/checkstyle/* gradle/gitlog/* gradle/release.sh .github/*
+Files: Dockerfile  gradle.properties  *.gradle  gradle/spotless/* gradle/pmd/* gradle/checkstyle/* gradle/gitlog/* gradle/release.sh .github/* publishToMaven.sh
 Copyright: 2019 SAP SE or an SAP affiliate company and NeonBee contributors
 License: EPL-2.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,7 @@ plugins {
 }
 
 group = 'io.neonbee'
-// have to use single quotes for XMake, change as soon as new version Gradle build plugin is merged
-version = '0.0.8'
+version = '0.2.2'
 mainClassName = 'io.neonbee.Launcher'
 archivesBaseName = 'neonbee-core'
 sourceCompatibility = 11

--- a/gradle/distribution.gradle
+++ b/gradle/distribution.gradle
@@ -80,7 +80,7 @@ task testJar(type: Jar) {
     archiveExtension = 'jar'
 }
 
-/** Builds the sources JAR */
+/** Builds the test sources JAR */
 task testSourcesJar(type: Jar) {
     from sourceSets.test.allJava
 
@@ -88,6 +88,22 @@ task testSourcesJar(type: Jar) {
 
     archiveAppendix = 'test'
     archiveClassifier = 'sources'
+}
+
+task testJavadoc(type: Javadoc) {
+  classpath += sourceSets.test.compileClasspath
+  classpath += sourceSets.main.compileClasspath
+  source = sourceSets.test.allJava
+}
+
+/** Builds the test JavaDoc JAR */
+task testJavadocJar(type: Jar) {
+    from testJavadoc
+
+    destinationDirectory = file("${buildDir}")
+
+    archiveAppendix = 'test'
+    archiveClassifier = 'javadoc'
 }
 
 // ##################### Source for Artifact neonbee-dist
@@ -183,5 +199,6 @@ build {
     dependsOn('javadocJar')
     dependsOn('testJar')
     dependsOn('testSourcesJar')
+    dependsOn('testJavadocJar')
     dependsOn('distTar')
 }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,10 +1,7 @@
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 publishing {
-    repositories {
-        mavenLocal()
-    }
-
     publications {
         // NeonBee Core Jar
         core(MavenPublication) {
@@ -13,6 +10,49 @@ publishing {
             artifact source: shadowJar
             artifact source: sourcesJar
             artifact source: javadocJar
+
+            pom {
+                name = 'NeonBee Core'
+                description = 'NeonBee is an open source reactive dataflow engine, a data stream processing framework using Vert.x.'
+                url = 'https://neonbee.io/'
+
+                licenses {
+                    license {
+                        name = 'Eclipse Public License version 2.0'
+                        url = 'https://opensource.org/licenses/EPL-2.0'
+                    }
+                }
+
+                scm {
+                    connection = 'scm:git:https://github.com/SAP/neonbee.git'
+                    developerConnection = 'scm:git:git@github.com:SAP/neonbee.git'
+                    url = 'https://github.com/sap/neonbee'
+                }
+
+                developers {
+                    developer {
+                        id = 'pascal'
+                        name = 'Pascal'
+                        email = 'pascal@neonbee.io'
+                    }
+                    developer {
+                        id = 'kristian'
+                        name = 'Kristian'
+                        email = 'kristian@neonbee.io'
+                    }
+                    developer {
+                        id = 'sebastian'
+                        name = 'Sebastian'
+                        email = 'sebastian@neonbee.io'
+                    }
+                    developer {
+                        id = 'danilo'
+                        name = 'Danilo'
+                        email = 'danilo@neonbee.io'
+                    }
+                }
+            }
+
             pom.withXml {
                 def dependenciesNode = asNode().appendNode('dependencies')
                 // Iterate over the implementation dependencies and add them to the pom.xml
@@ -29,6 +69,48 @@ publishing {
         dist(MavenPublication) {
             artifactId = 'neonbee-dist'
             artifact source: distTar
+
+            pom {
+                name = 'NeonBee Core Distribution'
+                description = 'NeonBee is an open source reactive dataflow engine, a data stream processing framework using Vert.x.'
+                url = 'https://neonbee.io/'
+
+                licenses {
+                    license {
+                        name = 'Eclipse Public License version 2.0'
+                        url = 'https://opensource.org/licenses/EPL-2.0'
+                    }
+                }
+
+                scm {
+                    connection = 'scm:git:https://github.com/SAP/neonbee.git'
+                    developerConnection = 'scm:git:git@github.com:SAP/neonbee.git'
+                    url = 'https://github.com/sap/neonbee'
+                }
+
+                developers {
+                    developer {
+                        id = 'pascal'
+                        name = 'Pascal'
+                        email = 'pascal@neonbee.io'
+                    }
+                    developer {
+                        id = 'kristian'
+                        name = 'Kristian'
+                        email = 'kristian@neonbee.io'
+                    }
+                    developer {
+                        id = 'sebastian'
+                        name = 'Sebastian'
+                        email = 'sebastian@neonbee.io'
+                    }
+                    developer {
+                        id = 'danilo'
+                        name = 'Danilo'
+                        email = 'danilo@neonbee.io'
+                    }
+                }
+            }
         }
 
         // NeonBee Test Jar
@@ -36,6 +118,50 @@ publishing {
             artifactId = "${project.archivesBaseName}-test"
             artifact source: testJar
             artifact source: testSourcesJar
+            artifact source: testJavadocJar
+
+            pom {
+                name = 'NeonBee Core Test'
+                description = 'NeonBee is an open source reactive dataflow engine, a data stream processing framework using Vert.x.'
+                url = 'https://neonbee.io/'
+
+                licenses {
+                    license {
+                        name = 'Eclipse Public License version 2.0'
+                        url = 'https://opensource.org/licenses/EPL-2.0'
+                    }
+                }
+
+                scm {
+                    connection = 'scm:git:https://github.com/SAP/neonbee.git'
+                    developerConnection = 'scm:git:git@github.com:SAP/neonbee.git'
+                    url = 'https://github.com/sap/neonbee'
+                }
+
+                developers {
+                    developer {
+                        id = 'pascal'
+                        name = 'Pascal'
+                        email = 'pascal@neonbee.io'
+                    }
+                    developer {
+                        id = 'kristian'
+                        name = 'Kristian'
+                        email = 'kristian@neonbee.io'
+                    }
+                    developer {
+                        id = 'sebastian'
+                        name = 'Sebastian'
+                        email = 'sebastian@neonbee.io'
+                    }
+                    developer {
+                        id = 'danilo'
+                        name = 'Danilo'
+                        email = 'danilo@neonbee.io'
+                    }
+                }
+            }
+
             pom.withXml {
                 def dependenciesNode = asNode().appendNode('dependencies')
                 // Iterate over the implementation dependencies and add them to the pom.xml
@@ -60,5 +186,27 @@ publishing {
                 dependencyNode.appendNode('version', project.version)
             }
         }
+    }
+
+    repositories {
+        maven {
+            name = 'mavenCentral'
+            credentials(PasswordCredentials)
+            def releasesRepoUrl = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/'
+            def snapshotsRepoUrl = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+        }
+    }
+}
+
+signing {
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+
+    if (signingKey != null && signingPassword != null) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign publishing.publications.core
+        sign publishing.publications.dist
+        sign publishing.publications.test
     }
 }

--- a/publishToMaven.sh
+++ b/publishToMaven.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+export ORG_GRADLE_PROJECT_signingPassword=EnterSigningPasswordHere
+export ORG_GRADLE_PROJECT_signingKey=EnterContentOfKeyArmorFileHere # e.g.:`cat ~/NeonBeePrivate.asc`
+
+export ORG_GRADLE_PROJECT_mavenCentralUsername=ossrh-jira-user
+export ORG_GRADLE_PROJECT_mavenCentralPassword=ossrh-jira-password
+
+cd "${SCRIPTPATH}"
+./gradlew publishAllPublicationsToMavenCentralRepository

--- a/src/test/java/io/neonbee/hook/internal/HookClassTemplate.java
+++ b/src/test/java/io/neonbee/hook/internal/HookClassTemplate.java
@@ -39,6 +39,7 @@ public class HookClassTemplate implements ClassTemplate {
     /**
      * Creates a dummy hook class.
      *
+     * @param hookTemplate    The path to the template file for the hook.
      * @param simpleClassName The simple class name of the new class
      * @throws IOException Hook template could not be read
      */
@@ -49,6 +50,7 @@ public class HookClassTemplate implements ClassTemplate {
     /**
      * Creates a dummy hook class.
      *
+     * @param hookTemplate    The path to the template file for the hook.
      * @param simpleClassName The simple class name of the new class
      * @param packageName     The package name of the class. Pass null for default package
      * @throws IOException Hook template could not be read

--- a/src/test/java/io/neonbee/internal/BasicJar.java
+++ b/src/test/java/io/neonbee/internal/BasicJar.java
@@ -31,9 +31,10 @@ public class BasicJar {
     }
 
     /**
-     * Creates a jar file with the passed content and an default manifest which only contains the manifest version
+     * Creates a jar file with the passed content and manifest.
      *
-     * @param content The content of the jar file
+     * @param content            The content of the jar file
+     * @param manifestAttributes The manifest of the jar file
      */
     public BasicJar(Map<String, String> manifestAttributes, Map<String, byte[]> content) {
         this(createManifest(manifestAttributes), content.entrySet().stream()

--- a/src/test/java/io/neonbee/internal/ClassTemplate.java
+++ b/src/test/java/io/neonbee/internal/ClassTemplate.java
@@ -46,7 +46,7 @@ public interface ClassTemplate {
     String getPackageName();
 
     /**
-     * @see Class#getName();
+     * @see Class#getName()
      *
      * @return The full qualified class name of the verticle
      */

--- a/src/test/java/io/neonbee/internal/NeonBeeModuleJar.java
+++ b/src/test/java/io/neonbee/internal/NeonBeeModuleJar.java
@@ -31,6 +31,10 @@ public class NeonBeeModuleJar extends BasicJar {
 
     /**
      * @see NeonBeeModuleJar#createManifest(String, Collection, Collection, Collection, Collection)
+     *
+     * @param name        The module name / identifier
+     * @param deployables The deployables
+     * @return A Manifest with the passed deployables
      */
     public static Manifest createManifest(String name, Collection<String> deployables) {
         return createManifest(name, deployables, List.of(), List.of(), List.of());
@@ -40,9 +44,11 @@ public class NeonBeeModuleJar extends BasicJar {
      * Generates a Manifest file with the attribute NeonBee-Deployables which contains the passed verticle deployables
      * and the attribute NeonBee-Models which contains the passed model paths.
      *
-     * @param deployables         The deployables
+     * @param name                The module name / identifier
+     * @param deployables         The FQN of the deployables
      * @param modelPaths          The paths to the model files (*.csn) inside of the JAR
      * @param extensionModelPaths The paths to the extension model files (*.edmx) inside of the JAR
+     * @param hooks               The FQN of the hooks
      * @return A Manifest with the passed deployables
      */
     public static Manifest createManifest(String name, Collection<String> deployables, Collection<String> modelPaths,

--- a/src/test/java/io/neonbee/test/base/NeonBeeTestBase.java
+++ b/src/test/java/io/neonbee/test/base/NeonBeeTestBase.java
@@ -145,7 +145,8 @@ public class NeonBeeTestBase {
      * Override this method to provide a non {@link WorkingDirectoryBuilder#standard() standard}
      * {@link WorkingDirectoryBuilder}.
      *
-     * @param testInfo The test information to be able to provide a test related WorkingDirectoryBuilder
+     * @param testInfo    The test information to be able to provide a test related WorkingDirectoryBuilder
+     * @param testContext The Vert.x test context of the current test run.
      * @return the WorkingDirectoryBuilder
      */
     @SuppressWarnings("PMD.UnusedFormalParameter")
@@ -230,7 +231,7 @@ public class NeonBeeTestBase {
      * Returns a pre-configured HTTP request which points to the NeonBee HTTP interface.
      *
      * <pre>
-     * path: /raw/Hodor -&gt; result: <host>:<port>/raw/Hodor
+     * path: /raw/Hodor -&gt; result: &lt;host&gt;:&lt;port&gt;/raw/Hodor
      * </pre>
      *
      * @param method The HTTP method of the request

--- a/src/test/java/io/neonbee/test/helper/MockitoHelper.java
+++ b/src/test/java/io/neonbee/test/helper/MockitoHelper.java
@@ -15,6 +15,7 @@ public final class MockitoHelper {
      *
      * @param handlerPosition The position of the handler in the signature of the mocked method
      * @param asyncResult     The result with which the {@link Handler} is called.
+     * @param <T>             The type of the result to handle
      * @return A {@link Answer} that triggers the {@link Handler} passed to the mocked method.
      */
     public static <T> Answer<Void> callHandlerAnswer(int handlerPosition, AsyncResult<T> asyncResult) {

--- a/src/test/java/io/neonbee/test/helper/ReflectionHelper.java
+++ b/src/test/java/io/neonbee/test/helper/ReflectionHelper.java
@@ -15,8 +15,18 @@ public final class ReflectionHelper {
      * @param fieldName   The field which is holding the value
      * @return The value of the field
      */
+
+    /**
+     *
+     * @param <T>         The expected type of the value
+     * @param fieldHolder The object which contains the field
+     * @param fieldName   The field which is holding the value
+     * @return The value of the field
+     * @throws NoSuchFieldException   If no such field exists in the fieldHolder
+     * @throws IllegalAccessException If JVM doesn't grant access to the field
+     */
     public static <T> T getValueOfPrivateField(Object fieldHolder, String fieldName)
-            throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+            throws NoSuchFieldException, IllegalAccessException {
         return getValueOfPrivateField(resolveClass(fieldHolder), fieldHolder, fieldName, false);
     }
 
@@ -30,11 +40,12 @@ public final class ReflectionHelper {
      * @param removeFinal Pass true to remove the final modifier of the field, before it is read the first time
      *                    otherwise it is cached with the final value in the FieldAccessor.
      * @return The value of the field
+     * @throws NoSuchFieldException   If no such field exists in the fieldHolder
+     * @throws IllegalAccessException If JVM doesn't grant access to the field
      */
     @SuppressWarnings("unchecked")
     private static <T> T getValueOfPrivateField(Class<?> clazz, Object fieldHolder, String fieldName,
-            boolean removeFinal)
-            throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+            boolean removeFinal) throws NoSuchFieldException, IllegalAccessException {
         Field fieldToModify = clazz.getDeclaredField(fieldName);
         fieldToModify.setAccessible(true);
         if (removeFinal) {
@@ -48,12 +59,15 @@ public final class ReflectionHelper {
      * Returns the value of a private field. This method should be used, when the object which holds the field is not
      * directly the class which declares the field. E.g. in case of extensions.
      *
+     * @param <T>       The expected type of the value
      * @param clazz     The class which contains the field
      * @param fieldName The field which is holding the value
      * @return The value of the field
+     * @throws NoSuchFieldException   If no such field exists in the fieldHolder
+     * @throws IllegalAccessException If JVM doesn't grant access to the field
      */
     public static <T> T getValueOfPrivateStaticField(Class<?> clazz, String fieldName)
-            throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+            throws NoSuchFieldException, IllegalAccessException {
         return getValueOfPrivateField(clazz, null, fieldName, false);
     }
 
@@ -65,9 +79,11 @@ public final class ReflectionHelper {
      * @param valueToSet     The value to set
      *
      * @return An ExecutionBlock that resets the field to its value before the modification happened.
+     * @throws NoSuchFieldException   If no such field exists in the fieldHolder
+     * @throws IllegalAccessException If JVM doesn't grant access to the field
      */
     public static ExecutionBlock setValueOfPrivateField(Object objectToModify, String fieldName, Object valueToSet)
-            throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+            throws NoSuchFieldException, IllegalAccessException {
         Object oldValue = getValueOfPrivateField(resolveClass(objectToModify), objectToModify, fieldName, true);
         setValueOfPrivateField(resolveClass(objectToModify), objectToModify, fieldName, valueToSet);
 
@@ -83,10 +99,11 @@ public final class ReflectionHelper {
      * @param objectToModify The object which contains the field
      * @param fieldName      The target field
      * @param valueToSet     The value to set
+     * @throws NoSuchFieldException   If no such field exists in the fieldHolder
+     * @throws IllegalAccessException If JVM doesn't grant access to the field
      */
     private static void setValueOfPrivateField(Class<?> clazz, Object objectToModify, String fieldName,
-            Object valueToSet)
-            throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+            Object valueToSet) throws NoSuchFieldException, IllegalAccessException {
         Field fieldToModify = clazz.getDeclaredField(fieldName);
         fieldToModify.setAccessible(true);
         removeFinalModifier(fieldToModify);
@@ -101,9 +118,11 @@ public final class ReflectionHelper {
      * @param valueToSet The value to set
      *
      * @return An ExecutionBlock that resets the field to its value before the modification happened.
+     * @throws NoSuchFieldException   If no such field exists in the fieldHolder
+     * @throws IllegalAccessException If JVM doesn't grant access to the field
      */
     public static ExecutionBlock setValueOfPrivateStaticField(Class<?> clazz, String fieldName, Object valueToSet)
-            throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+            throws NoSuchFieldException, IllegalAccessException {
         Object oldValue = getValueOfPrivateField(clazz, null, fieldName, true);
 
         setValueOfPrivateField(clazz, null, fieldName, valueToSet);
@@ -115,8 +134,7 @@ public final class ReflectionHelper {
         return c.isAnonymousClass() ? resolveClass(c.getSuperclass()) : c;
     }
 
-    private static void removeFinalModifier(Field field)
-            throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+    private static void removeFinalModifier(Field field) throws NoSuchFieldException, IllegalAccessException {
         Field modifiersField = Field.class.getDeclaredField("modifiers");
         modifiersField.setAccessible(true);
         modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);

--- a/src/test/java/io/neonbee/test/helper/ResourceHelper.java
+++ b/src/test/java/io/neonbee/test/helper/ResourceHelper.java
@@ -32,7 +32,7 @@ public final class ResourceHelper {
      * resolved against the related resource folder. This path construct is called <i>related resources path</i>,
      * because the path is related to the parent class which is calling this method.
      * <p>
-     * Related Resources Path: <resources folder>/<package as path>
+     * Related Resources Path: &gt;resources folder&lt;/&gt;package as path&lt;
      *
      * The passed filename gets resolved against the related resources path.
      *
@@ -175,7 +175,7 @@ public final class ResourceHelper {
      * construct is the so called related test resource path. Because the path is related to the test class which is
      * calling this method.
      * <p>
-     * Related Test Resources Path: <test resources folder>/<package as path>
+     * Related Test Resources Path: &gt;test resources folder&lt;/&gt;package as path&lt;
      *
      * The passed file path gets resolved against the related test resources path.
      *

--- a/src/test/java/io/neonbee/test/helper/WorkingDirectoryBuilder.java
+++ b/src/test/java/io/neonbee/test/helper/WorkingDirectoryBuilder.java
@@ -124,9 +124,9 @@ public final class WorkingDirectoryBuilder {
      *
      * @param workingDirRoot The {@link Path} to the root of the working directory, the directory don't need to exist
      *                       already.
-     * @throws Exception In case that something went wrong.
+     * @throws IOException In case that something went wrong.
      */
-    public void build(Path workingDirRoot) throws Exception {
+    public void build(Path workingDirRoot) throws IOException {
         switch (dirType) {
         case NONE:
             break;
@@ -209,6 +209,7 @@ public final class WorkingDirectoryBuilder {
     }
 
     /**
+     * @param sourcePath The path from where the working directory should be copied from.
      * @return a WorkingDirectoryBuilder that creates a working directory with the content of a passed source
      *         {@link Path}. The source could be a directory or a zip file.
      */


### PR DESCRIPTION
This patch ...

* ... adds meta information for license, scm or developers to the
pom.xml which is required by maven central.

* adds a task to create a test Javadoc artifact, which is required by
maven central.

* adds fixes for violations in the test Javadoc

* adds the script 'publishToMaven.sh' which can be used to add required
credentials when publishing to maven central.