### PR TITLE
fix: switch to async. log appender

### DIFF
--- a/resources/config/logback.xml
+++ b/resources/config/logback.xml
@@ -4,6 +4,9 @@
             <pattern>%d{HH:mm:ss.SSS} [%thread] {%marker} %level %logger - %msg%n</pattern>
         </encoder>
     </appender>
+    <appender name="ASYNC_STDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="STDOUT" />
+    </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_DIR}/neonbee.log</file>
@@ -21,10 +24,13 @@
             <pattern>%d{HH:mm:ss.SSS} [%thread] {%marker} %level %logger - %msg%n</pattern>
         </encoder>
     </appender>
+    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="FILE" />
+    </appender>
 
     <!-- Configure so that it outputs to both console and log file, default log level is WARNING -->
     <root level="INFO">
-        <appender-ref ref="STDOUT" />
-        <appender-ref ref="FILE" />
+        <appender-ref ref="ASYNC_STDOUT" />
+        <appender-ref ref="ASYNC_FILE" />
     </root>
 </configuration>

--- a/src/test/resources/io/neonbee/test/base/NeonBeeTestBase-Logback.xml
+++ b/src/test/resources/io/neonbee/test/base/NeonBeeTestBase-Logback.xml
@@ -4,6 +4,9 @@
             <pattern>%d{HH:mm:ss.SSS} [%thread] {%marker} %level %logger - %msg%n</pattern>
         </encoder>
     </appender>
+    <appender name="ASYNC_STDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="STDOUT" />
+    </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_DIR}/neonbee.log</file>
@@ -21,10 +24,13 @@
             <pattern>%d{HH:mm:ss.SSS} [%thread] {%marker} %level %logger - %msg%n</pattern>
         </encoder>
     </appender>
+    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="FILE" />
+    </appender>
 
     <!-- Configure so that it outputs to both console and log file, default log level is WARNING -->
     <root level="DEBUG">
-        <appender-ref ref="STDOUT" />
-        <appender-ref ref="FILE" />
+        <appender-ref ref="ASYNC_STDOUT" />
+        <appender-ref ref="ASYNC_FILE" />
     </root>
 </configuration>


### PR DESCRIPTION
The default configuration for logback currently is using blocking appenders which, in Vert.x, is generally discouraged. Switching to logbacks AsyncAppender interface, for unblocking the logging threads.