### PR TITLE
Make neonbee launcher options configurable via environment variables

### DIFF
--- a/src/test/java/io/neonbee/LauncherTest.java
+++ b/src/test/java/io/neonbee/LauncherTest.java
@@ -4,11 +4,13 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.neonbee.Launcher.INTERFACE;
 import static io.neonbee.Launcher.parseOptions;
 import static io.neonbee.test.helper.FileSystemHelper.createTempDirectory;
+import static io.neonbee.test.helper.SystemHelper.withEnvironment;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -26,9 +28,12 @@ class LauncherTest {
 
     private String[] args;
 
+    private static String workDir;
+
     @BeforeAll
     static void setUp() throws IOException {
         tempDirPath = createTempDirectory();
+        workDir = tempDirPath.toAbsolutePath().toString();
     }
 
     @AfterAll
@@ -37,77 +42,61 @@ class LauncherTest {
     }
 
     @Test
-    @DisplayName("should throw error, if working directory value is not passed")
+    @DisplayName("should throw an error, if working directory value is not passed")
     void throwErrorIfWorkingDirValueIsEmpty() {
         args = new String[] { "-cwd" };
-        MissingValueException exception =
-                assertThrows(MissingValueException.class, () -> parseOptions(INTERFACE.parse(List.of(args))));
+        MissingValueException exception = assertThrows(MissingValueException.class, this::parseOptionsArgs);
         assertThat(exception.getMessage()).isEqualTo("The option 'working-directory' requires a value");
     }
 
     @Test
-    @DisplayName("should throw error, if instance-name is empty")
+    @DisplayName("should throw an error, if instance-name is empty")
     void throwErrorIfInstanceNameIsEmpty() {
-        args = new String[] { "-cwd", tempDirPath.toAbsolutePath().toString(), "-name", "" };
-        IllegalArgumentException exception =
-                assertThrows(IllegalArgumentException.class, () -> parseOptions(INTERFACE.parse(List.of(args))));
+        args = new String[] { "-cwd", workDir, "-name", "" };
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, this::parseOptionsArgs);
         assertThat(exception.getMessage()).isEqualTo("instanceName must not be empty");
-    }
-
-    @Test
-    @DisplayName("should use passed instance-name")
-    void usePassedInstanceName() {
-        args = new String[] { "-cwd", tempDirPath.toAbsolutePath().toString(), "-name", "Hodor" };
-        NeonBeeOptions neonBeeOptions = parseOptions(INTERFACE.parse(List.of(args)));
-        assertThat(neonBeeOptions.getInstanceName()).isEqualTo("Hodor");
     }
 
     @Test
     @DisplayName("should throw error, if the passed value is other than integer for worker pool size")
     void validateWorkerPoolSizeValue() {
-        args = new String[] { "-cwd", tempDirPath.toAbsolutePath().toString(), "-name", "Hodor", "-wps", "hodor" };
-        InvalidValueException exception =
-                assertThrows(InvalidValueException.class, () -> parseOptions(INTERFACE.parse(List.of(args))));
+        args = new String[] { "-cwd", workDir, "-name", "Hodor", "-wps", "hodor" };
+        InvalidValueException exception = assertThrows(InvalidValueException.class, this::parseOptionsArgs);
         assertThat(exception.getMessage()).isEqualTo("The value 'hodor' is not accepted by 'worker-pool-size'");
     }
 
     @Test
     @DisplayName("should throw error, if the passed value is other than integer for event loop pool size")
     void validateEventLoopPoolSizeValue() {
-        args = new String[] { "-cwd", tempDirPath.toAbsolutePath().toString(), "-name", "Hodor", "-elps", "hodor" };
-        InvalidValueException exception =
-                assertThrows(InvalidValueException.class, () -> parseOptions(INTERFACE.parse(List.of(args))));
+        args = new String[] { "-cwd", workDir, "-name", "Hodor", "-elps", "hodor" };
+        InvalidValueException exception = assertThrows(InvalidValueException.class, this::parseOptionsArgs);
         assertThat(exception.getMessage()).isEqualTo("The value 'hodor' is not accepted by 'event-loop-pool-size'");
     }
 
     @Test
     @DisplayName("should generate expected neonbee options")
-    void testExpectedNeonBeeOptions() {
-        args = new String[] { "-cwd", tempDirPath.toAbsolutePath().toString(), "-name", "Hodor", "-wps", "2", "-elps",
-                "2", "-no-cp", "-no-jobs", "-svp", "9000" };
-        NeonBeeOptions neonBeeOptions = parseOptions(INTERFACE.parse(List.of(args)));
-        assertThat(neonBeeOptions.getInstanceName()).isEqualTo("Hodor");
-        assertThat(neonBeeOptions.getWorkerPoolSize()).isEqualTo(2);
-        assertThat(neonBeeOptions.getEventLoopPoolSize()).isEqualTo(2);
-        assertThat(neonBeeOptions.shouldIgnoreClassPath()).isTrue();
-        assertThat(neonBeeOptions.shouldDisableJobScheduling()).isTrue();
-        assertThat(neonBeeOptions.getServerVerticlePort()).isEqualTo(9000);
+    void testExpectedNeonBeeOptions() throws Exception {
+        args = new String[] { "-cwd", workDir, "-name", "Hodor", "-wps", "2", "-elps", "2", "-no-cp", "-no-jobs",
+                "-svp", "9000" };
+        assertNeonBeeOptions();
+
         args = new String[] {};
-        neonBeeOptions = parseOptions(INTERFACE.parse(List.of(args)));
-        assertThat(neonBeeOptions.getServerVerticlePort()).isNull();
+        Map<String, String> envMap = Map.of("NEONBEE_WORKING_DIR", workDir, "NEONBEE_INSTANCE_NAME", "Hodor",
+                "NEONBEE_WORKER_POOL_SIZE", "2", "NEONBEE_EVENT_LOOP_POOL_SIZE", "2", "NEONBEE_IGNORE_CLASS_PATH",
+                "true", "NEONBEE_DISABLE_JOB_SCHEDULING", "true", "NEONBEE_SERVER_VERTICLE_PORT", "9000");
+        withEnvironment(envMap, this::assertNeonBeeOptions);
     }
 
     @Test
     @DisplayName("should generate expected clustered neonbee options")
-    void testExpectedClusterNeonBeeOptions() {
-        args = new String[] { "-cwd", tempDirPath.toAbsolutePath().toString(), "-cl", "-cc", "hazelcast-local.xml",
-                "-clp", "10000" };
-        NeonBeeOptions neonBeeOptions = parseOptions(INTERFACE.parse(List.of(args)));
-        assertThat(neonBeeOptions.getClusterPort()).isEqualTo(10000);
-        assertThat(neonBeeOptions.isClustered()).isTrue();
-        assertThat(neonBeeOptions.getClusterConfig()).isInstanceOf(ClasspathXmlConfig.class);
-        ClasspathXmlConfig xmlConfig = (ClasspathXmlConfig) neonBeeOptions.getClusterConfig();
-        assertThat(xmlConfig.getNetworkConfig().getPort()).isEqualTo(20000);
+    void testExpectedClusterNeonBeeOptions() throws Exception {
+        args = new String[] { "-cwd", workDir, "-cl", "-cc", "hazelcast-local.xml", "-clp", "10000" };
+        assertClusteredOptions();
+
+        args = new String[] {};
+        Map<String, String> envMap = Map.of("NEONBEE_WORKING_DIR", workDir, "NEONBEE_CLUSTERED", "true",
+                "NEONBEE_CLUSTER_CONFIG", "hazelcast-local.xml", "NEONBEE_CLUSTER_PORT", "10000");
+        withEnvironment(envMap, this::assertClusteredOptions);
     }
 
     @Test
@@ -130,5 +119,29 @@ class LauncherTest {
         public boolean isPreProcessorExecuted() {
             return preProcessorExecuted;
         }
+    }
+
+    private void assertNeonBeeOptions() {
+        NeonBeeOptions neonBeeOptions = parseOptionsArgs();
+        assertThat(neonBeeOptions.getInstanceName()).isEqualTo("Hodor");
+        assertThat(neonBeeOptions.getWorkerPoolSize()).isEqualTo(2);
+        assertThat(neonBeeOptions.getEventLoopPoolSize()).isEqualTo(2);
+        assertThat(neonBeeOptions.shouldIgnoreClassPath()).isTrue();
+        assertThat(neonBeeOptions.shouldDisableJobScheduling()).isTrue();
+        assertThat(neonBeeOptions.getServerVerticlePort()).isEqualTo(9000);
+    }
+
+    private void assertClusteredOptions() {
+        NeonBeeOptions neonBeeOptions = parseOptionsArgs();
+        assertThat(neonBeeOptions.getClusterPort()).isEqualTo(10000);
+        assertThat(neonBeeOptions.isClustered()).isTrue();
+        assertThat(neonBeeOptions.getClusterConfig()).isInstanceOf(ClasspathXmlConfig.class);
+
+        ClasspathXmlConfig xmlConfig = (ClasspathXmlConfig) neonBeeOptions.getClusterConfig();
+        assertThat(xmlConfig.getNetworkConfig().getPort()).isEqualTo(20000);
+    }
+
+    private NeonBeeOptions parseOptionsArgs() {
+        return parseOptions(INTERFACE.parse(List.of(args)));
     }
 }

--- a/src/test/java/io/neonbee/test/helper/SystemHelper.java
+++ b/src/test/java/io/neonbee/test/helper/SystemHelper.java
@@ -37,6 +37,21 @@ public final class SystemHelper {
         modifiableEnvironment.putAll(newEnvironment);
     }
 
+    /**
+     * This method replaces the JVM wide copy of the system environment with the passed environment map, executes the
+     * passed runnable, and resets the environment variables to the original value again.
+     *
+     * @param newEnvironment The new environment map
+     * @param runnable       The code that should be executed within the context of passed environment variables
+     * @throws Exception Could not change environment
+     */
+    public static void withEnvironment(Map<String, String> newEnvironment, Runnable runnable) throws Exception {
+        Map<String, String> oldEnvironment = Map.copyOf(System.getenv());
+        setEnvironment(newEnvironment);
+        runnable.run();
+        SystemHelper.setEnvironment(oldEnvironment);
+    }
+
     private SystemHelper() {
         // Utils class no need to instantiate
     }


### PR DESCRIPTION
For deployment on cloud environments, it is beneficial to provide the
launcher options via environment variables instead of command line
arguments. This change supports reading options either from command line
or environment variable.