### PR TITLE
fix: enable parseUriInfo for OData URIs containing properties

### DIFF
--- a/src/main/java/io/neonbee/entity/EntityVerticle.java
+++ b/src/main/java/io/neonbee/entity/EntityVerticle.java
@@ -59,6 +59,9 @@ public abstract class EntityVerticle extends DataVerticle<EntityWrapper> {
     @VisibleForTesting
     static final int ENTITY_SET_NAME_GROUP = 5;
 
+    @VisibleForTesting
+    static final int ENTITY_PROPERTY_NAME_GROUP = 6;
+
     /**
      * Pattern to match OData URI paths.
      *
@@ -75,15 +78,17 @@ public abstract class EntityVerticle extends DataVerticle<EntityWrapper> {
      * Some examples:
      *
      * <pre>
-     * URI path                          | Group 1 (Svc. Nsp.) | 2. CDS Nsp. | 3. Name | 4. Enty. Path | 5. ESN
-     * --------------------------------------------------------------------------------------------------------
-     * my.very/own.Service/Entity('Key') | my.very/own.Service | my.very/own | Service | Entity('Key') | Entity
-     * my.Service/Entity('Key')          | my.Service          | my          | Service | Entity('Key') | Entity
-     * Service/Entity('Key')             | Service             |             | Service | Entity('Key') | Entity
+     * URI path                          | Group 1 (Svc. Nsp.) | 2. CDS Nsp. | 3. Name | 4. Enty. Path | 5. ESN | 6. Property
+     * ----------------------------------------------------------------------------------------------------------------------
+     * my.very/own.Service/Entity('Key') | my.very/own.Service | my.very/own | Service | Entity('Key') | Entity |
+     * my.Service/Entity('Key')          | my.Service          | my          | Service | Entity('Key') | Entity |
+     * Service/Entity('Key')/property    | Service             |             | Service | Entity('Key') | Entity | property
+     * Service/Entity('Key')             | Service             |             | Service | Entity('Key') | Entity |
      * </pre>
      */
     @VisibleForTesting
-    static final Pattern URI_PATH_PATTERN = Pattern.compile("^/*((?:(.*)\\.)?(.*))/(([A-Za-z_]\\w+).*)$");
+    static final Pattern URI_PATH_PATTERN =
+            Pattern.compile("^/*((?:(.*)\\.)?(.*?))/(([A-Za-z_]\\w+).*?)(?:(?<=\\))/(.*))?$");
 
     private static final LoggingFacade LOGGER = LoggingFacade.create();
 

--- a/src/test/java/io/neonbee/entity/EntityVerticleTest.java
+++ b/src/test/java/io/neonbee/entity/EntityVerticleTest.java
@@ -3,6 +3,8 @@ package io.neonbee.entity;
 import static com.google.common.truth.Truth.assertThat;
 import static io.neonbee.entity.EntityVerticle.CDS_NAMESPACE_GROUP;
 import static io.neonbee.entity.EntityVerticle.CDS_SERVICE_NAME_GROUP;
+import static io.neonbee.entity.EntityVerticle.ENTITY_PATH_GROUP;
+import static io.neonbee.entity.EntityVerticle.ENTITY_PROPERTY_NAME_GROUP;
 import static io.neonbee.entity.EntityVerticle.ENTITY_SET_NAME_GROUP;
 import static io.neonbee.entity.EntityVerticle.SERVICE_NAMESPACE_GROUP;
 import static io.neonbee.entity.EntityVerticle.URI_PATH_PATTERN;
@@ -131,6 +133,12 @@ class EntityVerticleTest extends EntityVerticleTestBase {
 
         assertThat((matcher = URI_PATH_PATTERN.matcher("Service/Entity(1)")).find()).isTrue();
         assertThat(matcher.group(ENTITY_SET_NAME_GROUP)).isEqualTo("Entity");
+
+        assertThat((matcher = URI_PATH_PATTERN.matcher("Service/Entity(1)/property")).find()).isTrue();
+        assertThat(matcher.group(SERVICE_NAMESPACE_GROUP)).isEqualTo("Service");
+        assertThat(matcher.group(ENTITY_PATH_GROUP)).isEqualTo("Entity(1)");
+        assertThat(matcher.group(ENTITY_SET_NAME_GROUP)).isEqualTo("Entity");
+        assertThat(matcher.group(ENTITY_PROPERTY_NAME_GROUP)).isEqualTo("property");
 
         assertThat((matcher = URI_PATH_PATTERN.matcher("Service/Entity/$count")).find()).isTrue();
         assertThat(matcher.group(ENTITY_SET_NAME_GROUP)).isEqualTo("Entity");


### PR DESCRIPTION
Before this patch it was not possible to parse OData URIs that were
containing a property as last segment of the path.