### PR TITLE
Add publishing workflow

### DIFF
--- a/.github/workflows/.commitlintrc.json
+++ b/.github/workflows/.commitlintrc.json
@@ -12,6 +12,24 @@
             0,
             "always",
             100
+        ],
+        "type-enum": [
+            0,
+            "always",
+            [
+                "build",
+                "chore",
+                "ci",
+                "docs",
+                "feat",
+                "fix",
+                "perf",
+                "refactor",
+                "release",
+                "revert",
+                "style",
+                "test"
+            ]
         ]
     }
 }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,181 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publishToMavenCentral:
+    runs-on: ubuntu-latest
+
+    outputs:
+      releaseVersion: ${{ steps.getVersion.outputs.releaseVersion }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: "11.0.2"
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Get new version
+        id: getVersion
+        run: |
+          set -euo pipefail
+          version="$(./gradlew properties -q | grep -w "version:" | awk '{print $2}')"
+          echo ::set-output name=releaseVersion::"${version}"
+          echo "New release version: ${version}"
+
+      - name: Publish to maven central
+        env:
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY_ARMOR }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USER }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        run: |
+          ./gradlew clean publishAllPublicationsToMavenCentralRepository
+
+  publishRelease:
+    runs-on: ubuntu-latest
+    needs: [publishToMavenCentral]
+
+    if: startsWith(github.event.head_commit.message, 'release:') && (endsWith(needs.publishToMavenCentral.outputs.releaseVersion, '-SNAPSHOT') == false)
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: "11.0.2"
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Tag release commit
+        run: |
+          git tag "${{ needs.publishToMavenCentral.outputs.releaseVersion }}"
+
+      - name: Set snapshot version
+        id: snapshot
+        run: |
+          tagVersion="${{ needs.publishToMavenCentral.outputs.releaseVersion }}"
+          rv="${tagVersion%-*}"
+          snapshotVersion="${rv:0:-1}$(bc <<< "${rv: -1}+1")-SNAPSHOT"
+          echo ::set-output name=snapshotVersion::"${snapshotVersion}"
+          ./gradlew setNewVersion -P newVersion=${snapshotVersion}
+
+          if git diff --no-ext-diff --quiet --exit-code; then
+            >&2 echo "No diff detected in git." ; exit 1
+          fi
+
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add -A build.gradle
+          git commit -m "release(snapshot): ${snapshotVersion}"
+
+      - name: Install chevron
+        run: |
+          pip install chevron
+
+      - name: Get changelog
+        shell: python
+        run: |
+          import os
+          import json
+          import chevron
+
+          file = "CHANGELOG.json"
+          if not os.path.isfile(file):
+              raise "file {} not found".format(file)
+          with open(file, "r") as stream:
+              changelog_json = json.load(stream)
+
+          version = "${{ needs.publishToMavenCentral.outputs.releaseVersion }}"
+          target_version = version.split("-")[0].split(".")
+          current_tag = None
+          for tag in changelog_json["tags"]:
+              if (
+                  tag["version"]["major"] == int(target_version[0])
+                  and tag["version"]["minor"] == int(target_version[1])
+                  and tag["version"]["patch"] == int(target_version[2])
+              ):
+                  current_tag = tag
+                  break
+
+          tmpl = """
+          ## Changelog
+          {{#sections}}
+
+          ### {{title}}
+
+          {{#commits}}
+          - {{#commitScope}}**{{commitPackage}}{{commitScope}}**: {{/commitScope}}{{& commitSubject}}{{#subjectIssues}} ([#{{id}}]({{url}})){{/subjectIssues}} ([{{hash8}}]({{commitUrl}})){{#hasCloseIssues}}, closes{{#closeIssues}} [#{{id}}]({{url}}){{/closeIssues}}{{/hasCloseIssues}}
+          {{/commits}}
+          {{/sections}}
+          """
+          args = {
+              "template": tmpl,
+              "data": current_tag,
+          }
+          rendered=chevron.render(**args)
+          print(rendered)
+          with open('release_changelog.md', 'w') as f:
+            f.write(rendered)
+
+      - name: Set Changelog
+        id: setChangelog
+        run: |
+          echo ::set-output name=releaseBody::"$( jq -rRs 'gsub("\r";"%0D")|gsub("\n";"%0A")' < ./release_changelog.md )"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+          tags: true
+
+      - name: Publish snapshot to maven central
+        env:
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY_ARMOR }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USER }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        run: |
+          ./gradlew clean publishAllPublicationsToMavenCentralRepository
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.publishToMavenCentral.outputs.releaseVersion }}
+          release_name: Release ${{ needs.publishToMavenCentral.outputs.releaseVersion }}
+          body: ${{ steps.setChangelog.outputs.releaseBody }}
+          draft: true
+          prerelease: false

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -21,7 +21,7 @@ License: EPL-2.0
 
 #### NeonBee Build
 
-Files: Dockerfile  gradle.properties  *.gradle  gradle/spotless/* gradle/pmd/* gradle/checkstyle/* gradle/gitlog/* gradle/release.sh .github/* publishToMaven.sh
+Files: Dockerfile  gradle.properties  *.gradle  gradle/spotless/* gradle/pmd/* gradle/checkstyle/* gradle/gitlog/* gradle/release.sh .github/* publishToMaven.sh CHANGELOG.*
 Copyright: 2019 SAP SE or an SAP affiliate company and NeonBee contributors
 License: EPL-2.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 
 group = 'io.neonbee'
-version = '0.2.2'
+version = '0.2.3-SNAPSHOT'
 mainClassName = 'io.neonbee.Launcher'
 archivesBaseName = 'neonbee-core'
 sourceCompatibility = 11

--- a/docs/github_releases.md
+++ b/docs/github_releases.md
@@ -1,16 +1,33 @@
 # Release new versions on GitHub
 
-The following process requires at least two contributors, as there is no CI or review process for verification.
+1. Checkout a new branch
 
-1. Merge all commits to master that should be part of the next release
-2. Check out origin master
-3. Execute the release task
+    ```console
+    git checkout -b release-<nextVersion> origin/main
+    ```
+
+2. Execute the gradle release task
 
     ```console
     ./gradlew release -PnextVersion=<nextVersion>
     ```
 
-    This updates the version in the build.gradle and updates the CHANGELOG. It generates a commit with the changed files and creates a tag `nextVersion`.
+    This task updates the version in the `build.gradle` to `<nextVersion>` and updates `CHANGELOG.*`.
+    It also generates a commit with the changed files.
 
-4. Push to master `git push -u origin HEAD:master --tags` (Note: pull request workflow not possible because this would generate a new commit, which would not be referenced by the tag)
-5. Push to the related release branch `git push -u origin HEAD:0.x`, where 0.x refers to the related major version
+3. Push the branch
+
+    ```console
+    `git push -u origin HEAD:refs/heads/release-<nextVersion>
+    ```
+
+4. Open a new pull request against the `main` branch
+5. Get approval from at least one committer. Once the pull request has been merged, a GitHub Action workflow will be triggered. The workflow publishes the version to maven central and creates a Github Draft Release with the corresponding changelog.
+6. Once the workflow in step 5. has finished fetch and push the newly created release tag to the related release branch. Example:
+
+    ```console
+    git fetch
+    git push origin <nextVersion>:/refs/heads/0.x
+    ```
+
+    where `0.x` refers to the related major version

--- a/gradle/changelog.gradle
+++ b/gradle/changelog.gradle
@@ -2,7 +2,6 @@ changelog {
     toRef = 'HEAD'
     isUnstable = true
     strategy = 'slow'
-    lastVersion = version
 
     jsonFile = file("${project.rootDir}/CHANGELOG.json")
     fileSets = [

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -210,3 +210,10 @@ signing {
         sign publishing.publications.test
     }
 }
+
+task setNewVersion {
+    if (project.hasProperty('newVersion')) {
+        println "Set Project version from $version to $newVersion"
+        buildFile.setText(buildFile.getText().replaceFirst("version = '$version'", "version = '$newVersion'"))
+    }
+}

--- a/gradle/release.sh
+++ b/gradle/release.sh
@@ -25,4 +25,3 @@ git add build.gradle CHANGELOG.*
 git --no-pager diff --cached -- build.gradle
 
 git commit -m "release: ${NEXT_VERSION}"
-git tag "${NEXT_VERSION}"


### PR DESCRIPTION
This change adds a GitHub Actions workflow which automates the
publishing of releases to maven central and the creation of GitHub
releases.