### PR TITLE
chore: add PMD rules to avoid unnecessary modifiers in tests

### DIFF
--- a/gradle/pmd/customRules/AvoidUnnecessaryTestClassesModifier/TestCases.xml
+++ b/gradle/pmd/customRules/AvoidUnnecessaryTestClassesModifier/TestCases.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data xmlns="http://pmd.sourceforge.net/rule-tests"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+   <test-code>
+      <description>Avoid public, protected or private modifier for test classes</description>
+      <expected-problems>0</expected-problems>
+      <code><![CDATA[
+public class Foo {
+
+  private static class TestJobVerticle {
+  }
+
+  @Test
+  public void bar() {
+  }
+}
+
+private class Foo1 {
+
+  @Test
+  public void bar() {
+  }
+}
+
+protected class Foo2 {
+
+  @Test
+  public void bar() {
+  }
+}
+
+public class Foo3 {
+
+  @ParameterizedTest(name = "{index}: For Product: {0}")
+  void bar() {
+  }
+}
+
+class Foo4 {
+
+  @Test
+  public void bar() {
+  }
+}
+        ]]></code>
+      <source-type>java 11</source-type>
+   </test-code>
+
+</test-data>

--- a/gradle/pmd/customRules/AvoidUnnecessaryTestClassesModifier/rule.xml
+++ b/gradle/pmd/customRules/AvoidUnnecessaryTestClassesModifier/rule.xml
@@ -1,0 +1,22 @@
+<rule name="AvoidUnnecessaryTestClassesModifier"
+      language="java"
+      minimumLanguageVersion="11"
+      message="Avoid public, protected or private modifier for test classes"
+      class="net.sourceforge.pmd.lang.rule.XPathRule">
+    <description>
+        Avoid public, protected or private modifier for test classes. There is no benefit.
+    </description>
+    <priority>1</priority>
+    <properties>
+        <property name="version" value="2.0"/>
+        <property name="xpath">
+            <value>
+                <![CDATA[
+                //TypeDeclaration/ClassOrInterfaceDeclaration[@Public = true() or @Private = true() or @Protected = true()]
+                [.//Annotation[@AnnotationName = "Test" or @AnnotationName = "ParameterizedTest"]]
+                ]]>
+            </value>
+        </property>
+    </properties>
+</rule>
+

--- a/gradle/pmd/customRules/AvoidUnnecessaryTestMethodsModifier/Testcases.xml
+++ b/gradle/pmd/customRules/AvoidUnnecessaryTestMethodsModifier/Testcases.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data xmlns="http://pmd.sourceforge.net/rule-tests"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+   <test-code>
+      <description>Avoid public, protected or private modifier for test methods</description>
+      <expected-problems>0</expected-problems>
+      <code><![CDATA[
+class Foo {
+  @Test
+  public void bar() {
+  }
+  
+  @Test
+  private void foo() {
+  }
+
+  @Test
+  void foobar() {
+  }
+
+  @Test
+  protected void foobar() {
+  }
+
+  static class TestPreProcessor implements LauncherPreProcessor {
+        private boolean preProcessorExecuted;
+
+        @Override
+        public void execute(NeonBeeOptions options) {
+            this.preProcessorExecuted = true;
+        }
+
+        public boolean isPreProcessorExecuted() {
+            return preProcessorExecuted;
+        }
+    }
+}
+        ]]></code>
+      <source-type>java 11</source-type>
+   </test-code>
+
+</test-data>

--- a/gradle/pmd/customRules/AvoidUnnecessaryTestMethodsModifier/rule.xml
+++ b/gradle/pmd/customRules/AvoidUnnecessaryTestMethodsModifier/rule.xml
@@ -1,0 +1,23 @@
+<rule name="AvoidUnnecessaryTestMethodsModifier"
+      language="java"
+      minimumLanguageVersion="11"
+      message="Avoid public, protected or private modifier for test methods"
+      class="net.sourceforge.pmd.lang.rule.XPathRule">
+    <description>
+        Avoid public, protected or private modifier for test methods. There is no benefit.
+    </description>
+    <priority>1</priority>
+    <properties>
+        <property name="version" value="2.0"/>
+        <property name="xpath">
+            <value>
+                <![CDATA[
+                //ClassOrInterfaceBodyDeclaration
+                [./Annotation/MarkerAnnotation[@AnnotationName = "Test"]]
+                [./MethodDeclaration[@Public=true() or @Private=true() or @Protcted=true()]]
+                ]]>
+            </value>
+        </property>
+    </properties>
+</rule>
+

--- a/gradle/pmd/customRuleset.xml
+++ b/gradle/pmd/customRuleset.xml
@@ -48,4 +48,49 @@
              </property>
          </properties>
     </rule>
+
+    <rule name="AvoidUnnecessaryTestMethodsModifier"
+      language="java"
+      minimumLanguageVersion="11"
+      message="Avoid public, protected or private modifier for test methods"
+      class="net.sourceforge.pmd.lang.rule.XPathRule">
+        <description>
+            Avoid public, protected or private modifier for test methods. There is no benefit.
+        </description>
+        <priority>1</priority>
+        <properties>
+            <property name="version" value="2.0"/>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+                    //ClassOrInterfaceBodyDeclaration
+                    [./Annotation/MarkerAnnotation[@AnnotationName = "Test"]]
+                    [./MethodDeclaration[@Public=true() or @Private=true() or @Protcted=true()]]
+                    ]]>
+                </value>
+            </property>
+        </properties>
+    </rule>
+
+    <rule name="AvoidUnnecessaryTestClassesModifier"
+      language="java"
+      minimumLanguageVersion="11"
+      message="Avoid public, protected or private modifier for test classes"
+      class="net.sourceforge.pmd.lang.rule.XPathRule">
+        <description>
+            Avoid public, protected or private modifier for test classes. There is no benefit.
+        </description>
+        <priority>1</priority>
+        <properties>
+            <property name="version" value="2.0"/>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+                    //TypeDeclaration/ClassOrInterfaceDeclaration[@Public = true() or @Private = true() or @Protected = true()]
+                    [.//Annotation[@AnnotationName = "Test" or @AnnotationName = "ParameterizedTest"]]
+                    ]]>
+                </value>
+            </property>
+        </properties>
+    </rule>
 </ruleset>

--- a/src/main/java/io/neonbee/internal/processor/odata/NavigationPropertyHelper.java
+++ b/src/main/java/io/neonbee/internal/processor/odata/NavigationPropertyHelper.java
@@ -26,7 +26,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.RoutingContext;
 
-public class NavigationPropertyHelper {
+public final class NavigationPropertyHelper {
     private static final LoggingFacade LOGGER = LoggingFacade.create();
 
     /**
@@ -158,5 +158,9 @@ public class NavigationPropertyHelper {
             EdmNavigationProperty navProb = ((UriResourceNavigation) resourceParts.get(1)).getProperty();
             return getNavigationTargetEntitySet(resourceEntitySet, navProb, routingContext);
         }
+    }
+
+    private NavigationPropertyHelper() {
+
     }
 }

--- a/src/main/java/io/neonbee/internal/processor/odata/edm/EdmConstants.java
+++ b/src/main/java/io/neonbee/internal/processor/odata/edm/EdmConstants.java
@@ -33,7 +33,7 @@ public final class EdmConstants {
 
     public static final BigInteger EDM_BYTE_MIN = BigInteger.ZERO;
 
-    public static final BigInteger EDM_BYTE_MAX = BigInteger.valueOf((Byte.MAX_VALUE * 2) + 1);
+    public static final BigInteger EDM_BYTE_MAX = BigInteger.valueOf((Byte.MAX_VALUE * 2L) + 1);
 
     public static final BigInteger EDM_INT16_MIN = BigInteger.valueOf(Short.MIN_VALUE);
 

--- a/src/main/java/io/neonbee/internal/scanner/ClassPathScanner.java
+++ b/src/main/java/io/neonbee/internal/scanner/ClassPathScanner.java
@@ -239,10 +239,11 @@ public class ClassPathScanner {
             URI uri = manifestResource.toURI();
             // filter for manifest files inside of jar files
             if ("jar".equals(uri.getScheme())) {
-                FileSystem fileSystem = FileSystems.newFileSystem(uri, Map.of());
-                Path rootPath = fileSystem.getPath("/");
-                scanDirectoryWithPredicateRecursive(rootPath, predicate).forEach(path -> resources.add(path.toUri()));
-                fileSystem.close();
+                try (FileSystem fileSystem = FileSystems.newFileSystem(uri, Map.of())) {
+                    Path rootPath = fileSystem.getPath("/");
+                    scanDirectoryWithPredicateRecursive(rootPath, predicate)
+                            .forEach(path -> resources.add(path.toUri()));
+                }
             }
         }
         return resources;

--- a/src/main/java/io/neonbee/logging/LoggingFacade.java
+++ b/src/main/java/io/neonbee/logging/LoggingFacade.java
@@ -120,8 +120,7 @@ public interface LoggingFacade extends Logger {
             String msg = "routingContext must not be null, otherwise no correlationId can be extracted";
             throw new NullPointerException(msg);
         }
-        Optional.ofNullable(routingContext.get(CORRELATION_ID)).map(Object::toString)
-                .ifPresent(correlationId -> correlateWith(correlationId));
+        Optional.ofNullable(routingContext.get(CORRELATION_ID)).map(Object::toString).ifPresent(this::correlateWith);
         return this;
     }
 

--- a/src/test/java/io/neonbee/LauncherTest.java
+++ b/src/test/java/io/neonbee/LauncherTest.java
@@ -21,24 +21,24 @@ import io.neonbee.test.helper.FileSystemHelper;
 import io.vertx.core.cli.InvalidValueException;
 import io.vertx.core.cli.MissingValueException;
 
-public class LauncherTest {
+class LauncherTest {
     private static Path tempDirPath;
 
     private String[] args;
 
     @BeforeAll
-    public static void setUp() throws IOException {
+    static void setUp() throws IOException {
         tempDirPath = createTempDirectory();
     }
 
     @AfterAll
-    public static void tearDown() throws IOException {
+    static void tearDown() {
         FileSystemHelper.deleteRecursiveBlocking(tempDirPath);
     }
 
     @Test
     @DisplayName("should throw error, if working directory value is not passed")
-    public void throwErrorIfWorkingDirValueIsEmpty() {
+    void throwErrorIfWorkingDirValueIsEmpty() {
         args = new String[] { "-cwd" };
         MissingValueException exception =
                 assertThrows(MissingValueException.class, () -> parseOptions(INTERFACE.parse(List.of(args))));
@@ -47,7 +47,7 @@ public class LauncherTest {
 
     @Test
     @DisplayName("should throw error, if instance-name is empty")
-    public void throwErrorIfInstanceNameIsEmpty() {
+    void throwErrorIfInstanceNameIsEmpty() {
         args = new String[] { "-cwd", tempDirPath.toAbsolutePath().toString(), "-name", "" };
         IllegalArgumentException exception =
                 assertThrows(IllegalArgumentException.class, () -> parseOptions(INTERFACE.parse(List.of(args))));
@@ -56,7 +56,7 @@ public class LauncherTest {
 
     @Test
     @DisplayName("should use passed instance-name")
-    public void usePassedInstanceName() {
+    void usePassedInstanceName() {
         args = new String[] { "-cwd", tempDirPath.toAbsolutePath().toString(), "-name", "Hodor" };
         NeonBeeOptions neonBeeOptions = parseOptions(INTERFACE.parse(List.of(args)));
         assertThat(neonBeeOptions.getInstanceName()).isEqualTo("Hodor");
@@ -64,7 +64,7 @@ public class LauncherTest {
 
     @Test
     @DisplayName("should throw error, if the passed value is other than integer for worker pool size")
-    public void validateWorkerPoolSizeValue() {
+    void validateWorkerPoolSizeValue() {
         args = new String[] { "-cwd", tempDirPath.toAbsolutePath().toString(), "-name", "Hodor", "-wps", "hodor" };
         InvalidValueException exception =
                 assertThrows(InvalidValueException.class, () -> parseOptions(INTERFACE.parse(List.of(args))));
@@ -73,7 +73,7 @@ public class LauncherTest {
 
     @Test
     @DisplayName("should throw error, if the passed value is other than integer for event loop pool size")
-    public void validateEventLoopPoolSizeValue() {
+    void validateEventLoopPoolSizeValue() {
         args = new String[] { "-cwd", tempDirPath.toAbsolutePath().toString(), "-name", "Hodor", "-elps", "hodor" };
         InvalidValueException exception =
                 assertThrows(InvalidValueException.class, () -> parseOptions(INTERFACE.parse(List.of(args))));
@@ -82,7 +82,7 @@ public class LauncherTest {
 
     @Test
     @DisplayName("should generate expected neonbee options")
-    public void testExpectedNeonBeeOptions() {
+    void testExpectedNeonBeeOptions() {
         args = new String[] { "-cwd", tempDirPath.toAbsolutePath().toString(), "-name", "Hodor", "-wps", "2", "-elps",
                 "2", "-no-cp", "-no-jobs", "-svp", "9000" };
         NeonBeeOptions neonBeeOptions = parseOptions(INTERFACE.parse(List.of(args)));
@@ -99,7 +99,7 @@ public class LauncherTest {
 
     @Test
     @DisplayName("should generate expected clustered neonbee options")
-    public void testExpectedClusterNeonBeeOptions() {
+    void testExpectedClusterNeonBeeOptions() {
         args = new String[] { "-cwd", tempDirPath.toAbsolutePath().toString(), "-cl", "-cc", "hazelcast-local.xml",
                 "-clp", "10000" };
         NeonBeeOptions neonBeeOptions = parseOptions(INTERFACE.parse(List.of(args)));
@@ -112,7 +112,7 @@ public class LauncherTest {
 
     @Test
     @DisplayName("should execute list of preprocessors.")
-    public void testExecutePreProcessors() {
+    void testExecutePreProcessors() {
         TestPreProcessor processor = new TestPreProcessor();
         List<LauncherPreProcessor> preProcessors = List.of(processor);
         Launcher.executePreProcessors(preProcessors, new NeonBeeOptions.Mutable());

--- a/src/test/java/io/neonbee/NeonBeeConfigTest.java
+++ b/src/test/java/io/neonbee/NeonBeeConfigTest.java
@@ -12,18 +12,18 @@ import org.junit.jupiter.api.Test;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
-public class NeonBeeConfigTest {
+class NeonBeeConfigTest {
 
     @Test
     @DisplayName("should read the trackingDataHandlingStrategy correctly")
-    public void readtrackingDataHandlingStrategy() {
+    void readtrackingDataHandlingStrategy() {
         NeonBeeConfig config = new NeonBeeConfig(new JsonObject().put("trackingDataHandlingStrategy", "ABC"));
         assertThat(config.getTrackingDataHandlingStrategy()).isEqualTo("ABC");
     }
 
     @Test
     @DisplayName("should read the trackingDataHandlingStrategy correctly")
-    public void getPlatformClassesTest() {
+    void getPlatformClassesTest() {
         List<String> validListOfPlatformClasses = List.of("hodor");
         List<Object> nonValidListOfPlatformClasses = List.of("hodor", 3);
 

--- a/src/test/java/io/neonbee/NeonBeeExtensionBasedTest.java
+++ b/src/test/java/io/neonbee/NeonBeeExtensionBasedTest.java
@@ -23,12 +23,12 @@ import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(NeonBeeExtension.class)
-public class NeonBeeExtensionBasedTest {
+class NeonBeeExtensionBasedTest {
 
     @Test
     @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
     @DisplayName("NeonBee should start with default options / default working directory")
-    public void testNeonBeeDefault(@NeonBeeInstanceConfiguration(activeProfiles = NeonBeeProfile.ALL) NeonBee neonBee) {
+    void testNeonBeeDefault(@NeonBeeInstanceConfiguration(activeProfiles = NeonBeeProfile.ALL) NeonBee neonBee) {
         assertThat(neonBee).isNotNull();
         assertThat(isClustered(neonBee)).isFalse();
     }
@@ -36,7 +36,7 @@ public class NeonBeeExtensionBasedTest {
     @Test
     @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
     @DisplayName("NeonBee should start with NONE profile. Only system verticle should be deployed")
-    public void testNeonBeeWithNoneProfile(NeonBee neonBee) {
+    void testNeonBeeWithNoneProfile(NeonBee neonBee) {
         assertThat(neonBee).isNotNull();
         assertThat(neonBee.getOptions().getActiveProfiles()).isEmpty();
         assertThat(isClustered(neonBee)).isFalse();
@@ -45,7 +45,7 @@ public class NeonBeeExtensionBasedTest {
     @Test
     @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Instances with the same name should return the same NeonBee instance")
-    public void testSameNeonBeeInstance(@NeonBeeInstanceConfiguration(instanceName = "node1") NeonBee instance1,
+    void testSameNeonBeeInstance(@NeonBeeInstanceConfiguration(instanceName = "node1") NeonBee instance1,
             @NeonBeeInstanceConfiguration(instanceName = "node1") NeonBee instance2) {
         assertThat(instance1).isSameInstanceAs(instance2);
     }
@@ -53,7 +53,7 @@ public class NeonBeeExtensionBasedTest {
     @Test
     @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
     @DisplayName("NeonBee should start with CORE profile and deploy CoreDataVerticle")
-    public void testNeonBeeWithCoreDeployment(
+    void testNeonBeeWithCoreDeployment(
             @NeonBeeInstanceConfiguration(activeProfiles = NeonBeeProfile.CORE) NeonBee neonBee,
             VertxTestContext testContext) {
         assertThat(neonBee).isNotNull();
@@ -68,7 +68,7 @@ public class NeonBeeExtensionBasedTest {
     @Test
     @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
     @DisplayName("NeonBee should start with NONE profile and deploy CoreDataVerticle manually")
-    public void testNeonBeeWithNoneDeploymentAndManualDeployment(@NeonBeeInstanceConfiguration() NeonBee neonBee,
+    void testNeonBeeWithNoneDeploymentAndManualDeployment(@NeonBeeInstanceConfiguration() NeonBee neonBee,
             VertxTestContext testContext) {
         assertThat(neonBee).isNotNull();
         assertThat(neonBee.getOptions().getActiveProfiles()).isEmpty();
@@ -83,7 +83,7 @@ public class NeonBeeExtensionBasedTest {
     @Test
     @Timeout(value = 20, timeUnit = TimeUnit.SECONDS)
     @DisplayName("3 NeonBee instances with WEB, CORE and STABLE profiles should be started and join one cluster.")
-    public void testNeonBeeWithClusters(
+    void testNeonBeeWithClusters(
             @NeonBeeInstanceConfiguration(activeProfiles = NeonBeeProfile.WEB, clustered = true) NeonBee web,
             @NeonBeeInstanceConfiguration(activeProfiles = NeonBeeProfile.CORE, clustered = true) NeonBee core,
             @NeonBeeInstanceConfiguration(activeProfiles = NeonBeeProfile.STABLE, clustered = true) NeonBee stable) {

--- a/src/test/java/io/neonbee/NeonBeeOptionsTest.java
+++ b/src/test/java/io/neonbee/NeonBeeOptionsTest.java
@@ -15,29 +15,29 @@ import com.hazelcast.config.ClasspathXmlConfig;
 import io.neonbee.test.helper.FileSystemHelper;
 import io.vertx.core.eventbus.EventBusOptions;
 
-public class NeonBeeOptionsTest {
+class NeonBeeOptionsTest {
     @Test
     @DisplayName("should generate an instance name if no instance name is passed")
-    public void generateNameIfNoIsPassed() {
+    void generateNameIfNoIsPassed() {
         assertThat(new NeonBeeOptions.Mutable().getInstanceName()).containsMatch("^NeonBee-.{36}$");
     }
 
     @Test
     @DisplayName("should generate an instance name if null is passed as an instance name")
-    public void generateNameIfNullIsPassed() {
+    void generateNameIfNullIsPassed() {
         assertThat(new NeonBeeOptions.Mutable().setInstanceName(null).getInstanceName())
                 .containsMatch("^NeonBee-.{36}$");
     }
 
     @Test
     @DisplayName("should not generate an instance name if an instance name is passed")
-    public void usePassedInstanceName() {
+    void usePassedInstanceName() {
         assertThat(new NeonBeeOptions.Mutable().setInstanceName("Hodor").getInstanceName()).isEqualTo("Hodor");
     }
 
     @Test
     @DisplayName("should throw an error, if passed instance name is empty")
-    public void checkThatInstanceNameIsNotEmpty() {
+    void checkThatInstanceNameIsNotEmpty() {
         IllegalArgumentException exception =
                 assertThrows(IllegalArgumentException.class, () -> new NeonBeeOptions.Mutable().setInstanceName(""));
         assertThat(exception.getMessage()).isEqualTo("instanceName must not be empty");
@@ -45,7 +45,7 @@ public class NeonBeeOptionsTest {
 
     @Test
     @DisplayName("should throw an error, if event loop pool size is less then 1")
-    public void checkThatEventLoopPoolSizeIsIsAtLeastOne() {
+    void checkThatEventLoopPoolSizeIsIsAtLeastOne() {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
                 () -> new NeonBeeOptions.Mutable().setEventLoopPoolSize(0));
         assertThat(exception.getMessage()).isEqualTo("eventLoopSize must be > 0");
@@ -53,7 +53,7 @@ public class NeonBeeOptionsTest {
 
     @Test
     @DisplayName("should throw an error, if worker pool size is less then 1")
-    public void checkThatWorkerPoolSizeIsIsAtLeastOne() {
+    void checkThatWorkerPoolSizeIsIsAtLeastOne() {
         IllegalArgumentException exception =
                 assertThrows(IllegalArgumentException.class, () -> new NeonBeeOptions.Mutable().setWorkerPoolSize(0));
         assertThat(exception.getMessage()).isEqualTo("workerPoolSize must be > 0");
@@ -61,7 +61,7 @@ public class NeonBeeOptionsTest {
 
     @Test
     @DisplayName("should throw an error, if working directory is null")
-    public void checkThatWorkingDirIsNotNull() {
+    void checkThatWorkingDirIsNotNull() {
         NullPointerException exception =
                 assertThrows(NullPointerException.class, () -> new NeonBeeOptions.Mutable().setWorkingDirectory(null));
         assertThat(exception.getMessage()).isEqualTo("workingDirectory must not be null");
@@ -69,7 +69,7 @@ public class NeonBeeOptionsTest {
 
     @Test
     @DisplayName("should set workingDirectory, if working directory does exist on the file system")
-    public void checkThatWorkingDirExists() throws IOException {
+    void checkThatWorkingDirExists() throws IOException {
         Path tempDirPath = createTempDirectory();
         new NeonBeeOptions.Mutable().setWorkingDirectory(tempDirPath);
         FileSystemHelper.deleteRecursiveBlocking(tempDirPath);
@@ -77,7 +77,7 @@ public class NeonBeeOptionsTest {
 
     @Test
     @DisplayName("should resolve working directory subfolders according to the working directory path")
-    public void checkThatSubfoldersExist() throws IOException {
+    void checkThatSubfoldersExist() throws IOException {
         Path tempDirPath = createTempDirectory();
         NeonBeeOptions opts = new NeonBeeOptions.Mutable().setWorkingDirectory(tempDirPath);
         assertThat((Object) opts.getLogDirectory()).isEqualTo(tempDirPath.resolve("logs"));
@@ -89,32 +89,32 @@ public class NeonBeeOptionsTest {
 
     @Test
     @DisplayName("should ignore class path if set")
-    public void shouldIgnoreClassPath() {
+    void shouldIgnoreClassPath() {
         assertThat(new NeonBeeOptions.Mutable().setIgnoreClassPath(true).shouldIgnoreClassPath()).isTrue();
     }
 
     @Test
     @DisplayName("should not schedule jobs if set")
-    public void shouldDisableJobScheduling() {
+    void shouldDisableJobScheduling() {
         assertThat(new NeonBeeOptions.Mutable().setDisableJobScheduling(true).shouldDisableJobScheduling()).isTrue();
     }
 
     @Test
     @DisplayName("should enable clustered mode if set")
-    public void shouldEnableClustered() {
+    void shouldEnableClustered() {
         assertThat(new NeonBeeOptions.Mutable().setClustered(true).isClustered()).isTrue();
     }
 
     @Test
     @DisplayName("Test port set correctly")
-    public void checkClusterPort() {
+    void checkClusterPort() {
         assertThat(new NeonBeeOptions.Mutable().getClusterPort()).isEqualTo(EventBusOptions.DEFAULT_CLUSTER_PORT);
         assertThat(new NeonBeeOptions.Mutable().setClusterPort(10000).getClusterPort()).isEqualTo(10000);
     }
 
     @Test
     @DisplayName("Test config set correctly")
-    public void checkClusterConfig() {
+    void checkClusterConfig() {
         assertThat(new NeonBeeOptions.Mutable().setClusterConfigResource("hazelcast-local.xml").getClusterConfig())
                 .isInstanceOf(ClasspathXmlConfig.class);
         ClasspathXmlConfig xmlConfig = (ClasspathXmlConfig) new NeonBeeOptions.Mutable()
@@ -124,14 +124,14 @@ public class NeonBeeOptionsTest {
 
     @Test
     @DisplayName("Test server verticle port set correctly")
-    public void checkServerVerticlePort() {
+    void checkServerVerticlePort() {
         assertThat(new NeonBeeOptions.Mutable().getServerVerticlePort()).isNull();
         assertThat(new NeonBeeOptions.Mutable().setServerVerticlePort(10000).getServerVerticlePort()).isEqualTo(10000);
     }
 
     @Test
     @DisplayName("Test server profiles set correctly")
-    public void checkProfiles() {
+    void checkProfiles() {
         assertThat(new NeonBeeOptions.Mutable().setActiveProfileValues("CORE,WEB").getActiveProfiles())
                 .contains(NeonBeeProfile.CORE);
         assertThat(new NeonBeeOptions.Mutable().setActiveProfileValues("CORE,WEB").getActiveProfiles())

--- a/src/test/java/io/neonbee/NeonBeeProfileTest.java
+++ b/src/test/java/io/neonbee/NeonBeeProfileTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 /**
  * NeonBee deployment profile.
  */
-public class NeonBeeProfileTest {
+class NeonBeeProfileTest {
 
     @Test
     @DisplayName("is profile active")

--- a/src/test/java/io/neonbee/NeonBeeTest.java
+++ b/src/test/java/io/neonbee/NeonBeeTest.java
@@ -36,7 +36,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class NeonBeeTest extends NeonBeeTestBase {
+class NeonBeeTest extends NeonBeeTestBase {
 
     @Override
     protected WorkingDirectoryBuilder provideWorkingDirectoryBuilder(TestInfo testInfo, VertxTestContext testContext) {
@@ -53,7 +53,7 @@ public class NeonBeeTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 4, timeUnit = TimeUnit.SECONDS)
     @DisplayName("NeonBee should start with default options / default working directory")
-    public void testStart(Vertx vertx) {
+    void testStart(Vertx vertx) {
         assertThat(getNeonBee()).isNotNull();
         assertThat(NeonBee.instance(vertx)).isNotNull();
     }
@@ -62,7 +62,7 @@ public class NeonBeeTest extends NeonBeeTestBase {
     @Disabled("If the working dir is deleted, it's not possible to override the HttpServerDefaultPort ...")
     @Timeout(value = 4, timeUnit = TimeUnit.SECONDS)
     @DisplayName("NeonBee should start with no working directory and create the working directory")
-    public void testStartWithNoWorkingDirectory() {
+    void testStartWithNoWorkingDirectory() {
         assertThat(Files.isDirectory(getNeonBee().getOptions().getWorkingDirectory())).isTrue();
     }
 
@@ -70,14 +70,14 @@ public class NeonBeeTest extends NeonBeeTestBase {
     @Disabled("If the working dir is empty, it's not possible to override the HttpServerDefaultPort ...")
     @Timeout(value = 4, timeUnit = TimeUnit.SECONDS)
     @DisplayName("NeonBee should start with an empty working directory and create the logs directory")
-    public void testStartWithEmptyWorkingDirectory() {
+    void testStartWithEmptyWorkingDirectory() {
         assertThat(Files.isDirectory(getNeonBee().getOptions().getLogDirectory())).isTrue();
     }
 
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Vert.x should start in non-clustered mode. ")
-    public void testStandaloneInitialization(VertxTestContext testContext) {
+    void testStandaloneInitialization(VertxTestContext testContext) {
         NeonBee.initVertx(new NeonBeeOptions.Mutable()).onComplete(testContext.succeeding(vertx -> {
             assertThat(vertx.isClustered()).isFalse();
             testContext.completeNow();
@@ -87,7 +87,7 @@ public class NeonBeeTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Vert.x should start in clustered mode.")
-    public void testClusterInitialization(VertxTestContext testContext) {
+    void testClusterInitialization(VertxTestContext testContext) {
         NeonBee.initVertx(
                 new NeonBeeOptions.Mutable().setClustered(true).setClusterConfigResource("hazelcast-local.xml"))
                 .onComplete(testContext.succeeding(vertx -> {
@@ -98,7 +98,7 @@ public class NeonBeeTest extends NeonBeeTestBase {
 
     @Test
     @DisplayName("NeonBee should register and unregister local consumer correct.")
-    public void testRegisterAndUnregisterLocalConsumer() {
+    void testRegisterAndUnregisterLocalConsumer() {
         String address = "DataVerticle1";
         assertThat(getNeonBee().isLocalConsumerAvailable(address)).isFalse();
         getNeonBee().registerLocalConsumer(address);
@@ -110,7 +110,7 @@ public class NeonBeeTest extends NeonBeeTestBase {
     @SuppressWarnings("unchecked")
     @Test
     @DisplayName("Vert.x should add eventbus interceptors.")
-    public void testDecorateEventbus() throws Exception {
+    void testDecorateEventbus() throws Exception {
         Vertx vertx = NeonBeeMockHelper.defaultVertxMock();
         NeonBee neonBee = NeonBeeMockHelper.registerNeonBeeMock(vertx, new NeonBeeOptions.Mutable(),
                 new NeonBeeConfig(new JsonObject().put("trackingDataHandlingStrategy", "wrongvalue")));
@@ -132,7 +132,7 @@ public class NeonBeeTest extends NeonBeeTestBase {
     }
 
     @Test
-    public void testFilterByProfile() {
+    void testFilterByProfile() {
         assertThat(NeonBee.filterByAutoDeployAndProfiles(CoreVerticle.class, List.<NeonBeeProfile>of(CORE))).isTrue();
         assertThat(NeonBee.filterByAutoDeployAndProfiles(CoreVerticle.class, List.<NeonBeeProfile>of(CORE, STABLE)))
                 .isTrue();

--- a/src/test/java/io/neonbee/cluster/LocalPreferredClusterTest.java
+++ b/src/test/java/io/neonbee/cluster/LocalPreferredClusterTest.java
@@ -37,7 +37,7 @@ import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(NeonBeeExtension.class)
 @Execution(ExecutionMode.SAME_THREAD)
-public class LocalPreferredClusterTest {
+class LocalPreferredClusterTest {
     private static final String LOCAL = "local";
 
     private static final String REMOTE = "remote";
@@ -49,7 +49,7 @@ public class LocalPreferredClusterTest {
     @BeforeEach
     @Timeout(value = 20, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Setup the cluster nodes and deploy the consumers")
-    public void setUp(@NeonBeeInstanceConfiguration(clustered = true) NeonBee localNode,
+    void setUp(@NeonBeeInstanceConfiguration(clustered = true) NeonBee localNode,
             @NeonBeeInstanceConfiguration(clustered = true) NeonBee remoteNode, VertxTestContext testContext) {
         this.localNode = localNode;
         deployVerticle(localNode.getVertx(), new ConsumerVerticle(LOCAL))
@@ -58,14 +58,14 @@ public class LocalPreferredClusterTest {
     }
 
     @AfterEach
-    public void tearDown(VertxTestContext testContext) {
+    void tearDown(VertxTestContext testContext) {
         localNode.getVertx().close(testContext.succeedingThenComplete());
     }
 
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Test that localPreferred requests are always dispatched to local consumer")
-    public void testLocalPreferredRequest(VertxTestContext testContext) {
+    void testLocalPreferredRequest(VertxTestContext testContext) {
         // Create a localPreferred request
         DataRequest request = new DataRequest(ConsumerVerticle.NAME);
         fireRequests(request).onComplete(testContext.succeeding(responseMap -> {
@@ -77,7 +77,7 @@ public class LocalPreferredClusterTest {
     @Test
     @Timeout(value = 20, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Test that localPreferred requests are dispatched to remote consumers when no local consumer is available")
-    public void testLocalPreferredRequestWithoutLocalConsumer(VertxTestContext testContext) {
+    void testLocalPreferredRequestWithoutLocalConsumer(VertxTestContext testContext) {
         // Create a localPreferred request
         DataRequest request = new DataRequest(ConsumerVerticle.NAME);
         undeployAllVerticlesOfClass(localNode.getVertx(), ConsumerVerticle.class).compose(v -> fireRequests(request))
@@ -90,7 +90,7 @@ public class LocalPreferredClusterTest {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Test that non localPreferred requests are dispatched to local and remote consumers")
-    public void testNonLocalPreferredRequest(VertxTestContext testContext) {
+    void testNonLocalPreferredRequest(VertxTestContext testContext) {
         Range<Long> expectedRange = Range.closed(REPETITION / 2 - 1, REPETITION / 2 + 1);
 
         // Create a non localPreferred request
@@ -110,7 +110,7 @@ public class LocalPreferredClusterTest {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Test that data verticle are registered and deregistered properly as local consumer")
-    public void testLocalConsumerRegistration(VertxTestContext testContext) {
+    void testLocalConsumerRegistration(VertxTestContext testContext) {
         String verticleAddress = "DataVerticle[" + ConsumerVerticle.NAME + "]";
         assertThat(localNode.isLocalConsumerAvailable(verticleAddress)).isTrue();
         undeployAllVerticlesOfClass(localNode.getVertx(), ConsumerVerticle.class)

--- a/src/test/java/io/neonbee/cluster/LocalRequestClusterTest.java
+++ b/src/test/java/io/neonbee/cluster/LocalRequestClusterTest.java
@@ -26,7 +26,7 @@ import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(NeonBeeExtension.class)
-public class LocalRequestClusterTest {
+class LocalRequestClusterTest {
     private static final DataVerticle<JsonObject> LOCAL_TARGET_VERTICLE = new DataVerticle<>() {
         @Override
         public String getName() {
@@ -42,7 +42,7 @@ public class LocalRequestClusterTest {
     @Test
     @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Test that setLocalOnly works as expected")
-    public void testLocalRequest(@NeonBeeInstanceConfiguration(clustered = true) NeonBee source,
+    void testLocalRequest(@NeonBeeInstanceConfiguration(clustered = true) NeonBee source,
             @NeonBeeInstanceConfiguration(clustered = true) NeonBee target, VertxTestContext testContext) {
         Checkpoint nonLocalRequest = testContext.checkpoint();
         Checkpoint localRequest = testContext.checkpoint();

--- a/src/test/java/io/neonbee/cluster/TrackingInterceptorClusterTest.java
+++ b/src/test/java/io/neonbee/cluster/TrackingInterceptorClusterTest.java
@@ -34,7 +34,7 @@ import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith({ NeonBeeExtension.class, MockitoExtension.class })
-public class TrackingInterceptorClusterTest {
+class TrackingInterceptorClusterTest {
 
     @Mock
     private TrackingDataHandlingStrategy strategy;
@@ -50,7 +50,7 @@ public class TrackingInterceptorClusterTest {
     @Test
     @Timeout(value = 20, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Body of messages over distributed eventbus should be non-empty.")
-    public void testNeonBeeWithClusters(@NeonBeeInstanceConfiguration(clustered = true) NeonBee core,
+    void testNeonBeeWithClusters(@NeonBeeInstanceConfiguration(clustered = true) NeonBee core,
             @NeonBeeInstanceConfiguration(clustered = true) NeonBee stable, VertxTestContext testContext) {
 
         stable.getVertx().eventBus().addInboundInterceptor(new TrackingInterceptor(MessageDirection.INBOUND, strategy))

--- a/src/test/java/io/neonbee/data/DataQueryTest.java
+++ b/src/test/java/io/neonbee/data/DataQueryTest.java
@@ -13,18 +13,18 @@ import org.junit.jupiter.api.Test;
 
 import io.vertx.core.buffer.Buffer;
 
-public class DataQueryTest {
+class DataQueryTest {
 
     private DataQuery query;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         query = new DataQuery();
     }
 
     @Test
     @DisplayName("setQuery should set a query and reset parameters to null")
-    public void testSetQuery() {
+    void testSetQuery() {
         query.parameters = Collections.emptyMap();
         query.setQuery("name=Hodor");
         assertThat(query.getQuery()).isEqualTo("name=Hodor");
@@ -33,7 +33,7 @@ public class DataQueryTest {
 
     @Test
     @DisplayName("getQuery should return the parameters joined to a String if parameters is non null")
-    public void testGetQuery2() {
+    void testGetQuery2() {
         query.parameters = Map.of("Hodor", List.of("Hodor"));
         assertThat(query.getQuery()).isEqualTo("Hodor=Hodor");
 
@@ -43,7 +43,7 @@ public class DataQueryTest {
 
     @Test
     @DisplayName("getParameters should return a Map with the query parameters")
-    public void testGetParameters() {
+    void testGetParameters() {
         query.setQuery("Hodor=Hodor&Jon=Snow&Hodor=Hodor2");
         Map<String, List<String>> expected = Map.of("Hodor", List.of("Hodor", "Hodor2"), "Jon", List.of("Snow"));
         assertThat(query.getParameters()).containsExactlyEntriesIn(expected);
@@ -51,7 +51,7 @@ public class DataQueryTest {
 
     @Test
     @DisplayName("getParameterValues should return a List with the values for a given parameter")
-    public void testGetParameterValues() {
+    void testGetParameterValues() {
         query.setQuery("Hodor=Hodor&Jon=Snow&Hodor=Hodor2");
         List<String> expected = List.of("Hodor", "Hodor2");
         assertThat(query.getParameterValues("Hodor")).containsExactlyElementsIn(expected);
@@ -59,7 +59,7 @@ public class DataQueryTest {
 
     @Test
     @DisplayName("getParameter should return the value for a given parameter")
-    public void testGetParameter() {
+    void testGetParameter() {
         query.setQuery("Hodor=Hodor&Jon=Snow&Hodor=Hodor2&Some=Data&Empty=&AlsoEmpty&Test=123");
         assertThat(query.getParameter("Hodor")).isEqualTo("Hodor");
         assertThat(query.getParameter("Jon")).isEqualTo("Snow");
@@ -71,7 +71,7 @@ public class DataQueryTest {
 
     @Test
     @DisplayName("getParameter should return the first value for a given parameter")
-    public void testGetFirstParameter() {
+    void testGetFirstParameter() {
         query.setQuery("Hodor=Hodor&Jon=Snow&Hodor=Hodor2");
         String expected = "Hodor";
         assertThat(query.getParameter("Hodor")).isEqualTo(expected);
@@ -79,7 +79,7 @@ public class DataQueryTest {
 
     @Test
     @DisplayName("addParameter should add a given parameter with value(s)")
-    public void testAddParameter() {
+    void testAddParameter() {
         Map<String, List<String>> expected = Map.of("Jon", List.of("Snow"));
         assertThat(query.addParameter("Jon", "Snow").parameters).isEqualTo(expected);
 
@@ -89,7 +89,7 @@ public class DataQueryTest {
 
     @Test
     @DisplayName("setParameter should set a given parameter with value(s)")
-    public void testSetParameter() {
+    void testSetParameter() {
         Map<String, List<String>> expected = Map.of("Jon", List.of("Snow"));
         assertThat(query.setParameter("Jon", "Snow").parameters).isEqualTo(expected);
 
@@ -102,7 +102,7 @@ public class DataQueryTest {
 
     @Test
     @DisplayName("setParameter should set a given parameter with value(s)")
-    public void testRemoveParameter() {
+    void testRemoveParameter() {
         query.parameters = Map.of("Hodor", List.of("Hodor", "Hodor2"), "Jon", List.of("Snow", "Know", "Nothing"));
         query.setQuery(query.getQuery());
 
@@ -112,7 +112,7 @@ public class DataQueryTest {
 
     @Test
     @DisplayName("parseQueryString should parse a query string correct")
-    public void testParseQueryString() {
+    void testParseQueryString() {
         Map<String, List<String>> expected = Map.of("Hodor", List.of(""));
         assertThat(DataQuery.parseQueryString("Hodor")).containsExactlyEntriesIn(expected);
         assertThat(DataQuery.parseQueryString("Hodor=")).containsExactlyEntriesIn(expected);
@@ -129,7 +129,7 @@ public class DataQueryTest {
 
     @Test
     @DisplayName("setUriPath should not work if it contains a query")
-    public void testSetUriPathWithQuery() {
+    void testSetUriPathWithQuery() {
         Exception thrownException = assertThrows(IllegalArgumentException.class, () -> {
             new DataQuery().setUriPath("/raw/MyDataVerticle?param=value");
         });
@@ -138,7 +138,7 @@ public class DataQueryTest {
 
     @Test
     @DisplayName("DataQuery creation should not work if it uriPath contains a query")
-    public void testDataQueryCreation() {
+    void testDataQueryCreation() {
         Exception thrownException = assertThrows(IllegalArgumentException.class, () -> {
             new DataQuery("/odata/MyNamespace.MyService/MyEntitySet?$param=value");
         });
@@ -147,14 +147,14 @@ public class DataQueryTest {
 
     @Test
     @DisplayName("DataQuery should have empty map when no header is passed")
-    public void testEmptyHeader() {
+    void testEmptyHeader() {
         DataQuery query = new DataQuery("uri", "name=Hodor");
         assertThat(query.getHeaders()).isEqualTo(Map.of());
     }
 
     @Test
     @DisplayName("Equals should return false with different bodies")
-    public void testEqualsWithDifferentBodies() {
+    void testEqualsWithDifferentBodies() {
         DataQuery query1 = new DataQuery(DataAction.CREATE, "uri", "name=Hodor", Map.of("header1", List.of("value1")),
                 Buffer.buffer("payload1"));
         assertThat(query1.copy().setBody(Buffer.buffer("payload2"))).isNotEqualTo(query1);

--- a/src/test/java/io/neonbee/data/DataRequestTest.java
+++ b/src/test/java/io/neonbee/data/DataRequestTest.java
@@ -6,11 +6,11 @@ import org.apache.olingo.commons.api.edm.FullQualifiedName;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-public class DataRequestTest {
+class DataRequestTest {
 
     @Test
     @DisplayName("test localPreferred handling")
-    public void testLocalPreferred() {
+    void testLocalPreferred() {
         DataRequest request = new DataRequest(new FullQualifiedName("namespace", "name"), new DataQuery());
         assertThat(request.isLocalPreferred()).isTrue();
         request.setLocalPreferred(false);

--- a/src/test/java/io/neonbee/data/DataVerticleTest.java
+++ b/src/test/java/io/neonbee/data/DataVerticleTest.java
@@ -17,7 +17,7 @@ import io.vertx.core.Future;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class DataVerticleTest extends DataVerticleTestBase {
+class DataVerticleTest extends DataVerticleTestBase {
     // Data Verticle that has NOT the @NeonBeeDeployable annotation
     private DataVerticleImpl0 dataVerticleImpl0;
 

--- a/src/test/java/io/neonbee/data/internal/DataContextImplTest.java
+++ b/src/test/java/io/neonbee/data/internal/DataContextImplTest.java
@@ -172,7 +172,7 @@ class DataContextImplTest {
 
     @Test
     @DisplayName("DataVerticleCoordinate toString")
-    public void testToString() {
+    void testToString() {
         DataVerticleCoordinateImpl coordinate = new DataVerticleCoordinateImpl("DataVerticle")
                 .setDeploymentId("deploymentid").setIpAddress("ipAddress");
         assertThat(coordinate.toString())
@@ -233,13 +233,13 @@ class DataContextImplTest {
 
     @Test
     @DisplayName("it should be fine to create a empty context")
-    public void testNewContextConstructor() {
+    void testNewContextConstructor() {
         testEmptyContext(new DataContextImpl());
     }
 
     @Test
     @DisplayName("it should be fine to create a empty context with null values for the constructor")
-    public void testNullValueContextConstructor() {
+    void testNullValueContextConstructor() {
         testEmptyContext(new DataContextImpl(null, null, null, null));
     }
 
@@ -252,7 +252,7 @@ class DataContextImplTest {
 
     @Test
     @DisplayName("the context should accept any correlation id (incl. null)")
-    public void testCorrelationId() {
+    void testCorrelationId() {
         assertThat(new DataContextImpl("expected1", null, null, null).correlationId()).isEqualTo("expected1");
         assertThat(new DataContextImpl("expected2", null, null, null).correlationId()).isEqualTo("expected2");
         assertThat(new DataContextImpl(null, null, null, null).correlationId()).isNull();
@@ -260,7 +260,7 @@ class DataContextImplTest {
 
     @Test
     @DisplayName("the context should accept any bearer token (incl. null)")
-    public void testBearerToken() {
+    void testBearerToken() {
         assertThat(new DataContextImpl(null, "expected1", null, null).bearerToken()).isEqualTo("expected1");
         assertThat(new DataContextImpl(null, "expected2", null, null).bearerToken()).isEqualTo("expected2");
         assertThat(new DataContextImpl(null, null, null, null).bearerToken()).isNull();
@@ -268,7 +268,7 @@ class DataContextImplTest {
 
     @Test
     @DisplayName("the context should accept any user principal (incl. null)")
-    public void testUserPrincipal() {
+    void testUserPrincipal() {
         assertThat(new DataContextImpl(null, null, new JsonObject(), null).userPrincipal())
                 .isInstanceOf(JsonObject.class);
         assertThat(new DataContextImpl(null, null, new JsonObject().put("anyAttribute", "anyExpectedValue"), null)
@@ -278,7 +278,7 @@ class DataContextImplTest {
 
     @Test
     @DisplayName("the user principal of a context should be immutable")
-    public void testUserPrincipalImmutable() {
+    void testUserPrincipalImmutable() {
         assertThrows(UnsupportedOperationException.class, () -> new DataContextImpl(null, null, new JsonObject(), null)
                 .userPrincipal().put("anyAttribute", "anyValue"));
         assertThrows(UnsupportedOperationException.class,
@@ -287,7 +287,7 @@ class DataContextImplTest {
 
     @Test
     @DisplayName("the user arbitrary data of a context")
-    public void testArbitraryData() {
+    void testArbitraryData() {
         assertThat(new DataContextImpl(null, null, null, null).data()).isEmpty();
         // should create a mutable map
         assertDoesNotThrow(() -> new DataContextImpl(null, null, null, Collections.emptyMap()).data()
@@ -301,7 +301,7 @@ class DataContextImplTest {
 
     @Test
     @DisplayName("test passing a routing context instead")
-    public void testWithRoutingContext() {
+    void testWithRoutingContext() {
         RoutingContext routingContextMock = mock(RoutingContext.class);
         HttpServerRequest requestMock = mock(HttpServerRequest.class);
         User userMock = mock(User.class);
@@ -320,7 +320,7 @@ class DataContextImplTest {
 
     @Test
     @DisplayName("test encoding / decoding null context")
-    public void testNullEncodeDecode() {
+    void testNullEncodeDecode() {
         DataContext dataContext = DataContextImpl.decodeContextFromString(
                 DataContextImpl.encodeContextToString(new DataContextImpl(null, null, null, null)));
         assertThat(dataContext.correlationId()).isNull();
@@ -331,7 +331,7 @@ class DataContextImplTest {
 
     @Test
     @DisplayName("test encoding / decoding context")
-    public void testEncodeDecode() {
+    void testEncodeDecode() {
         DataContext dataContext = DataContextImpl.decodeContextFromString(DataContextImpl.encodeContextToString(
                 new DataContextImpl("expected1", "expected2", new JsonObject().put("expectedKey", "expectedValue"),
                         new JsonObject().put("expected1", "expected2").put("expectedArray", new JsonArray().add(0))

--- a/src/test/java/io/neonbee/entity/EntityModelManagerTest.java
+++ b/src/test/java/io/neonbee/entity/EntityModelManagerTest.java
@@ -39,7 +39,7 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class EntityModelManagerTest extends NeonBeeTestBase {
+class EntityModelManagerTest extends NeonBeeTestBase {
     private static final Path TEST_SERVICE_1_MODEL_PATH = TEST_RESOURCES.resolveRelated("TestService1.csn");
 
     private static final Path TEST_SERVICE_2_MODEL_PATH = TEST_RESOURCES.resolveRelated("TestService2.csn");
@@ -49,7 +49,7 @@ public class EntityModelManagerTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("should return the same odata instance for one thread")
-    public void validateODataBufferInSameThread() {
+    void validateODataBufferInSameThread() {
         OData odata1 = getBufferedOData();
         OData odata2 = getBufferedOData();
         assertThat(odata1).isSameInstanceAs(odata2);
@@ -58,7 +58,7 @@ public class EntityModelManagerTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("should return different odata instances for multiple threads")
-    public void validateODataBufferInDifferentThreads() {
+    void validateODataBufferInDifferentThreads() {
         CompletableFuture<OData> odataFuture1 = new CompletableFuture<>();
         CompletableFuture<OData> odataFuture2 = new CompletableFuture<>();
 
@@ -75,7 +75,7 @@ public class EntityModelManagerTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("check if loading a non-existent model fails")
-    public void loadNonExistingModelTest(Vertx vertx, VertxTestContext testContext) {
+    void loadNonExistingModelTest(Vertx vertx, VertxTestContext testContext) {
         new EntityModelManager.Loader(vertx).loadModel(Path.of("not.existing.Service.csn"))
                 .onComplete(testContext.failing(result -> testContext.completeNow()));
     }
@@ -83,7 +83,7 @@ public class EntityModelManagerTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("check if multiple models can be loaded from files")
-    public void loadEDMXModelsTest(Vertx vertx, VertxTestContext testContext) {
+    void loadEDMXModelsTest(Vertx vertx, VertxTestContext testContext) {
         Loader loader = new EntityModelManager.Loader(vertx);
         CompositeFuture
                 .all(loader.loadModel(TEST_SERVICE_1_MODEL_PATH), loader.loadModel(TEST_SERVICE_2_MODEL_PATH),
@@ -104,7 +104,7 @@ public class EntityModelManagerTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("check if models from file system can be loaded")
-    public void loadModelsFileSystemTest(Vertx vertx, VertxTestContext testContext) {
+    void loadModelsFileSystemTest(Vertx vertx, VertxTestContext testContext) {
         Loader loader = new EntityModelManager.Loader(vertx);
         CompositeFuture
                 .all(loader.loadModel(TEST_SERVICE_1_MODEL_PATH), loader.loadModel(TEST_SERVICE_2_MODEL_PATH),
@@ -124,7 +124,7 @@ public class EntityModelManagerTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("check if the models from classpath can be loaded ")
-    public void loadFromClassPathTest(Vertx vertx, VertxTestContext testContext) throws IOException {
+    void loadFromClassPathTest(Vertx vertx, VertxTestContext testContext) throws IOException {
         Loader loader = new EntityModelManager.Loader(vertx);
         loader.scanClassPath().onComplete(testContext.succeeding(result -> testContext.verify(() -> {
             assertThat(loader.models.get("io.neonbee.test1").getEdmx().getEdm().getEntityContainer().getNamespace())
@@ -139,7 +139,7 @@ public class EntityModelManagerTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("check if the models from module can be loaded ")
-    public void loadFromModuleTest(Vertx vertx, VertxTestContext testContext) throws IOException {
+    void loadFromModuleTest(Vertx vertx, VertxTestContext testContext) throws IOException {
         // Create models
         Map.Entry<String, byte[]> referenceModel = buildModelEntry("ReferenceService.csn");
 
@@ -164,7 +164,7 @@ public class EntityModelManagerTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("test if loading models doesn't fail for non-existing working directories")
-    public void dontFailModelLoadingOnNonExistingWorkingDir(Vertx vertx, VertxTestContext testContext) {
+    void dontFailModelLoadingOnNonExistingWorkingDir(Vertx vertx, VertxTestContext testContext) {
         new EntityModelManager.Loader(vertx).loadDir(Path.of("non-existing"))
                 .onComplete(testContext.succeeding(models -> testContext.completeNow()));
     }
@@ -172,7 +172,7 @@ public class EntityModelManagerTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("lazy model loading: NeonBee should not load any model files after starting")
-    public void lazyModelLoadingTest(Vertx vertx, VertxTestContext testContext) throws Exception {
+    void lazyModelLoadingTest(Vertx vertx, VertxTestContext testContext) throws Exception {
         Path workingDir = FileSystemHelper.createTempDirectory();
         WorkingDirectoryBuilder.hollow().addModel(TEST_RESOURCES.resolveRelated("TestService1.csn"))
                 .addModel(TEST_RESOURCES.resolveRelated("TestService2.csn")).build(workingDir);
@@ -218,7 +218,7 @@ public class EntityModelManagerTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("check if getting single shared models will work for get shared edmx model")
-    public void getSingleSharedModelsTest(Vertx vertx, VertxTestContext testContext) throws Exception {
+    void getSingleSharedModelsTest(Vertx vertx, VertxTestContext testContext) throws Exception {
         Path workingDir = FileSystemHelper.createTempDirectory();
         WorkingDirectoryBuilder.hollow().addModel(TEST_RESOURCES.resolveRelated("TestService1.csn"))
                 .addModel(TEST_RESOURCES.resolveRelated("TestService2.csn")).build(workingDir);
@@ -239,7 +239,7 @@ public class EntityModelManagerTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("check if getting single non-existing model will fail for get shared edmx model")
-    public void getSingleNonExistingSharedModelTest(Vertx vertx, VertxTestContext testContext) {
+    void getSingleNonExistingSharedModelTest(Vertx vertx, VertxTestContext testContext) {
         getSharedModel(vertx, "non-existing").onComplete(testContext.failing(throwable -> testContext.verify(() -> {
             assertThat(throwable).isInstanceOf(NoSuchElementException.class);
             testContext.completeNow();
@@ -249,7 +249,7 @@ public class EntityModelManagerTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("check if getting CSN Model works")
-    public void getCSNModelTest(Vertx vertx, VertxTestContext testContext) {
+    void getCSNModelTest(Vertx vertx, VertxTestContext testContext) {
         Loader loader = new EntityModelManager.Loader(vertx);
         Future<CdsModel> csnModelFuture = loader.loadCsnModel(TEST_SERVICE_1_MODEL_PATH);
         csnModelFuture.compose(v -> loader.loadModel(TEST_SERVICE_1_MODEL_PATH))
@@ -264,7 +264,7 @@ public class EntityModelManagerTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("register / unregister module models")
-    public void registerModuleModels(Vertx vertx, VertxTestContext testContext) throws IOException {
+    void registerModuleModels(Vertx vertx, VertxTestContext testContext) throws IOException {
         Path workingDirectory = getNeonBee().getOptions().getWorkingDirectory();
         NeonBeeMockHelper.registerNeonBeeMock(vertx,
                 new NeonBeeOptions.Mutable().setIgnoreClassPath(true).setWorkingDirectory(workingDirectory));
@@ -290,7 +290,7 @@ public class EntityModelManagerTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("register / unregister multiple modules to verify that changing the unmodifiable BUFFERED_MODELS is working correctly.")
-    public void registerMultipleModuleModels(Vertx vertx, VertxTestContext testContext) throws IOException {
+    void registerMultipleModuleModels(Vertx vertx, VertxTestContext testContext) throws IOException {
         Path workingDirectory = getNeonBee().getOptions().getWorkingDirectory();
         NeonBeeMockHelper.registerNeonBeeMock(vertx,
                 new NeonBeeOptions.Mutable().setIgnoreClassPath(true).setWorkingDirectory(workingDirectory));

--- a/src/test/java/io/neonbee/entity/EntityVerticleTest.java
+++ b/src/test/java/io/neonbee/entity/EntityVerticleTest.java
@@ -45,7 +45,7 @@ import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class EntityVerticleTest extends EntityVerticleTestBase {
+class EntityVerticleTest extends EntityVerticleTestBase {
     private EntityVerticle entityVerticleImpl1;
 
     private EntityVerticle entityVerticleImpl2;

--- a/src/test/java/io/neonbee/entity/EntityWrapperTest.java
+++ b/src/test/java/io/neonbee/entity/EntityWrapperTest.java
@@ -20,7 +20,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class EntityWrapperTest extends NeonBeeTestBase {
+class EntityWrapperTest extends NeonBeeTestBase {
     private static final EntityWrapper TEST_USER_WRAPPER =
             new EntityWrapper("io.neonbee.test2.TestService2Users.TestUsers", createTestUser());
 
@@ -43,7 +43,7 @@ public class EntityWrapperTest extends NeonBeeTestBase {
 
     @Test
     @DisplayName("Check if equals works as expected")
-    public void testEquals() {
+    void testEquals() {
         EntityWrapper fooBarEmptyString = new EntityWrapper("Foo.Bar", (Entity) null);
         EntityWrapper fooBarEmptyFQN = new EntityWrapper(new FullQualifiedName("Foo", "Bar"), (Entity) null);
         EntityWrapper hodorHodorEmptyFQN = new EntityWrapper(new FullQualifiedName("Hodor", "Hodor"), (Entity) null);
@@ -65,7 +65,7 @@ public class EntityWrapperTest extends NeonBeeTestBase {
     @Test
     @DisplayName("Check if toBuffer works as expected")
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
-    public void testToBuffer(VertxTestContext testContext) {
+    void testToBuffer(VertxTestContext testContext) {
         EntityModelManager.reloadModels(getNeonBee().getVertx()).onComplete(testContext.succeeding(map -> {
             testContext.verify(() -> {
                 Buffer buffer = TEST_USER_WRAPPER.toBuffer(getNeonBee().getVertx());
@@ -78,7 +78,7 @@ public class EntityWrapperTest extends NeonBeeTestBase {
     @Test
     @DisplayName("Check if fromBuffer works as expected")
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
-    public void testFromBuffer(VertxTestContext testContext) {
+    void testFromBuffer(VertxTestContext testContext) {
         EntityModelManager.reloadModels(getNeonBee().getVertx()).onComplete(testContext.succeeding(map -> {
             testContext.verify(() -> {
                 EntityWrapper decodedWrapper =

--- a/src/test/java/io/neonbee/entity/ModelDefinitionHelperTest.java
+++ b/src/test/java/io/neonbee/entity/ModelDefinitionHelperTest.java
@@ -17,7 +17,7 @@ import com.sap.cds.reflect.CdsModel;
 import com.sap.cds.reflect.impl.CdsModelBuilder;
 import com.sap.cds.reflect.impl.CdsServiceBuilder;
 
-public class ModelDefinitionHelperTest {
+class ModelDefinitionHelperTest {
 
     @Test
     @DisplayName("Checks if namespace can be extracted")

--- a/src/test/java/io/neonbee/helper/FileSystemHelperTest.java
+++ b/src/test/java/io/neonbee/helper/FileSystemHelperTest.java
@@ -34,7 +34,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(VertxExtension.class)
-public class FileSystemHelperTest {
+class FileSystemHelperTest {
     private Path tempDir;
 
     @BeforeEach

--- a/src/test/java/io/neonbee/hook/HookRegistryTest.java
+++ b/src/test/java/io/neonbee/hook/HookRegistryTest.java
@@ -17,7 +17,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(VertxExtension.class)
-public class HookRegistryTest {
+class HookRegistryTest {
     private final String correlID = "correl";
 
     @Test
@@ -42,8 +42,7 @@ public class HookRegistryTest {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Check that registerHooks throw an error if no constructor is available")
-    void registerHooksFails(VertxTestContext testContext)
-            throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+    void registerHooksFails(VertxTestContext testContext) throws SecurityException, IllegalArgumentException {
         HookRegistry registry = new TestHookRegistry();
 
         registry.registerHooks(Void.class, correlID).onComplete(testContext.failing(t -> {

--- a/src/test/java/io/neonbee/hook/internal/DefaultHookContextTest.java
+++ b/src/test/java/io/neonbee/hook/internal/DefaultHookContextTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import io.neonbee.hook.HookContext;
 import io.neonbee.hook.HookType;
 
-public class DefaultHookContextTest {
+class DefaultHookContextTest {
 
     @Test
     void withoutParametersTest() {

--- a/src/test/java/io/neonbee/hook/internal/DefaultHookRegistrationTest.java
+++ b/src/test/java/io/neonbee/hook/internal/DefaultHookRegistrationTest.java
@@ -24,7 +24,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(VertxExtension.class)
-public class DefaultHookRegistrationTest {
+class DefaultHookRegistrationTest {
     private DefaultHookRegistry hookRegistry;
 
     private Object instanceWithHook;

--- a/src/test/java/io/neonbee/hook/internal/DefaultHookRegistryTest.java
+++ b/src/test/java/io/neonbee/hook/internal/DefaultHookRegistryTest.java
@@ -25,7 +25,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(VertxExtension.class)
-public class DefaultHookRegistryTest {
+class DefaultHookRegistryTest {
     private static final String CORRELATION_ID = "bliblablub";
 
     private DefaultHookRegistry hookRegistry;

--- a/src/test/java/io/neonbee/internal/HelperTest.java
+++ b/src/test/java/io/neonbee/internal/HelperTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import io.neonbee.test.helper.ReflectionHelper;
 import io.neonbee.test.helper.SystemHelper;
 
-public class HelperTest {
+class HelperTest {
 
     @Test
     @DisabledOnOs(value = { WINDOWS }, disabledReason = "SystemHelper.setEnvironment has no effect on Windows")

--- a/src/test/java/io/neonbee/internal/JarHelperTest.java
+++ b/src/test/java/io/neonbee/internal/JarHelperTest.java
@@ -6,7 +6,7 @@ import java.net.URI;
 
 import org.junit.jupiter.api.Test;
 
-public class JarHelperTest {
+class JarHelperTest {
 
     @Test
     void extractFilePathTest() {

--- a/src/test/java/io/neonbee/internal/SelfFirstClassLoaderTest.java
+++ b/src/test/java/io/neonbee/internal/SelfFirstClassLoaderTest.java
@@ -32,7 +32,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(VertxExtension.class)
-public class SelfFirstClassLoaderTest {
+class SelfFirstClassLoaderTest {
     private static final String CLASS_NAME = "CoolTestClassWithUniqueName";
 
     private static final String RESOURCE_NAME = "CoolResourceWithUniqueName";
@@ -44,18 +44,18 @@ public class SelfFirstClassLoaderTest {
     private ClassLoader originalContextClassLoader;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         originalContextClassLoader = Thread.currentThread().getContextClassLoader();
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         Thread.currentThread().setContextClassLoader(originalContextClassLoader);
     }
 
     @Test
     @DisplayName("Test if the decision logic which class should be loaded from parent works correct")
-    public void testLoadFromParent() throws IOException {
+    void testLoadFromParent() throws IOException {
         SelfFirstClassLoader sfcl = new SelfFirstClassLoader(new URL[] {}, null,
                 List.of("io.neonbee.*", "io.Hod*", "com.example.LordCitrange"));
         assertThat(sfcl.loadFromParent("io.neonbee.DataVerticle")).isTrue();
@@ -71,7 +71,7 @@ public class SelfFirstClassLoaderTest {
 
     @Test
     @DisplayName("Test if the decision logic which class should be loaded from parent works correct if only a wildcard is passed")
-    public void testLoadFromParentWithOnlyWildcard() throws IOException {
+    void testLoadFromParentWithOnlyWildcard() throws IOException {
         SelfFirstClassLoader sfcl = new SelfFirstClassLoader(new URL[] {}, null, List.of("*"));
         assertThat(sfcl.loadFromParent("io.neonbee.DataVerticle")).isTrue();
         assertThat(sfcl.loadFromParent("com.example.LordCitrange")).isTrue();
@@ -81,7 +81,7 @@ public class SelfFirstClassLoaderTest {
 
     @Test
     @DisplayName("Test if empty or null strings are filtered out from passed parentPreferred strings")
-    public void testLoadFromParentWithEmptyOrNullStrings() throws IOException {
+    void testLoadFromParentWithEmptyOrNullStrings() throws IOException {
         List<String> expected = List.of("io.hodor.Hodor", "lord.Citrange");
         List<String> parentPreferred = new ArrayList<>(expected);
         parentPreferred.add("");
@@ -95,7 +95,7 @@ public class SelfFirstClassLoaderTest {
     @SuppressWarnings("unchecked")
     @Test
     @DisplayName("Test if parent preferred classes are loaded from parent class loader")
-    public void testParentPreferred() throws IOException, ClassNotFoundException {
+    void testParentPreferred() throws IOException, ClassNotFoundException {
         String otherClass = "OtherUniqueClassName";
         ClassLoader parentClassLoader = createClassLoaderWithJars(
                 List.of(new NeonBeeModuleJar("testmodule1", new IsoVerticleTemplate(CLASS_NAME, "parentAddress")),
@@ -121,8 +121,7 @@ public class SelfFirstClassLoaderTest {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Deployments must be able to load a different versions of a class, even if platform already uses this class")
-    public void loadClassesIsolatedTest(Vertx vertx, VertxTestContext testContext)
-            throws ClassNotFoundException, IOException {
+    void loadClassesIsolatedTest(Vertx vertx, VertxTestContext testContext) throws ClassNotFoundException, IOException {
         Checkpoint cp = testContext.checkpoint(2);
 
         // Create fake system classLoader which represents the class inside the platform

--- a/src/test/java/io/neonbee/internal/codec/BufferDeserializerTest.java
+++ b/src/test/java/io/neonbee/internal/codec/BufferDeserializerTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 
 import java.io.IOException;
 
-import org.json.JSONException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +13,7 @@ class BufferDeserializerTest {
 
     @Test
     @DisplayName("deserialization of a stream to buffer.")
-    public void testDeserialization() throws IOException, JSONException {
+    void testDeserialization() throws IOException {
         String json = "{\"type\":\"file\",\"content\":\"body\"}";
         ObjectMapper mapper = new ObjectMapper();
         BufferWrapper wrapper = mapper.readValue(json, BufferWrapper.class);

--- a/src/test/java/io/neonbee/internal/codec/BufferSerializerTest.java
+++ b/src/test/java/io/neonbee/internal/codec/BufferSerializerTest.java
@@ -15,7 +15,7 @@ class BufferSerializerTest {
 
     @Test
     @DisplayName("serialization of a buffer should produce the right JSON representation.")
-    public void testSerialization() throws IOException, JSONException {
+    void testSerialization() throws IOException, JSONException {
         BufferWrapper wrapper = new BufferWrapper("file", Buffer.buffer("body"));
         ObjectMapper mapper = new ObjectMapper();
         String json = mapper.writeValueAsString(wrapper);

--- a/src/test/java/io/neonbee/internal/codec/EntityWrapperMessageCodecTest.java
+++ b/src/test/java/io/neonbee/internal/codec/EntityWrapperMessageCodecTest.java
@@ -37,7 +37,7 @@ class EntityWrapperMessageCodecTest extends NeonBeeTestBase {
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         codec = new EntityWrapperMessageCodec(getNeonBee().getVertx());
     }
 

--- a/src/test/java/io/neonbee/internal/deploy/NeonBeeModuleTest.java
+++ b/src/test/java/io/neonbee/internal/deploy/NeonBeeModuleTest.java
@@ -36,7 +36,7 @@ import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
 @SuppressWarnings("StreamResourceLeak") // Ignore in Errorprone -> Because it is just a test
-public class NeonBeeModuleTest extends NeonBeeTestBase {
+class NeonBeeModuleTest extends NeonBeeTestBase {
     private static final String CORRELATION_ID = "correlId";
 
     @Test

--- a/src/test/java/io/neonbee/internal/deploy/PendingDeploymentTest.java
+++ b/src/test/java/io/neonbee/internal/deploy/PendingDeploymentTest.java
@@ -19,7 +19,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(VertxExtension.class)
-public class PendingDeploymentTest {
+class PendingDeploymentTest {
     private static final String CORRELATION_ID = "correlId";
 
     @Test

--- a/src/test/java/io/neonbee/internal/handler/CorrelationIdHandlerTest.java
+++ b/src/test/java/io/neonbee/internal/handler/CorrelationIdHandlerTest.java
@@ -16,10 +16,10 @@ import org.junit.jupiter.api.Test;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.RoutingContext;
 
-public class CorrelationIdHandlerTest {
+class CorrelationIdHandlerTest {
     @Test
     @DisplayName("test GENERATE_UUID correlation strategy")
-    public void generateUuidStrategy() {
+    void generateUuidStrategy() {
         RoutingContext routingContextMock = mock(RoutingContext.class);
         CorrelationIdHandler.create(GENERATE_UUID).handle(routingContextMock);
         verifyUuidCorrelationId(routingContextMock);
@@ -27,7 +27,7 @@ public class CorrelationIdHandlerTest {
 
     @Test
     @DisplayName("test REQUEST_HEADER correlation strategy fallback to UUID_STRATEGY")
-    public void requestHeaderStrategyFallback() {
+    void requestHeaderStrategyFallback() {
         RoutingContext routingContextMock = mock(RoutingContext.class);
         when(routingContextMock.request()).then(RETURNS_MOCKS);
         CorrelationIdHandler.create(REQUEST_HEADER).handle(routingContextMock);
@@ -36,7 +36,7 @@ public class CorrelationIdHandlerTest {
 
     @Test
     @DisplayName("test REQUEST_HEADER correlation strategy x-vcap-request-id header")
-    public void requestHeaderStrategyHeaders() {
+    void requestHeaderStrategyHeaders() {
         String expectedCorrelationId = "expectedCorrelationId";
 
         for (String header : new String[] { "X-CorrelationID", "x-vcap-request-id" }) {

--- a/src/test/java/io/neonbee/internal/handler/HooksHandlerTest.java
+++ b/src/test/java/io/neonbee/internal/handler/HooksHandlerTest.java
@@ -21,7 +21,7 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxTestContext;
 
-public class HooksHandlerTest extends DataVerticleTestBase {
+class HooksHandlerTest extends DataVerticleTestBase {
     private static final String CORRELATION_ID = "bliblablub";
 
     @Test

--- a/src/test/java/io/neonbee/internal/handler/InstanceInfoHandlerTest.java
+++ b/src/test/java/io/neonbee/internal/handler/InstanceInfoHandlerTest.java
@@ -16,11 +16,11 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.junit5.Timeout;
 
-public class InstanceInfoHandlerTest extends DataVerticleTestBase {
+class InstanceInfoHandlerTest extends DataVerticleTestBase {
     @Test
     @DisplayName("Check the set X-Instance-Info header")
     @Timeout(value = 1, timeUnit = TimeUnit.SECONDS)
-    public void testXInstanceName(Vertx vertx) {
+    void testXInstanceName(Vertx vertx) {
         createRequest(HttpMethod.GET, "/").send(asyncResponse -> {
             if (asyncResponse.succeeded()) {
                 HttpResponse<Buffer> response = asyncResponse.result();

--- a/src/test/java/io/neonbee/internal/handler/NotFoundHandlerTest.java
+++ b/src/test/java/io/neonbee/internal/handler/NotFoundHandlerTest.java
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Test;
 
 import io.vertx.ext.web.RoutingContext;
 
-public class NotFoundHandlerTest {
+class NotFoundHandlerTest {
     @Test
     @DisplayName("test not found handler")
-    public void testNotFound() {
+    void testNotFound() {
         RoutingContext routingContextMock = mock(RoutingContext.class);
         NotFoundHandler.create().handle(routingContextMock);
         verify(routingContextMock).fail(404);

--- a/src/test/java/io/neonbee/internal/handler/ODataEndpointHandlerTest.java
+++ b/src/test/java/io/neonbee/internal/handler/ODataEndpointHandlerTest.java
@@ -65,7 +65,7 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class ODataEndpointHandlerTest extends ODataEndpointTestBase {
+class ODataEndpointHandlerTest extends ODataEndpointTestBase {
 
     @Override
     protected List<Path> provideEntityModels() {
@@ -94,7 +94,7 @@ public class ODataEndpointHandlerTest extends ODataEndpointTestBase {
 
     @Test
     @DisplayName("map generic response")
-    public void checkGenericResponseMapping() {
+    void checkGenericResponseMapping() {
         ODataResponse odataResponse = new ODataResponse();
         odataResponse.setStatusCode(200);
         odataResponse.setHeader("expected1", "value1");
@@ -115,7 +115,7 @@ public class ODataEndpointHandlerTest extends ODataEndpointTestBase {
 
     @Test
     @DisplayName("map OData response")
-    public void checkODataResponseMapping() {
+    void checkODataResponseMapping() {
         ODataResponse odataResponse = new ODataResponse();
         ODataContent odataContentMock = mock(ODataContent.class);
         doAnswer((Answer<ODataContent>) invocation -> {
@@ -135,7 +135,7 @@ public class ODataEndpointHandlerTest extends ODataEndpointTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("check if (lazy) loading OData models on first request to ODataEndpoint works")
-    public void testODataEndpointLazyLoading(VertxTestContext testContext) {
+    void testODataEndpointLazyLoading(VertxTestContext testContext) {
         assertOData(requestMetadata("io.neonbee.handler.TestService"),
                 body -> assertThat(body.toString()).contains("<edmx:Edmx"), testContext)
                         .onComplete(testContext.succeedingThenComplete());
@@ -143,7 +143,7 @@ public class ODataEndpointHandlerTest extends ODataEndpointTestBase {
 
     @Test
     @DisplayName("test mapToODataRequest")
-    public void testMapToODataRequest() throws Exception {
+    void testMapToODataRequest() throws Exception {
         String expectedQuery = "$filter=foo eq 'bar'&$limit=42";
         String expectedPath = "/path";
         String expectedNamespace = "namespace";
@@ -169,7 +169,7 @@ public class ODataEndpointHandlerTest extends ODataEndpointTestBase {
     }
 
     @Test
-    public void testUriConversionRules() {
+    void testUriConversionRules() {
         // strict should not convert anything!
         assertThat(STRICT.apply("any-string")).isEqualTo("any-string");
         assertThat(STRICT.apply("anyOtherString")).isEqualTo("anyOtherString");
@@ -213,7 +213,7 @@ public class ODataEndpointHandlerTest extends ODataEndpointTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("check if multiple service endpoints are created with strict URI mapping")
-    public void testStrictUriConversion(VertxTestContext testContext) {
+    void testStrictUriConversion(VertxTestContext testContext) {
         all(assertOData(requestMetadata("io.neonbee.handler.TestService"), ODataEndpointHandlerTest::assertTS1Handler,
                 testContext),
                 assertOData(requestMetadata("io.neonbee.handler2.Test2Service"),
@@ -225,7 +225,7 @@ public class ODataEndpointHandlerTest extends ODataEndpointTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("check if loose URI mapping works")
-    public void testLooseUriConversion(VertxTestContext testContext) {
+    void testLooseUriConversion(VertxTestContext testContext) {
         all(assertOData(requestMetadata("io-neonbee-handler-test"), ODataEndpointHandlerTest::assertTS1Handler,
                 testContext),
                 assertOData(requestMetadata("io-neonbee-handler2-test2"), ODataEndpointHandlerTest::assertTS2Handler,
@@ -237,7 +237,7 @@ public class ODataEndpointHandlerTest extends ODataEndpointTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("check if CDS URI mapping works")
-    public void testCDSUriConversion(VertxTestContext testContext) {
+    void testCDSUriConversion(VertxTestContext testContext) {
         all(assertOData(requestMetadata("test"), ODataEndpointHandlerTest::assertTS1Handler, testContext),
                 assertOData(requestMetadata("test2"), ODataEndpointHandlerTest::assertTS2Handler, testContext),
                 assertOData(requestMetadata(""), ODataEndpointHandlerTest::assertTS3Handler, testContext))

--- a/src/test/java/io/neonbee/internal/handler/RawDataEndpointHandlerTest.java
+++ b/src/test/java/io/neonbee/internal/handler/RawDataEndpointHandlerTest.java
@@ -37,7 +37,7 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class RawDataEndpointHandlerTest extends DataVerticleTestBase {
+class RawDataEndpointHandlerTest extends DataVerticleTestBase {
     private static RoutingContext mockRoutingContext(String routingPath) {
         RoutingContext routingContextMock = mock(RoutingContext.class);
         Route routeMock = mock(Route.class);
@@ -52,7 +52,7 @@ public class RawDataEndpointHandlerTest extends DataVerticleTestBase {
 
     @Test
     @DisplayName("check qualified name")
-    public void checkQualifiedName() {
+    void checkQualifiedName() {
         assertThat(determineQualifiedName(mockRoutingContext("Verticle"))).isEqualTo("Verticle");
         assertThat(determineQualifiedName(mockRoutingContext("_verticle"))).isEqualTo("_verticle");
         assertThat(determineQualifiedName(mockRoutingContext("namespace/Verticle"))).isEqualTo("namespace/Verticle");

--- a/src/test/java/io/neonbee/internal/json/ImmutableJsonArrayTest.java
+++ b/src/test/java/io/neonbee/internal/json/ImmutableJsonArrayTest.java
@@ -8,21 +8,21 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
-public class ImmutableJsonArrayTest {
+class ImmutableJsonArrayTest {
     @Test
-    public void testImmutableClass() {
+    void testImmutableClass() {
         assertThat(new ImmutableJsonArray().getList().getClass()).isEqualTo(unmodifiableList(emptyList()).getClass());
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testImmutable() {
+    void testImmutable() {
         ImmutableJsonArray jsonArray = new ImmutableJsonArray();
 
         assertThrows(UnsupportedOperationException.class, () -> jsonArray.add(true));
@@ -44,7 +44,7 @@ public class ImmutableJsonArrayTest {
     }
 
     @Test
-    public void testImmutableConstruction() {
+    void testImmutableConstruction() {
         assertThrows(UnsupportedOperationException.class, () -> new ImmutableJsonArray().add(true));
         assertThrows(UnsupportedOperationException.class, () -> new ImmutableJsonArray("[]").add(true));
         assertThrows(UnsupportedOperationException.class, () -> new ImmutableJsonArray(List.of(1, 2, 3)).add(true));
@@ -53,7 +53,7 @@ public class ImmutableJsonArrayTest {
     }
 
     @Test
-    public void testGetPrimitives() {
+    void testGetPrimitives() {
         ImmutableJsonArray jsonArray = new ImmutableJsonArray(new JsonArray().add(1).add(true).add("String").addNull());
         assertThat(jsonArray.getInteger(0)).isEqualTo(1);
         assertThat(jsonArray.getBoolean(1)).isEqualTo(true);
@@ -67,7 +67,7 @@ public class ImmutableJsonArrayTest {
     }
 
     @Test
-    public void testGetComplexValues() {
+    void testGetComplexValues() {
         ImmutableJsonArray jsonArray = new ImmutableJsonArray(new JsonArray()
                 .add(new JsonObject().put("key1", 1).put("key2", true).put("key3", "String").putNull("key4"))
                 .add(new JsonArray().add(1).add(2).add(3)));
@@ -85,7 +85,7 @@ public class ImmutableJsonArrayTest {
     }
 
     @Test
-    public void testCopyIsMutable() {
+    void testCopyIsMutable() {
         assertDoesNotThrow(() -> new ImmutableJsonArray().copy().add(true));
     }
 }

--- a/src/test/java/io/neonbee/internal/json/ImmutableJsonObjectTest.java
+++ b/src/test/java/io/neonbee/internal/json/ImmutableJsonObjectTest.java
@@ -8,20 +8,20 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
-public class ImmutableJsonObjectTest {
+class ImmutableJsonObjectTest {
     @Test
-    public void testImmutableClass() {
+    void testImmutableClass() {
         assertThat(new ImmutableJsonObject().getMap().getClass()).isEqualTo(unmodifiableMap(emptyMap()).getClass());
     }
 
     @Test
-    public void testImmutable() {
+    void testImmutable() {
         ImmutableJsonObject jsonObject = new ImmutableJsonObject();
 
         assertThrows(UnsupportedOperationException.class, () -> jsonObject.put("keyX", true));
@@ -43,7 +43,7 @@ public class ImmutableJsonObjectTest {
     }
 
     @Test
-    public void testImmutableConstruction() {
+    void testImmutableConstruction() {
         assertThrows(UnsupportedOperationException.class, () -> new ImmutableJsonObject().put("keyX", true));
         assertThrows(UnsupportedOperationException.class, () -> new ImmutableJsonObject("{}").put("keyX", true));
         assertThrows(UnsupportedOperationException.class,
@@ -55,7 +55,7 @@ public class ImmutableJsonObjectTest {
     }
 
     @Test
-    public void testGetPrimitives() {
+    void testGetPrimitives() {
         ImmutableJsonObject jsonObject = new ImmutableJsonObject(
                 new JsonObject().put("key1", 1).put("key2", true).put("key3", "String").putNull("key4"));
         assertThat(jsonObject.getInteger("key1")).isEqualTo(1);
@@ -70,7 +70,7 @@ public class ImmutableJsonObjectTest {
     }
 
     @Test
-    public void testGetComplexValues() {
+    void testGetComplexValues() {
         ImmutableJsonObject jsonObject = new ImmutableJsonObject(new JsonObject()
                 .put("object", new JsonObject().put("key1", 1).put("key2", true).put("key3", "String").putNull("key4"))
                 .put("array", new JsonArray().add(1).add(2).add(3)));
@@ -89,7 +89,7 @@ public class ImmutableJsonObjectTest {
     }
 
     @Test
-    public void testCopyIsMutable() {
+    void testCopyIsMutable() {
         assertDoesNotThrow(() -> new ImmutableJsonObject().copy().put("keyX", true));
     }
 }

--- a/src/test/java/io/neonbee/internal/logging/LoggerManagerVerticleClusterTest.java
+++ b/src/test/java/io/neonbee/internal/logging/LoggerManagerVerticleClusterTest.java
@@ -35,13 +35,13 @@ import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(NeonBeeExtension.class)
-public class LoggerManagerVerticleClusterTest {
+class LoggerManagerVerticleClusterTest {
 
     private final DataContext dataContext = new DataContextImpl();
 
     @Test
     @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
-    public void testSetLoggerLevelInCluster(@NeonBeeInstanceConfiguration(clustered = true) NeonBee node1,
+    void testSetLoggerLevelInCluster(@NeonBeeInstanceConfiguration(clustered = true) NeonBee node1,
             @NeonBeeInstanceConfiguration(clustered = true) NeonBee node2, VertxTestContext testContext) {
         expectLogLevels(node1, "DEBUG", node2, "DEBUG", null, testContext);
     }
@@ -51,7 +51,7 @@ public class LoggerManagerVerticleClusterTest {
     // cannot be tested currently, as setting the log level for one logger always applies to the JVM (as loggers are
     // static entities, cluster test starts no separate JVM though, so log levels are shared)
     @Disabled
-    public void testSetLoggerLevelOnOneClusterNodeOnly(@NeonBeeInstanceConfiguration(clustered = true) NeonBee node1,
+    void testSetLoggerLevelOnOneClusterNodeOnly(@NeonBeeInstanceConfiguration(clustered = true) NeonBee node1,
             @NeonBeeInstanceConfiguration(clustered = true) NeonBee node2, VertxTestContext testContext) {
         expectLogLevels(node1, "DEBUG", node2, "ERROR", query -> {
             query.setParameter(QUERY_PARAMETER_LOCAL, Boolean.toString(true));

--- a/src/test/java/io/neonbee/internal/processor/CountEntityCollectionProcessorTest.java
+++ b/src/test/java/io/neonbee/internal/processor/CountEntityCollectionProcessorTest.java
@@ -13,7 +13,7 @@ import org.apache.olingo.server.api.uri.UriResource;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-public class CountEntityCollectionProcessorTest {
+class CountEntityCollectionProcessorTest {
 
     @Test
     @DisplayName("Throw an exception when URIResource has more than two parts")
@@ -21,9 +21,9 @@ public class CountEntityCollectionProcessorTest {
         UriInfo mockedUriInfo = mock(UriInfo.class);
         when(mockedUriInfo.getUriResourceParts()).thenReturn(Arrays.asList(new UriResource[] { null, null, null }));
 
+        CountEntityCollectionProcessor processor = new CountEntityCollectionProcessor(null, null, null);
         UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
-                () -> new CountEntityCollectionProcessor(null, null, null).readEntityCollection(null, null,
-                        mockedUriInfo, null));
+                () -> processor.readEntityCollection(null, null, mockedUriInfo, null));
         assertThat(exception).isEqualTo(TOO_MANY_PARTS_EXCEPTION);
     }
 }

--- a/src/test/java/io/neonbee/internal/processor/ETagTest.java
+++ b/src/test/java/io/neonbee/internal/processor/ETagTest.java
@@ -19,7 +19,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class ETagTest extends ODataEndpointTestBase {
+class ETagTest extends ODataEndpointTestBase {
 
     @Override
     protected List<Path> provideEntityModels() {

--- a/src/test/java/io/neonbee/internal/processor/EntityProcessorTest.java
+++ b/src/test/java/io/neonbee/internal/processor/EntityProcessorTest.java
@@ -13,7 +13,7 @@ import org.apache.olingo.server.api.uri.UriResource;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-public class EntityProcessorTest {
+class EntityProcessorTest {
 
     @Test
     @DisplayName("Throw an exception when URIResource has more than two parts")
@@ -21,8 +21,9 @@ public class EntityProcessorTest {
         UriInfo mockedUriInfo = mock(UriInfo.class);
         when(mockedUriInfo.getUriResourceParts()).thenReturn(Arrays.asList(new UriResource[] { null, null, null }));
 
+        EntityProcessor processor = new EntityProcessor(null, null, null);
         UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
-                () -> new EntityProcessor(null, null, null).readEntity(null, null, mockedUriInfo, null));
+                () -> processor.readEntity(null, null, mockedUriInfo, null));
         assertThat(exception).isEqualTo(TOO_MANY_PARTS_EXCEPTION);
     }
 }

--- a/src/test/java/io/neonbee/internal/processor/odata/edm/EdmHelperTest.java
+++ b/src/test/java/io/neonbee/internal/processor/odata/edm/EdmHelperTest.java
@@ -19,11 +19,11 @@ import org.apache.olingo.server.api.ODataApplicationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-public class EdmHelperTest {
+class EdmHelperTest {
 
     @Test
     @DisplayName("Test getEdmPrimitiveTypeKindByPropertyType method")
-    public void getEdmPrimitiveTypeKindByPropertyTypeTest() throws ODataApplicationException {
+    void getEdmPrimitiveTypeKindByPropertyTypeTest() throws ODataApplicationException {
         assertThat(EdmHelper.getEdmPrimitiveTypeKindByPropertyType("String")).isEqualTo(EdmPrimitiveTypeKind.String);
         assertThat(EdmHelper.getEdmPrimitiveTypeKindByPropertyType("Boolean")).isEqualTo(EdmPrimitiveTypeKind.Boolean);
         assertThat(EdmHelper.getEdmPrimitiveTypeKindByPropertyType("Int32")).isEqualTo(EdmPrimitiveTypeKind.Int32);
@@ -32,7 +32,7 @@ public class EdmHelperTest {
 
     @Test
     @DisplayName("Test extractValueFromLiteral method")
-    public void extractValueFromLiteralTest() {
+    void extractValueFromLiteralTest() {
         // String IDs
         assertThat(EdmHelper.extractValueFromLiteral("'ID5'")).isEqualTo("ID5");
         assertThat(EdmHelper.extractValueFromLiteral("'10815'")).isEqualTo("10815");
@@ -46,7 +46,7 @@ public class EdmHelperTest {
 
     @Test
     @DisplayName("Test isLocalDate")
-    public void isLocalDateTest() {
+    void isLocalDateTest() {
         assertThat(EdmHelper.isLocalDate("2010-01-01")).isTrue();
         assertThat(EdmHelper.isLocalDate("2010-12-31")).isTrue();
         assertThat(EdmHelper.isLocalDate("2010-2-31")).isFalse();
@@ -54,7 +54,7 @@ public class EdmHelperTest {
 
     @Test
     @DisplayName("Test isLocalDateTime")
-    public void isLocalDateTimeTest() {
+    void isLocalDateTimeTest() {
         assertThat(EdmHelper.isLocalDateTime("2010-01-01T05:32:09")).isTrue();
         assertThat(EdmHelper.isLocalDateTime("2010-01-01T05:32:09Z")).isFalse();
         assertThat(EdmHelper.isLocalDateTime("2010-2-31")).isFalse();
@@ -62,7 +62,7 @@ public class EdmHelperTest {
 
     @Test
     @DisplayName("Test convert string to edm property")
-    public void convertStringValueToEdmStringProperty() throws EdmPrimitiveTypeException {
+    void convertStringValueToEdmStringProperty() throws EdmPrimitiveTypeException {
         EdmProperty edmProperty = buildProperty("account", EdmPrimitiveTypeKind.String);
         Property property = EdmHelper.convertStringValueToEdmProperty("SAP-Account", edmProperty);
         assertThat(property.getValue()).isEqualTo("SAP-Account");
@@ -70,7 +70,7 @@ public class EdmHelperTest {
 
     @Test
     @DisplayName("Test convert string to edm int property")
-    public void convertStringValueToEdmInt32Property() throws EdmPrimitiveTypeException {
+    void convertStringValueToEdmInt32Property() throws EdmPrimitiveTypeException {
         EdmProperty edmProperty = buildProperty("age", EdmPrimitiveTypeKind.Int32);
         Property property = EdmHelper.convertStringValueToEdmProperty("12", edmProperty);
         assertThat(property.getValue()).isEqualTo(12);
@@ -78,7 +78,7 @@ public class EdmHelperTest {
 
     @Test
     @DisplayName("Test convert string to edm boolean property")
-    public void convertStringValueToEdmBooleanProperty() throws EdmPrimitiveTypeException {
+    void convertStringValueToEdmBooleanProperty() throws EdmPrimitiveTypeException {
         EdmProperty edmProperty = buildProperty("male", EdmPrimitiveTypeKind.Boolean);
         Property property = EdmHelper.convertStringValueToEdmProperty("true", edmProperty);
         assertThat(property.getValue()).isEqualTo(Boolean.TRUE);
@@ -86,7 +86,7 @@ public class EdmHelperTest {
 
     @Test
     @DisplayName("Test convert string to edm double property")
-    public void convertStringValueToEdmDoubleProperty() throws EdmPrimitiveTypeException {
+    void convertStringValueToEdmDoubleProperty() throws EdmPrimitiveTypeException {
         EdmProperty edmProperty = buildProperty("salary", EdmPrimitiveTypeKind.Double);
         Property property = EdmHelper.convertStringValueToEdmProperty("12.58", edmProperty);
         assertThat(property.getValue()).isEqualTo(12.58);
@@ -94,7 +94,7 @@ public class EdmHelperTest {
 
     @Test
     @DisplayName("Test convert string to edm decimal property")
-    public void convertStringValueToEdmDecimalProperty() throws EdmPrimitiveTypeException {
+    void convertStringValueToEdmDecimalProperty() throws EdmPrimitiveTypeException {
         CsdlProperty csdlProperty = new CsdlProperty();
         csdlProperty.setName("salary");
         csdlProperty.setType(EdmPrimitiveTypeKind.Decimal.getFullQualifiedName());
@@ -107,7 +107,7 @@ public class EdmHelperTest {
 
     @Test
     @DisplayName("Test convert string to edm date property")
-    public void convertStringValueToEdmDateProperty() throws EdmPrimitiveTypeException {
+    void convertStringValueToEdmDateProperty() throws EdmPrimitiveTypeException {
         EdmProperty edmProperty = buildProperty("birthdate", EdmPrimitiveTypeKind.Date);
         Calendar cal = Calendar.getInstance();
         cal.set(Calendar.YEAR, 1970);
@@ -122,7 +122,7 @@ public class EdmHelperTest {
 
     @Test
     @DisplayName("Test convert string to edm time property")
-    public void convertStringValueToEdmTimeOfDayProperty() throws EdmPrimitiveTypeException {
+    void convertStringValueToEdmTimeOfDayProperty() throws EdmPrimitiveTypeException {
         EdmProperty edmProperty = buildProperty("birthtime", EdmPrimitiveTypeKind.TimeOfDay);
         Calendar cal = Calendar.getInstance();
         cal.set(Calendar.YEAR, 1970);
@@ -141,7 +141,7 @@ public class EdmHelperTest {
 
     @Test
     @DisplayName("Test convert string to edm date time property")
-    public void convertStringValueToEdmDateTimeOffsetProperty() throws EdmPrimitiveTypeException {
+    void convertStringValueToEdmDateTimeOffsetProperty() throws EdmPrimitiveTypeException {
         EdmProperty edmProperty = buildProperty("birthtime", EdmPrimitiveTypeKind.DateTimeOffset);
         Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("Europe/Berlin"));
         cal.set(Calendar.YEAR, 1970);

--- a/src/test/java/io/neonbee/internal/processor/odata/edm/EdmPrimitiveNullTest.java
+++ b/src/test/java/io/neonbee/internal/processor/odata/edm/EdmPrimitiveNullTest.java
@@ -10,18 +10,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-public class EdmPrimitiveNullTest {
+class EdmPrimitiveNullTest {
     EdmPrimitiveNull edmPrimitiveNull;
 
     @BeforeEach
-    public void beforeEach() {
+    void beforeEach() {
         edmPrimitiveNull = new EdmPrimitiveNull();
     }
 
     @Test
     @DisplayName("Test equals method")
     @SuppressWarnings({ "EqualsIncompatibleType", "TruthSelfEquals" })
-    public void equalsTest() throws ClassNotFoundException {
+    void equalsTest() throws ClassNotFoundException {
         assertThat(edmPrimitiveNull).isEqualTo(edmPrimitiveNull);
         assertThat(edmPrimitiveNull).isEqualTo(new EdmPrimitiveNull());
         assertThat(edmPrimitiveNull).isEqualTo(EdmPrimitiveNull.getInstance());
@@ -30,63 +30,63 @@ public class EdmPrimitiveNullTest {
 
     @Test
     @DisplayName("Test fromUriLiteral method")
-    public void fromUriLiteralTest() throws EdmPrimitiveTypeException {
+    void fromUriLiteralTest() throws EdmPrimitiveTypeException {
         assertThat(edmPrimitiveNull.fromUriLiteral("null")).isEqualTo("null");
         assertThat(edmPrimitiveNull.fromUriLiteral(null)).isNull();
     }
 
     @Test
     @DisplayName("Test toUriLiteral method")
-    public void toUriLiteralTest() {
+    void toUriLiteralTest() {
         assertThat(edmPrimitiveNull.toUriLiteral("null")).isEqualTo("null");
         assertThat(edmPrimitiveNull.toUriLiteral(null)).isNull();
     }
 
     @Test
     @DisplayName("Test getDefaultType method")
-    public void getDefaultTypeTest() {
+    void getDefaultTypeTest() {
         assertThat(edmPrimitiveNull.getDefaultType()).isNull();
     }
 
     @Test
     @DisplayName("Test getName method")
-    public void getNameTest() {
+    void getNameTest() {
         assertThat(edmPrimitiveNull.getName()).isEqualTo("Null");
     }
 
     @Test
     @DisplayName("Test getNamespace method")
-    public void getNamespaceTest() {
+    void getNamespaceTest() {
         assertThat(edmPrimitiveNull.getNamespace()).isEqualTo("Edm");
     }
 
     @Test
     @DisplayName("Test getFullQualifiedName method")
-    public void getFullQualifiedNameTest() {
+    void getFullQualifiedNameTest() {
         assertThat(edmPrimitiveNull.getFullQualifiedName()).isEqualTo(new FullQualifiedName("Edm", "Null"));
     }
 
     @Test
     @DisplayName("Test getKind method")
-    public void getKindTest() {
+    void getKindTest() {
         assertThat(edmPrimitiveNull.getKind()).isEqualTo(EdmTypeKind.PRIMITIVE);
     }
 
     @Test
     @DisplayName("Test isCompatible method")
-    public void isCompatibleTest() {
+    void isCompatibleTest() {
         assertThat(edmPrimitiveNull.isCompatible(new EdmPrimitiveNull())).isTrue();
     }
 
     @Test
     @DisplayName("Test toString method")
-    public void toStringTest() {
+    void toStringTest() {
         assertThat(edmPrimitiveNull.toString()).isEqualTo("Edm.Null");
     }
 
     @Test
     @DisplayName("Test validate method")
-    public void validateTest() {
+    void validateTest() {
         assertThat(edmPrimitiveNull.validate(null, null, null, null, null, null)).isTrue();
         assertThat(edmPrimitiveNull.validate(null, true, null, null, null, null)).isTrue();
         assertThat(edmPrimitiveNull.validate("null", true, null, null, null, null)).isTrue();
@@ -96,7 +96,7 @@ public class EdmPrimitiveNullTest {
 
     @Test
     @DisplayName("Test valueOfString method")
-    public void valueOfStringTest() throws EdmPrimitiveTypeException {
+    void valueOfStringTest() throws EdmPrimitiveTypeException {
         assertThat(edmPrimitiveNull.valueOfString("null", null, null, null, null, null, String.class)).isNull();
         assertThrows(EdmPrimitiveTypeException.class,
                 () -> edmPrimitiveNull.valueOfString("Lord C.", null, null, null, null, null, String.class));
@@ -108,7 +108,7 @@ public class EdmPrimitiveNullTest {
 
     @Test
     @DisplayName("Test valueToString method")
-    public void valueToStringTest() throws EdmPrimitiveTypeException {
+    void valueToStringTest() throws EdmPrimitiveTypeException {
         assertThat(edmPrimitiveNull.valueToString("Lord C.", null, null, null, null, null)).isEqualTo("null");
         assertThat(edmPrimitiveNull.valueToString(null, true, null, null, null, null)).isNull();
         assertThrows(EdmPrimitiveTypeException.class,

--- a/src/test/java/io/neonbee/internal/processor/odata/expression/EntityChainedComparatorTest.java
+++ b/src/test/java/io/neonbee/internal/processor/odata/expression/EntityChainedComparatorTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import io.vertx.ext.web.RoutingContext;
 
-public class EntityChainedComparatorTest {
+class EntityChainedComparatorTest {
     @Test
     void compareTest() throws ODataApplicationException {
 

--- a/src/test/java/io/neonbee/internal/processor/odata/expression/EntityComparatorTest.java
+++ b/src/test/java/io/neonbee/internal/processor/odata/expression/EntityComparatorTest.java
@@ -11,7 +11,7 @@ import org.mockito.Mockito;
 
 import io.vertx.ext.web.RoutingContext;
 
-public class EntityComparatorTest {
+class EntityComparatorTest {
     @Test
     void compareTest() throws ODataApplicationException {
         // Sorty by ID asc order

--- a/src/test/java/io/neonbee/internal/processor/odata/expression/EntityComparisonTest.java
+++ b/src/test/java/io/neonbee/internal/processor/odata/expression/EntityComparisonTest.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
-public class EntityComparisonTest {
+class EntityComparisonTest {
     private final EntityComparison testEntityComparisonImplementation = new EntityComparison() {};
 
     private static final byte[] BYTES_TEST = "Test".getBytes(UTF_8);

--- a/src/test/java/io/neonbee/internal/processor/odata/expression/OrderExpressionExecutorTest.java
+++ b/src/test/java/io/neonbee/internal/processor/odata/expression/OrderExpressionExecutorTest.java
@@ -29,11 +29,9 @@ import org.apache.olingo.commons.api.edm.EdmPrimitiveTypeKind;
 import org.apache.olingo.commons.api.edm.constants.EdmTypeKind;
 import org.apache.olingo.commons.core.edm.EdmPropertyImpl;
 import org.apache.olingo.commons.core.edm.EdmTypeImpl;
-import org.apache.olingo.server.api.ODataApplicationException;
 import org.apache.olingo.server.api.uri.UriInfoResource;
 import org.apache.olingo.server.api.uri.UriResourcePrimitiveProperty;
 import org.apache.olingo.server.api.uri.queryoption.expression.Expression;
-import org.apache.olingo.server.api.uri.queryoption.expression.ExpressionVisitException;
 import org.apache.olingo.server.api.uri.queryoption.expression.ExpressionVisitor;
 import org.apache.olingo.server.core.uri.queryoption.OrderByItemImpl;
 import org.apache.olingo.server.core.uri.queryoption.OrderByOptionImpl;
@@ -43,7 +41,7 @@ import org.junit.jupiter.api.Test;
 
 import io.vertx.ext.web.RoutingContext;
 
-public class OrderExpressionExecutorTest {
+class OrderExpressionExecutorTest {
     private final RoutingContext routingContext = mock(RoutingContext.class);
 
     @Test
@@ -573,7 +571,7 @@ public class OrderExpressionExecutorTest {
 
     @SuppressWarnings("rawtypes")
     @Test
-    public void classDefinitionTest() throws Exception {
+    void classDefinitionTest() throws Exception {
         Constructor[] constructors = OrderExpressionExecutor.class.getDeclaredConstructors();
         // The class must only have one (private) constructor
         assertThat(constructors.length).isEqualTo(1);
@@ -589,7 +587,7 @@ public class OrderExpressionExecutorTest {
 
     public static class TestExpression implements Expression {
         @Override
-        public <T> T accept(ExpressionVisitor<T> visitor) throws ExpressionVisitException, ODataApplicationException {
+        public <T> T accept(ExpressionVisitor<T> visitor) {
             return null;
         }
     }

--- a/src/test/java/io/neonbee/internal/scanner/ClassPathScannerTest.java
+++ b/src/test/java/io/neonbee/internal/scanner/ClassPathScannerTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.Streams;
 import io.neonbee.internal.BasicJar;
 
-public class ClassPathScannerTest {
+class ClassPathScannerTest {
 
     @Test
     @DisplayName("Should find passed attribute in all Manifest files")

--- a/src/test/java/io/neonbee/internal/scanner/HookScannerTest.java
+++ b/src/test/java/io/neonbee/internal/scanner/HookScannerTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import io.neonbee.internal.BasicJar;
 
-public class HookScannerTest {
+class HookScannerTest {
 
     @Test
     @DisplayName("Should find classes which have methods that are annnotaed with @Hook or @Hooks")

--- a/src/test/java/io/neonbee/internal/tracking/TrackingInterceptorTest.java
+++ b/src/test/java/io/neonbee/internal/tracking/TrackingInterceptorTest.java
@@ -18,7 +18,7 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.eventbus.DeliveryContext;
 import io.vertx.core.json.JsonObject;
 
-public class TrackingInterceptorTest {
+class TrackingInterceptorTest {
     private TestMessage<Object> message;
 
     @BeforeEach

--- a/src/test/java/io/neonbee/internal/verticle/LoggerConfigurationTest.java
+++ b/src/test/java/io/neonbee/internal/verticle/LoggerConfigurationTest.java
@@ -19,7 +19,7 @@ import ch.qos.logback.classic.Logger;
 import io.neonbee.logging.LoggingFacade;
 import io.vertx.core.json.JsonObject;
 
-public class LoggerConfigurationTest {
+class LoggerConfigurationTest {
     public static final LoggerConfiguration ROOT = new LoggerConfiguration(Logger.ROOT_LOGGER_NAME, INFO);
 
     private static int logInstanceCount;
@@ -29,7 +29,7 @@ public class LoggerConfigurationTest {
     private final LoggerConfiguration logger2 = new LoggerConfiguration(null, DEBUG);
 
     @BeforeEach
-    public void setUpLoggers() {
+    void setUpLoggers() {
         // there is no way to "delete" log instances, thus create new log instances for each run
 
         String name1 = LoggerConfigurationTest.class.getSimpleName() + ++logInstanceCount;
@@ -42,7 +42,7 @@ public class LoggerConfigurationTest {
     }
 
     @Test
-    public void testBasics() {
+    void testBasics() {
         ROOT.hashCode();
         assertThat(ROOT.toString()).isEqualTo("LoggerConfiguration [name=ROOT, configuredLevel=INFO]");
         assertThat(ROOT.getName()).isEqualTo(Logger.ROOT_LOGGER_NAME);
@@ -50,37 +50,37 @@ public class LoggerConfigurationTest {
     }
 
     @Test
-    public void testToJson() {
+    void testToJson() {
         JsonObject json = ROOT.toJson();
         assertThat(json).isEqualTo(new JsonObject().put(NAME, "ROOT").put(CONFIGURED_LEVEL, "INFO"));
     }
 
     @Test
-    public void testFromJson() {
+    void testFromJson() {
         JsonObject json = new JsonObject().put(NAME, "logger1").put(CONFIGURED_LEVEL, ERROR.levelStr);
         LoggerConfiguration configuration = LoggerConfiguration.fromJson(json);
         assertThat(configuration).isEqualTo(new LoggerConfiguration("logger1", ERROR));
     }
 
     @Test
-    public void testCompare() {
+    void testCompare() {
         assertThat(ROOT.compareTo(logger1)).isEqualTo(-1);
         assertThat(logger2.compareTo(logger1)).isEqualTo(1);
     }
 
     @Test
-    public void testCopy() {
+    void testCopy() {
         assertThat(ROOT.copy()).isEqualTo(ROOT);
         assertThat(ROOT.copy()).isNotSameInstanceAs(ROOT);
     }
 
     @Test
-    public void testToAndFromJson() {
+    void testToAndFromJson() {
         assertThat(LoggerConfiguration.fromJson(logger1.toJson())).isEqualTo(logger1);
     }
 
     @Test
-    public void testApplyingEffectiveLogLevels() {
+    void testApplyingEffectiveLogLevels() {
         logger1.setEffectiveLevel(INFO);
         assertThat(logger1.getEffectiveLevel()).isEqualTo(INFO);
 

--- a/src/test/java/io/neonbee/internal/verticle/LoggerManagerVerticleTest.java
+++ b/src/test/java/io/neonbee/internal/verticle/LoggerManagerVerticleTest.java
@@ -21,7 +21,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class LoggerManagerVerticleTest extends DataVerticleTestBase {
+class LoggerManagerVerticleTest extends DataVerticleTestBase {
 
     @BeforeEach
     void setUp(VertxTestContext testContext) {
@@ -30,7 +30,7 @@ public class LoggerManagerVerticleTest extends DataVerticleTestBase {
 
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
-    public void testRetrieveData(VertxTestContext testContext) {
+    void testRetrieveData(VertxTestContext testContext) {
         DataRequest req = new DataRequest(LoggerManagerVerticle.QUALIFIED_NAME, new DataQuery());
         Future<JsonArray> response = requestData(req);
 
@@ -40,7 +40,7 @@ public class LoggerManagerVerticleTest extends DataVerticleTestBase {
 
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
-    public void testRetrieveDataWithQuery(VertxTestContext testContext) {
+    void testRetrieveDataWithQuery(VertxTestContext testContext) {
         DataRequest req = new DataRequest(LoggerManagerVerticle.QUALIFIED_NAME,
                 new DataQuery().setParameter("loggers", "io.neonbee.internal"));
         Future<JsonArray> response = requestData(req);
@@ -55,7 +55,7 @@ public class LoggerManagerVerticleTest extends DataVerticleTestBase {
 
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
-    public void testRetrieveDataWithMultipleQueryValues(VertxTestContext testContext) {
+    void testRetrieveDataWithMultipleQueryValues(VertxTestContext testContext) {
         DataRequest req = new DataRequest(LoggerManagerVerticle.QUALIFIED_NAME,
                 new DataQuery().setParameter("loggers", "io.neonbee.internal,io.vertx.core.file"));
         Future<JsonArray> response = requestData(req);
@@ -66,7 +66,7 @@ public class LoggerManagerVerticleTest extends DataVerticleTestBase {
 
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
-    public void testUpdateData(VertxTestContext testContext) {
+    void testUpdateData(VertxTestContext testContext) {
         List<LoggerConfiguration> configList = List.of(new LoggerConfiguration("io.neonbee.internal", ERROR),
                 new LoggerConfiguration("io.vertx.core.file", ERROR));
         DataRequest updateReq = new DataRequest(LoggerManagerVerticle.QUALIFIED_NAME,

--- a/src/test/java/io/neonbee/internal/verticle/ServerVerticleTest.java
+++ b/src/test/java/io/neonbee/internal/verticle/ServerVerticleTest.java
@@ -27,7 +27,7 @@ import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class ServerVerticleTest extends NeonBeeTestBase {
+class ServerVerticleTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     void testDetermineSessionHandling() throws InterruptedException {

--- a/src/test/java/io/neonbee/internal/verticle/WatchVerticleTest.java
+++ b/src/test/java/io/neonbee/internal/verticle/WatchVerticleTest.java
@@ -40,7 +40,7 @@ import io.vertx.junit5.VertxTestContext;
 import io.vertx.junit5.VertxTestContext.ExecutionBlock;
 
 @ExtendWith(VertxExtension.class)
-public class WatchVerticleTest {
+class WatchVerticleTest {
     private Path watchDir;
 
     @BeforeEach

--- a/src/test/java/io/neonbee/job/JobScheduleTest.java
+++ b/src/test/java/io/neonbee/job/JobScheduleTest.java
@@ -9,10 +9,10 @@ import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-public class JobScheduleTest {
+class JobScheduleTest {
     @Test
     @DisplayName("Initialize JobSchedule")
-    public void testJobSchedule() {
+    void testJobSchedule() {
         Instant now = Instant.now();
 
         JobSchedule schedule = new JobSchedule();
@@ -39,9 +39,7 @@ public class JobScheduleTest {
         assertThat(schedule.isPeriodic()).isTrue();
         assertThat(now.until(schedule.adjustInto(now), ChronoUnit.MINUTES)).isEqualTo(1337);
 
-        schedule = new JobSchedule(now, temporal -> {
-            return temporal.plus(20, ChronoUnit.SECONDS);
-        }, now);
+        schedule = new JobSchedule(now, temporal -> temporal.plus(20, ChronoUnit.SECONDS), now);
         assertThat(now.until(schedule.adjustInto(now), ChronoUnit.SECONDS)).isEqualTo(20);
     }
 }

--- a/src/test/java/io/neonbee/job/JobVerticleTest.java
+++ b/src/test/java/io/neonbee/job/JobVerticleTest.java
@@ -24,7 +24,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 
-public class JobVerticleTest {
+class JobVerticleTest {
     private static class TestJobVerticle extends JobVerticle {
         public final Vertx vertxMock;
 
@@ -91,7 +91,7 @@ public class JobVerticleTest {
 
     @Test
     @DisplayName("Verify that jobs are scheduled at the expected times")
-    public void verifyJobSchedule() {
+    void verifyJobSchedule() {
         TestJobVerticle testJobVerticle = new TestJobVerticle(new JobSchedule());
         // when a job is scheduled (once) the next time it is executed should be in approximately 100 ms (or less)
         verify(testJobVerticle.vertxMock).setTimer(longThat(isApproximately(100)), any());
@@ -153,7 +153,7 @@ public class JobVerticleTest {
 
     @Test
     @DisplayName("Verify that jobs executed when scheduled")
-    public void verifyJobExecuted() {
+    void verifyJobExecuted() {
         // if a one time job was scheduled, handler should be called once and undeploay should be called
         TestJobVerticle testJobVerticle = new TestJobVerticle(new JobSchedule(), true, false, 100);
         assertThat(testJobVerticle.jobExecuted).isEqualTo(1);
@@ -183,7 +183,7 @@ public class JobVerticleTest {
 
     @Test
     @DisplayName("Verify that jobs are disabled when flag is set")
-    public void verifyDisableJobScheduling() {
+    void verifyDisableJobScheduling() {
         TestJobVerticle testJobVerticle = new TestJobVerticle(new JobSchedule(), true, true);
         assertThat(testJobVerticle.jobExecuted).isEqualTo(0);
         verify(testJobVerticle.vertxMock).undeploy(any());

--- a/src/test/java/io/neonbee/logging/LoggingFacadeTest.java
+++ b/src/test/java/io/neonbee/logging/LoggingFacadeTest.java
@@ -23,7 +23,7 @@ import io.neonbee.data.internal.DataContextImpl;
 import io.vertx.ext.web.RoutingContext;
 
 @SuppressWarnings({ "PMD.MoreThanOneLogger", "PMD.ProperLogger" })
-public class LoggingFacadeTest {
+class LoggingFacadeTest {
     private static final LoggingFacade MOCKED_LOGGING_FACADE = mock(LoggingFacade.class, CALLS_REAL_METHODS);
 
     @BeforeEach

--- a/src/test/java/io/neonbee/logging/internal/LoggingFacadeImplTest.java
+++ b/src/test/java/io/neonbee/logging/internal/LoggingFacadeImplTest.java
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.Marker;
 
 @SuppressWarnings("PMD.MoreThanOneLogger")
-public class LoggingFacadeImplTest {
+class LoggingFacadeImplTest {
     private static final String DUMMY_LOG_MSG = "HODOR {}";
 
     private static final Object DUMMY_ARGUMENT = new Object();

--- a/src/test/java/io/neonbee/test/base/NeonBeeTestBaseTest.java
+++ b/src/test/java/io/neonbee/test/base/NeonBeeTestBaseTest.java
@@ -14,7 +14,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class NeonBeeTestBaseTest extends NeonBeeTestBase {
+class NeonBeeTestBaseTest extends NeonBeeTestBase {
     private static final JsonObject PRINCIPAL = new JsonObject().put("Hodor", "Hodor");
 
     @Override

--- a/src/test/java/io/neonbee/test/base/ODataRequestTest.java
+++ b/src/test/java/io/neonbee/test/base/ODataRequestTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-public class ODataRequestTest {
+class ODataRequestTest {
     private final Map<String, Object> compositeMap = new HashMap<>();
 
     private final String expectedServiceRootURL = "my-namespace";
@@ -20,7 +20,7 @@ public class ODataRequestTest {
 
     @BeforeEach
     @DisplayName("Setup the base OData request")
-    public void setUp() {
+    void setUp() {
         FullQualifiedName fqn = new FullQualifiedName("my-namespace", "my-entity");
         odataRequest = new ODataRequest(fqn);
         compositeMap.clear();
@@ -28,7 +28,7 @@ public class ODataRequestTest {
 
     @Test
     @DisplayName("with $metadata set")
-    public void testGetUriWithMetadata() {
+    void testGetUriWithMetadata() {
         odataRequest.setMetadata();
         assertThat(odataRequest.getUri()).isEqualTo(expectedServiceRootURL + "/$metadata");
         odataRequest.setMetadata().setKey(1).setProperty("ignore");
@@ -37,7 +37,7 @@ public class ODataRequestTest {
 
     @Test
     @DisplayName("with $count set")
-    public void testGetUriWithCount() {
+    void testGetUriWithCount() {
         odataRequest.setCount();
         assertThat(odataRequest.getUri()).isEqualTo(expectedServiceRootURL + "/my-entity/$count");
         odataRequest.setCount().setKey(1).setProperty("ignore");
@@ -46,34 +46,34 @@ public class ODataRequestTest {
 
     @Test
     @DisplayName("with namespace and entity name")
-    public void testGetUriNamespace() {
+    void testGetUriNamespace() {
         assertThat(odataRequest.getUri()).isEqualTo(expectedServiceRootURL + "/my-entity");
     }
 
     @Test
     @DisplayName("with single string key")
-    public void testGetUriSingleStringKey() {
+    void testGetUriSingleStringKey() {
         odataRequest.setKey("0123");
         assertThat(odataRequest.getUri()).isEqualTo(expectedServiceRootURL + "/my-entity('0123')");
     }
 
     @Test
     @DisplayName("with single long key")
-    public void testGetUriSingleLongKey() {
+    void testGetUriSingleLongKey() {
         odataRequest.setKey(1234);
         assertThat(odataRequest.getUri()).isEqualTo(expectedServiceRootURL + "/my-entity(1234)");
     }
 
     @Test
     @DisplayName("with single date key")
-    public void testGetUriSingleDateKey() {
+    void testGetUriSingleDateKey() {
         odataRequest.setKey(LocalDate.of(2020, 2, 22));
         assertThat(odataRequest.getUri()).isEqualTo(expectedServiceRootURL + "/my-entity(2020-02-22)");
     }
 
     @Test
     @DisplayName("with multiple valid keys")
-    public void testGetUriMultipleValidKeys() {
+    void testGetUriMultipleValidKeys() {
         compositeMap.put("ID", 123L);
         compositeMap.put("Name", "cheese");
         compositeMap.put("Description", "something");
@@ -90,7 +90,7 @@ public class ODataRequestTest {
 
     @Test
     @DisplayName("with multiple invalid keys")
-    public void testGetUriMultipleInvalidKeys() {
+    void testGetUriMultipleInvalidKeys() {
         compositeMap.put("ID", 123L);
         compositeMap.put("", "cheese");
         odataRequest.setKey(compositeMap);
@@ -104,7 +104,7 @@ public class ODataRequestTest {
 
     @Test
     @DisplayName("with wrong type")
-    public void testGetUriWrongType() {
+    void testGetUriWrongType() {
         compositeMap.put("ID", '1');
         try {
             odataRequest.setKey(compositeMap);
@@ -117,7 +117,7 @@ public class ODataRequestTest {
 
     @Test
     @DisplayName("with multiple invocations of setKey")
-    public void testGetUriMultipleInvocationsOfSetKey() {
+    void testGetUriMultipleInvocationsOfSetKey() {
         compositeMap.put("ID", 123L);
         odataRequest.setKey(compositeMap).setKey(123L).setKey("surprise");
         assertThat(odataRequest.getUri()).isEqualTo(expectedServiceRootURL + "/my-entity('surprise')");
@@ -125,14 +125,14 @@ public class ODataRequestTest {
 
     @Test
     @DisplayName("with property set")
-    public void testGetUriWithProperty() {
+    void testGetUriWithProperty() {
         odataRequest.setProperty("my-property");
         assertThat(odataRequest.getUri()).isEqualTo(expectedServiceRootURL + "/my-entity/my-property");
     }
 
     @Test
     @DisplayName("with expand single attribute")
-    public void testExpand() {
+    void testExpand() {
         odataRequest.setKey("0123").setExpandQuery("ExpandItem");
         assertThat(odataRequest.getUri()).isEqualTo(expectedServiceRootURL + "/my-entity('0123')?$expand=ExpandItem");
     }

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataCreateEntityTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataCreateEntityTest.java
@@ -22,7 +22,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class ODataCreateEntityTest extends ODataEndpointTestBase {
+class ODataCreateEntityTest extends ODataEndpointTestBase {
 
     @Override
     protected List<Path> provideEntityModels() {

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataDeleteEntityTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataDeleteEntityTest.java
@@ -17,7 +17,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class ODataDeleteEntityTest extends ODataEndpointTestBase {
+class ODataDeleteEntityTest extends ODataEndpointTestBase {
     private ODataRequest oDataRequest;
 
     @Override

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataExpandEntityCollectionTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataExpandEntityCollectionTest.java
@@ -41,7 +41,7 @@ import io.vertx.junit5.VertxTestContext;
  * http://baseUrl/odata/io.neonbee.test.NavProbs/Categories?$expand=products
  * </pre>
  */
-public class ODataExpandEntityCollectionTest extends ODataEndpointTestBase {
+class ODataExpandEntityCollectionTest extends ODataEndpointTestBase {
     @Override
     protected List<Path> provideEntityModels() {
         return List.of(getDeclaredEntityModel());

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataExpandEntityTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataExpandEntityTest.java
@@ -46,7 +46,7 @@ import io.vertx.junit5.VertxTestContext;
  * </pre>
  *
  */
-public class ODataExpandEntityTest extends ODataEndpointTestBase {
+class ODataExpandEntityTest extends ODataEndpointTestBase {
     @Override
     protected List<Path> provideEntityModels() {
         return List.of(getDeclaredEntityModel());

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataFilterTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataFilterTest.java
@@ -27,7 +27,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class ODataFilterTest extends ODataEndpointTestBase {
+class ODataFilterTest extends ODataEndpointTestBase {
     private ODataRequest oDataRequest;
 
     @Override

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataNavigationPropertiesTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataNavigationPropertiesTest.java
@@ -45,7 +45,7 @@ import io.vertx.junit5.VertxTestContext;
  * </pre>
  *
  */
-public class ODataNavigationPropertiesTest extends ODataEndpointTestBase {
+class ODataNavigationPropertiesTest extends ODataEndpointTestBase {
     @Override
     protected List<Path> provideEntityModels() {
         return List.of(getDeclaredEntityModel());

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataOrderTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataOrderTest.java
@@ -24,7 +24,7 @@ import io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class ODataOrderTest extends ODataEndpointTestBase {
+class ODataOrderTest extends ODataEndpointTestBase {
     private ODataRequest request;
 
     @Override

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataReadEntitiesTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataReadEntitiesTest.java
@@ -37,7 +37,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class ODataReadEntitiesTest extends ODataEndpointTestBase {
+class ODataReadEntitiesTest extends ODataEndpointTestBase {
 
     @Override
     protected List<Path> provideEntityModels() {

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataReadEntityTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataReadEntityTest.java
@@ -37,7 +37,7 @@ import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class ODataReadEntityTest extends ODataEndpointTestBase {
+class ODataReadEntityTest extends ODataEndpointTestBase {
     private ODataRequestMod oDataRequest;
 
     @Override

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataUpdateEntityTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataUpdateEntityTest.java
@@ -43,7 +43,7 @@ import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
-public class ODataUpdateEntityTest extends ODataEndpointTestBase {
+class ODataUpdateEntityTest extends ODataEndpointTestBase {
     private ODataRequest oDataRequest;
 
     @Override

--- a/src/test/java/io/neonbee/test/helper/ReflectionHelperTest.java
+++ b/src/test/java/io/neonbee/test/helper/ReflectionHelperTest.java
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.Test;
 
 import io.vertx.junit5.VertxTestContext.ExecutionBlock;
 
-public class ReflectionHelperTest {
+class ReflectionHelperTest {
     private static final Integer NUMBER = 2;
 
     @Test
     @DisplayName("Check that final fields can be modified")
-    public void testSetValueOfPrivateStaticField() throws Throwable {
+    void testSetValueOfPrivateStaticField() throws Throwable {
         assertThat(NUMBER).isEqualTo(2);
         ExecutionBlock reset = ReflectionHelper.setValueOfPrivateStaticField(getClass(), "NUMBER", 3);
         assertThat(NUMBER).isEqualTo(3);


### PR DESCRIPTION
JUnit5 is more tolerant regarding the visibilities of Test classes and
methods than JUnit4, which required everything to be public. JUnit5
supports default package, public and protected visibility, even if it is
recommended to use the default package visibility, which improves the
readability of code.

These rules enforce the recommended standard.

Co-authored-by: Pascal Krause <pascal.krause@sap.com>