### PR TITLE
fix: use gradle task for setting new version

### DIFF
--- a/gradle/release.sh
+++ b/gradle/release.sh
@@ -18,8 +18,7 @@ git tag "${NEXT_VERSION}"  # hack: creating a temporary local tag which is neede
 ./gradlew changelog
 git tag -d "${NEXT_VERSION}"
 
-sed -i.bak "s/^version = \'[^\']*\'/version = \'${NEXT_VERSION}\'/g" build.gradle
-rm -f build.gradle.bak
+./gradlew setNewVersion -P newVersion=${NEXT_VERSION}
 
 git add build.gradle CHANGELOG.*
 git --no-pager diff --cached -- build.gradle


### PR DESCRIPTION
The regex pattern which was used in the sed command did not work when
running on linux.