### PR TITLE
feat: add $expand support for entity collections

### DIFF
--- a/.github/workflows/.commitlintrc.json
+++ b/.github/workflows/.commitlintrc.json
@@ -7,6 +7,11 @@
             0,
             "always",
             100
+        ],
+        "footer-max-line-length": [
+            0,
+            "always",
+            100
         ]
     }
 }

--- a/src/main/java/io/neonbee/internal/processor/odata/EntityExpander.java
+++ b/src/main/java/io/neonbee/internal/processor/odata/EntityExpander.java
@@ -1,0 +1,130 @@
+package io.neonbee.internal.processor.odata;
+
+import static io.neonbee.entity.EntityVerticle.requestEntity;
+import static io.neonbee.internal.Helper.allComposite;
+import static io.vertx.core.Future.succeededFuture;
+import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.olingo.commons.api.data.Entity;
+import org.apache.olingo.commons.api.data.EntityCollection;
+import org.apache.olingo.commons.api.data.Link;
+import org.apache.olingo.commons.api.edm.EdmEntityType;
+import org.apache.olingo.commons.api.edm.EdmNavigationProperty;
+import org.apache.olingo.commons.api.edm.EdmReferentialConstraint;
+import org.apache.olingo.commons.api.edm.constants.EdmTypeKind;
+import org.apache.olingo.server.api.uri.UriResourceNavigation;
+import org.apache.olingo.server.api.uri.queryoption.ExpandOption;
+
+import io.neonbee.data.DataQuery;
+import io.neonbee.data.DataRequest;
+import io.neonbee.data.internal.DataContextImpl;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.RoutingContext;
+
+public final class EntityExpander {
+    private final List<EdmNavigationProperty> navigationProperties;
+
+    private final Map<EdmEntityType, List<Entity>> fetchedEntities;
+
+    private EntityExpander(List<EdmNavigationProperty> navigationProperties,
+            Map<EdmEntityType, List<Entity>> fetchedEntities) {
+        this.navigationProperties = navigationProperties;
+        this.fetchedEntities = fetchedEntities;
+    }
+
+    /**
+     * Creating the EntityExpander is an asynchronous operation, because during the creation the EntityExpander fetches
+     * all referenced and <b>potentially</b> required entities based on the expand options. When the EntityExpander is
+     * created successfully, the expand of an entity happens synchronously.
+     *
+     * @param vertx          The Vert.x instance
+     * @param expandOption   The expand options of the OData request
+     * @param routingContext The routingContext of the request
+     * @return A {@link Future} holding a {@link EntityExpander} when it is completed.
+     */
+    public static Future<EntityExpander> create(Vertx vertx, ExpandOption expandOption, RoutingContext routingContext) {
+        if (expandOption != null) {
+            List<EdmNavigationProperty> navigationProperties = getNavigationProperties(expandOption);
+            Map<EdmEntityType, List<Entity>> fetchedEntities = new HashMap<>();
+
+            List<Future<?>> fetchFutures =
+                    navigationProperties.stream().map(EdmNavigationProperty::getType).distinct().map(type -> {
+                        DataRequest req = new DataRequest(type.getFullQualifiedName(), new DataQuery());
+                        return requestEntity(vertx, req, new DataContextImpl(routingContext))
+                                .map(ew -> fetchedEntities.put(type, ew.getEntities()));
+                    }).collect(toList());
+            return allComposite(fetchFutures).map(v -> new EntityExpander(navigationProperties, fetchedEntities));
+        } else {
+            return succeededFuture(new EntityExpander(List.of(), Map.of()));
+        }
+    }
+
+    private static List<EdmNavigationProperty> getNavigationProperties(ExpandOption expandOption) {
+        return expandOption.getExpandItems().stream().map(item -> item.getResourcePath().getUriResourceParts().get(0))
+                .filter(UriResourceNavigation.class::isInstance).map(UriResourceNavigation.class::cast)
+                .map(UriResourceNavigation::getProperty).collect(toList());
+    }
+
+    /**
+     * Expands the attributes of the passed Entity.
+     *
+     * @param entityToExpand The entity to expand
+     */
+    public void expand(Entity entityToExpand) {
+        for (EdmNavigationProperty navigationProperty : navigationProperties) {
+            if (!EdmTypeKind.ENTITY.equals(navigationProperty.getType().getKind())) {
+                throw new UnsupportedOperationException("At the moment only type Entity can be expanded");
+            }
+
+            List<Entity> entitiesToLink = getRelatedEntities(entityToExpand, navigationProperty);
+            linkEntities(entityToExpand, navigationProperty, entitiesToLink);
+        }
+    }
+
+    private void linkEntities(Entity entity, EdmNavigationProperty navigationProperty, List<Entity> entitiesToLink) {
+        Link link = new Link();
+        link.setTitle(navigationProperty.getName());
+        // Reveal if navigation property is Collection or Entity
+        if (navigationProperty.isCollection()) {
+            EntityCollection expandCollection = new EntityCollection();
+            expandCollection.getEntities().addAll(entitiesToLink);
+            link.setInlineEntitySet(expandCollection);
+        } else {
+            link.setInlineEntity(entitiesToLink.get(0));
+        }
+        entity.getNavigationLinks().add(link);
+    }
+
+    private List<Entity> getRelatedEntities(Entity entityToExpand, EdmNavigationProperty navigationProperty) {
+        boolean isCollection = navigationProperty.isCollection();
+
+        List<Entity> filteredEntities = new ArrayList<>(fetchedEntities.get(navigationProperty.getType()));
+
+        List<EdmReferentialConstraint> constraints =
+                isCollection ? navigationProperty.getPartner().getReferentialConstraints()
+                        : navigationProperty.getReferentialConstraints();
+
+        for (EdmReferentialConstraint constraint : constraints) {
+            String propertyName = isCollection ? constraint.getReferencedPropertyName() : constraint.getPropertyName();
+            String referencePropertyName =
+                    isCollection ? constraint.getPropertyName() : constraint.getReferencedPropertyName();
+
+            Object propertyValue = entityToExpand.getProperty(propertyName).getValue();
+            List<Entity> remainingEntities = List.copyOf(filteredEntities);
+            filteredEntities.clear();
+            for (Entity referenceEntity : remainingEntities) {
+                Object referencePropertyValue = referenceEntity.getProperty(referencePropertyName).getValue();
+                if (propertyValue.equals(referencePropertyValue)) {
+                    filteredEntities.add(referenceEntity);
+                }
+            }
+        }
+        return filteredEntities;
+    }
+}

--- a/src/test/java/io/neonbee/test/base/ODataRequest.java
+++ b/src/test/java/io/neonbee/test/base/ODataRequest.java
@@ -57,6 +57,8 @@ public class ODataRequest {
 
     private String property;
 
+    private String systemQueryExpand;
+
     private Buffer body;
 
     /**
@@ -359,6 +361,18 @@ public class ODataRequest {
     }
 
     /**
+     * Configure the system query expand with the passed value. The expandValue "Products" would result into
+     * "expand=Products".
+     *
+     * @param expandValue the value for the expand query
+     * @return An {@link ODataRequest} with the passed expand query
+     */
+    public ODataRequest setExpandQuery(String expandValue) {
+        systemQueryExpand = "expand=" + expandValue;
+        return this;
+    }
+
+    /**
      * Builds and returns the OData URL of the {@link ODataRequest} based on namespace, entity name, key predicates,
      * properties, and OData suffixes {@code $metadata}, {@code $count}.
      *
@@ -374,7 +388,8 @@ public class ODataRequest {
         if (count) {
             return entitySet + "/$count";
         }
-        return entitySet + getPredicate(keys) + (Strings.isNullOrEmpty(property) ? EMPTY : '/' + property);
+        return entitySet + getPredicate(keys) + (Strings.isNullOrEmpty(property) ? EMPTY : '/' + property)
+                + (Strings.isNullOrEmpty(systemQueryExpand) ? EMPTY : "?$" + systemQueryExpand);
     }
 
     private String getPredicate(Map<String, String> keyMap) throws IllegalArgumentException {

--- a/src/test/java/io/neonbee/test/base/ODataRequestTest.java
+++ b/src/test/java/io/neonbee/test/base/ODataRequestTest.java
@@ -129,4 +129,11 @@ public class ODataRequestTest {
         odataRequest.setProperty("my-property");
         assertThat(odataRequest.getUri()).isEqualTo(expectedServiceRootURL + "/my-entity/my-property");
     }
+
+    @Test
+    @DisplayName("with expand single attribute")
+    public void testExpand() {
+        odataRequest.setKey("0123").setExpandQuery("ExpandItem");
+        assertThat(odataRequest.getUri()).isEqualTo(expectedServiceRootURL + "/my-entity('0123')?$expand=ExpandItem");
+    }
 }

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataExpandEntityCollectionTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataExpandEntityCollectionTest.java
@@ -1,0 +1,96 @@
+package io.neonbee.test.endpoint.odata;
+
+import static io.neonbee.test.endpoint.odata.verticle.NavPropsCategoriesEntityVerticle.ALL_CATEGORIES;
+import static io.neonbee.test.endpoint.odata.verticle.NavPropsCategoriesEntityVerticle.CATEGORIES_ENTITY_SET_FQN;
+import static io.neonbee.test.endpoint.odata.verticle.NavPropsCategoriesEntityVerticle.FOOD_CATEGORY;
+import static io.neonbee.test.endpoint.odata.verticle.NavPropsCategoriesEntityVerticle.MOTORCYCLE_CATEGORY;
+import static io.neonbee.test.endpoint.odata.verticle.NavPropsCategoriesEntityVerticle.addProductsToCategory;
+import static io.neonbee.test.endpoint.odata.verticle.NavPropsProductsEntityVerticle.ALL_PRODUCTS;
+import static io.neonbee.test.endpoint.odata.verticle.NavPropsProductsEntityVerticle.CHEESE_PRODUCT;
+import static io.neonbee.test.endpoint.odata.verticle.NavPropsProductsEntityVerticle.PRODUCTS_ENTITY_SET_FQN;
+import static io.neonbee.test.endpoint.odata.verticle.NavPropsProductsEntityVerticle.STEAK_PRODUCT;
+import static io.neonbee.test.endpoint.odata.verticle.NavPropsProductsEntityVerticle.STREET_GLIDE_SPECIAL_PRODUCT;
+import static io.neonbee.test.endpoint.odata.verticle.NavPropsProductsEntityVerticle.S_1000_RR_PRODUCT;
+import static io.neonbee.test.endpoint.odata.verticle.NavPropsProductsEntityVerticle.addCategoryToProduct;
+import static io.neonbee.test.endpoint.odata.verticle.NavPropsProductsEntityVerticle.getDeclaredEntityModel;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.neonbee.test.base.ODataEndpointTestBase;
+import io.neonbee.test.base.ODataRequest;
+import io.neonbee.test.endpoint.odata.verticle.NavPropsCategoriesEntityVerticle;
+import io.neonbee.test.endpoint.odata.verticle.NavPropsProductsEntityVerticle;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+
+public class ODataExpandEntityCollectionTest extends ODataEndpointTestBase {
+    @Override
+    protected List<Path> provideEntityModels() {
+        return List.of(getDeclaredEntityModel());
+    }
+
+    @BeforeEach
+    void setUp(VertxTestContext testContext) {
+        CompositeFuture
+                .all(deployVerticle(new NavPropsProductsEntityVerticle()),
+                        deployVerticle(new NavPropsCategoriesEntityVerticle()))
+                .onComplete(testContext.succeedingThenComplete());
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("Expand property 'category' in Products")
+    void testExpandCategoryInProducts(VertxTestContext testContext) {
+        ODataRequest oDataRequest = new ODataRequest(PRODUCTS_ENTITY_SET_FQN).setExpandQuery("category");
+        List<JsonObject> expected = List.of(addCategoryToProduct(STEAK_PRODUCT, FOOD_CATEGORY),
+                addCategoryToProduct(CHEESE_PRODUCT, FOOD_CATEGORY),
+                addCategoryToProduct(S_1000_RR_PRODUCT, MOTORCYCLE_CATEGORY),
+                addCategoryToProduct(STREET_GLIDE_SPECIAL_PRODUCT, MOTORCYCLE_CATEGORY));
+
+        assertODataEntitySetContainsExactly(requestOData(oDataRequest), expected, testContext)
+                .onComplete(testContext.succeedingThenComplete());
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("Do not expand property 'category' in Products")
+    void testDoNotExpandCategoryInProducts(VertxTestContext testContext) {
+        ODataRequest oDataRequest = new ODataRequest(PRODUCTS_ENTITY_SET_FQN);
+        List<JsonObject> expected = ALL_PRODUCTS;
+
+        assertODataEntitySetContainsExactly(requestOData(oDataRequest), expected, testContext)
+                .onComplete(testContext.succeedingThenComplete());
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.HOURS)
+    @DisplayName("Expand property 'products' in Categories")
+    void testExpandProductsInCategory(VertxTestContext testContext) {
+        ODataRequest oDataRequest = new ODataRequest(CATEGORIES_ENTITY_SET_FQN).setExpandQuery("products");
+        List<JsonObject> expected = List.of(
+                addProductsToCategory(FOOD_CATEGORY, List.of(STEAK_PRODUCT, CHEESE_PRODUCT)),
+                addProductsToCategory(MOTORCYCLE_CATEGORY, List.of(S_1000_RR_PRODUCT, STREET_GLIDE_SPECIAL_PRODUCT)));
+
+        assertODataEntitySetContainsExactly(requestOData(oDataRequest), expected, testContext)
+                .onComplete(testContext.succeedingThenComplete());
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("Do not expand property 'products' in Categories")
+    void testDoNotExpandProductsInCategory(VertxTestContext testContext) {
+        ODataRequest oDataRequest = new ODataRequest(CATEGORIES_ENTITY_SET_FQN);
+        List<JsonObject> expected = ALL_CATEGORIES;
+
+        assertODataEntitySetContainsExactly(requestOData(oDataRequest), expected, testContext)
+                .onComplete(testContext.succeedingThenComplete());
+    }
+}

--- a/src/test/java/io/neonbee/test/endpoint/odata/verticle/NavPropsCategoriesEntityVerticle.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/verticle/NavPropsCategoriesEntityVerticle.java
@@ -1,0 +1,71 @@
+package io.neonbee.test.endpoint.odata.verticle;
+
+import static io.neonbee.test.helper.ResourceHelper.TEST_RESOURCES;
+import static io.vertx.core.Future.succeededFuture;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.olingo.commons.api.data.Entity;
+import org.apache.olingo.commons.api.data.Property;
+import org.apache.olingo.commons.api.data.ValueType;
+import org.apache.olingo.commons.api.edm.FullQualifiedName;
+
+import io.neonbee.data.DataContext;
+import io.neonbee.data.DataMap;
+import io.neonbee.data.DataQuery;
+import io.neonbee.entity.EntityVerticle;
+import io.neonbee.entity.EntityWrapper;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+
+public class NavPropsCategoriesEntityVerticle extends EntityVerticle {
+    public static final FullQualifiedName CATEGORIES_ENTITY_SET_FQN =
+            new FullQualifiedName("io.neonbee.test.NavProbs", "Categories");
+
+    public static final String PROPERTY_NAME_ID = "ID";
+
+    public static final String PROPERTY_NAME_NAME = "name";
+
+    public static final String PROPERTY_NAME_PRODUCTS = "products";
+
+    public static final JsonObject FOOD_CATEGORY = createCategory(1, "Food");
+
+    public static final JsonObject MOTORCYCLE_CATEGORY = createCategory(2, "Motorcycles");
+
+    public static final List<JsonObject> ALL_CATEGORIES = List.of(FOOD_CATEGORY, MOTORCYCLE_CATEGORY);
+
+    @Override
+    public Future<Set<FullQualifiedName>> entityTypeNames() {
+        return succeededFuture(Set.of(CATEGORIES_ENTITY_SET_FQN));
+    }
+
+    @Override
+    public Future<EntityWrapper> retrieveData(DataQuery query, DataMap require, DataContext context) {
+        List<Entity> allEntities = ALL_CATEGORIES.stream().map(NavPropsCategoriesEntityVerticle::createCategory)
+                .collect(Collectors.toList());
+        return succeededFuture(new EntityWrapper(CATEGORIES_ENTITY_SET_FQN, allEntities));
+    }
+
+    public static Entity createCategory(JsonObject category) {
+        return new Entity()
+                .addProperty(new Property(null, PROPERTY_NAME_ID, ValueType.PRIMITIVE,
+                        category.getInteger(PROPERTY_NAME_ID)))
+                .addProperty(new Property(null, PROPERTY_NAME_NAME, ValueType.PRIMITIVE,
+                        category.getString(PROPERTY_NAME_NAME)));
+    }
+
+    public static JsonObject createCategory(int id, String name) {
+        return new JsonObject().put(PROPERTY_NAME_ID, id).put(PROPERTY_NAME_NAME, name);
+    }
+
+    public static JsonObject addProductsToCategory(JsonObject category, List<JsonObject> expanedProducts) {
+        return category.copy().put(PROPERTY_NAME_PRODUCTS, expanedProducts);
+    }
+
+    public static Path getDeclaredEntityModel() {
+        return TEST_RESOURCES.resolveRelated("NavigationProperty.csn");
+    }
+}

--- a/src/test/java/io/neonbee/test/endpoint/odata/verticle/NavPropsProductsEntityVerticle.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/verticle/NavPropsProductsEntityVerticle.java
@@ -1,0 +1,81 @@
+package io.neonbee.test.endpoint.odata.verticle;
+
+import static io.neonbee.test.helper.ResourceHelper.TEST_RESOURCES;
+import static io.vertx.core.Future.succeededFuture;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.olingo.commons.api.data.Entity;
+import org.apache.olingo.commons.api.data.Property;
+import org.apache.olingo.commons.api.data.ValueType;
+import org.apache.olingo.commons.api.edm.FullQualifiedName;
+
+import io.neonbee.data.DataContext;
+import io.neonbee.data.DataMap;
+import io.neonbee.data.DataQuery;
+import io.neonbee.entity.EntityVerticle;
+import io.neonbee.entity.EntityWrapper;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+
+public class NavPropsProductsEntityVerticle extends EntityVerticle {
+    public static final FullQualifiedName PRODUCTS_ENTITY_SET_FQN =
+            new FullQualifiedName("io.neonbee.test.NavProbs", "Products");
+
+    public static final String PROPERTY_NAME_ID = "ID";
+
+    public static final String PROPERTY_NAME_NAME = "name";
+
+    public static final String PROPERTY_NAME_CATEGORY_ID = "category_ID";
+
+    public static final String PROPERTY_NAME_CATEGORY = "category";
+
+    public static final JsonObject STEAK_PRODUCT = createProduct(1, "Steak", 1);
+
+    public static final JsonObject CHEESE_PRODUCT = createProduct(2, "Cheese", 1);
+
+    public static final JsonObject S_1000_RR_PRODUCT = createProduct(21, "S 1000 RR", 2);
+
+    public static final JsonObject STREET_GLIDE_SPECIAL_PRODUCT = createProduct(22, "Street Glide Special", 2);
+
+    public static final List<JsonObject> ALL_PRODUCTS =
+            List.of(STEAK_PRODUCT, CHEESE_PRODUCT, S_1000_RR_PRODUCT, STREET_GLIDE_SPECIAL_PRODUCT);
+
+    @Override
+    public Future<Set<FullQualifiedName>> entityTypeNames() {
+        return succeededFuture(Set.of(PRODUCTS_ENTITY_SET_FQN));
+    }
+
+    @Override
+    public Future<EntityWrapper> retrieveData(DataQuery query, DataMap require, DataContext context) {
+        List<Entity> allEntities =
+                ALL_PRODUCTS.stream().map(NavPropsProductsEntityVerticle::createProduct).collect(Collectors.toList());
+        return succeededFuture(new EntityWrapper(PRODUCTS_ENTITY_SET_FQN, allEntities));
+    }
+
+    public static Entity createProduct(JsonObject category) {
+        return new Entity()
+                .addProperty(new Property(null, PROPERTY_NAME_ID, ValueType.PRIMITIVE,
+                        category.getInteger(PROPERTY_NAME_ID)))
+                .addProperty(new Property(null, PROPERTY_NAME_NAME, ValueType.PRIMITIVE,
+                        category.getString(PROPERTY_NAME_NAME)))
+                .addProperty(new Property(null, PROPERTY_NAME_CATEGORY_ID, ValueType.PRIMITIVE,
+                        category.getInteger(PROPERTY_NAME_CATEGORY_ID)));
+    }
+
+    public static JsonObject createProduct(int id, String name, int categoryId) {
+        return new JsonObject().put(PROPERTY_NAME_ID, id).put(PROPERTY_NAME_NAME, name).put(PROPERTY_NAME_CATEGORY_ID,
+                categoryId);
+    }
+
+    public static JsonObject addCategoryToProduct(JsonObject product, JsonObject expanedCategory) {
+        return product.copy().put(PROPERTY_NAME_CATEGORY, expanedCategory.copy());
+    }
+
+    public static Path getDeclaredEntityModel() {
+        return TEST_RESOURCES.resolveRelated("NavigationProperty.csn");
+    }
+}

--- a/src/test/resources/io/neonbee/test/endpoint/odata/verticle/NavigationProperty.cds
+++ b/src/test/resources/io/neonbee/test/endpoint/odata/verticle/NavigationProperty.cds
@@ -1,0 +1,16 @@
+namespace io.neonbee.test;
+
+service NavProbs {
+    entity Products {
+        key ID : Integer;
+        name : String;
+        category : Association to Categories;
+    }
+
+    entity Categories {
+        key ID : Integer;
+        name : String;
+        products: Association to many Products on products.category = $self;
+    }
+}
+

--- a/src/test/resources/io/neonbee/test/endpoint/odata/verticle/NavigationProperty.csn
+++ b/src/test/resources/io/neonbee/test/endpoint/odata/verticle/NavigationProperty.csn
@@ -1,0 +1,70 @@
+{
+  "namespace": "io.neonbee.test",
+  "definitions": {
+    "io.neonbee.test.NavProbs": {
+      "@source": "NavigationProperty.cds",
+      "kind": "service"
+    },
+    "io.neonbee.test.NavProbs.Categories": {
+      "kind": "entity",
+      "elements": {
+        "ID": {
+          "key": true,
+          "type": "cds.Integer"
+        },
+        "name": {
+          "type": "cds.String"
+        },
+        "products": {
+          "type": "cds.Association",
+          "cardinality": {
+            "max": "*"
+          },
+          "target": "io.neonbee.test.NavProbs.Products",
+          "on": [
+            {
+              "ref": [
+                "products",
+                "category"
+              ]
+            },
+            "=",
+            {
+              "ref": [
+                "$self"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "io.neonbee.test.NavProbs.Products": {
+      "kind": "entity",
+      "elements": {
+        "ID": {
+          "key": true,
+          "type": "cds.Integer"
+        },
+        "name": {
+          "type": "cds.String"
+        },
+        "category": {
+          "type": "cds.Association",
+          "target": "io.neonbee.test.NavProbs.Categories",
+          "keys": [
+            {
+              "ref": [
+                "ID"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  "meta": {
+    "flavor": "inferred",
+    "creator": "CDS Compiler v1.49.0"
+  },
+  "$version": "1.0"
+}

--- a/src/test/resources/io/neonbee/test/endpoint/odata/verticle/io.neonbee.test.NavProbs.edmx
+++ b/src/test/resources/io/neonbee/test/endpoint/odata/verticle/io.neonbee.test.NavProbs.edmx
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="io.neonbee.test.NavProbs" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+
+      <EntityContainer Name="EntityContainer">
+        <EntitySet Name="Categories" EntityType="io.neonbee.test.NavProbs.Categories">
+          <NavigationPropertyBinding Path="products" Target="Products"/>
+        </EntitySet>
+        <EntitySet Name="Products" EntityType="io.neonbee.test.NavProbs.Products">
+          <NavigationPropertyBinding Path="category" Target="Categories"/>
+        </EntitySet>
+      </EntityContainer>
+
+      <EntityType Name="Categories">
+        <Key>
+          <PropertyRef Name="ID"/>
+        </Key>
+        <Property Name="ID" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="name" Type="Edm.String"/>
+        <NavigationProperty Name="products" Type="Collection(io.neonbee.test.NavProbs.Products)" Partner="category"/>
+      </EntityType>
+
+      <EntityType Name="Products">
+        <Key>
+          <PropertyRef Name="ID"/>
+        </Key>
+        <Property Name="ID" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="name" Type="Edm.String"/>
+        <NavigationProperty Name="category" Type="io.neonbee.test.NavProbs.Categories" Partner="products">
+          <ReferentialConstraint Property="category_ID" ReferencedProperty="ID"/>
+        </NavigationProperty>
+        <Property Name="category_ID" Type="Edm.Int32"/>
+      </EntityType>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
This is a limited implementation of the $expand option. It has the
following limitations:
- Only work for read requests
- Only work for attributes of the requested entity
- No support for filter options based on attributes of expanded entities

[1] http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part2-url-conventions/odata-v4.0-errata03-os-part2-url-conventions-complete.html#_Toc453752359