### PR TITLE
fix: calculation of system query count

### DIFF
--- a/src/main/java/io/neonbee/internal/processor/CountEntityCollectionProcessor.java
+++ b/src/main/java/io/neonbee/internal/processor/CountEntityCollectionProcessor.java
@@ -110,8 +110,8 @@ public class CountEntityCollectionProcessor extends AsynchronousProcessor
             // Fetch the data from backend
             fetchEntities(request, edmEntityType, ew -> {
                 try {
-                    applyCountOption(uriInfo.getCountOption(), ew.getEntities(), entityCollection);
                     List<Entity> resultEntityList = applyFilterQueryOption(uriInfo.getFilterOption(), ew.getEntities());
+                    applyCountOption(uriInfo.getCountOption(), resultEntityList, entityCollection);
                     if (!resultEntityList.isEmpty()) {
                         applyOrderByQueryOption(uriInfo.getOrderByOption(), resultEntityList);
                         resultEntityList = applySkipQueryOption(uriInfo.getSkipOption(), resultEntityList);
@@ -161,7 +161,7 @@ public class CountEntityCollectionProcessor extends AsynchronousProcessor
                 new DataContextImpl(routingContext)).onFailure(getProcessPromise()::fail).onSuccess(resultHandler);
     }
 
-    private void applyCountOption(CountOption countOption, List<Entity> unfilteredEntities,
+    private void applyCountOption(CountOption countOption, List<Entity> filteredEntities,
             EntityCollection entityCollection) {
         // Apply $count system query option. The $count system query option with a value of true
         // specifies that the total count of items within a collection matching the request be returned
@@ -169,7 +169,7 @@ public class CountEntityCollectionProcessor extends AsynchronousProcessor
         // options, and returns the total count of results across all pages including only those results
         // matching any specified $filter and $search.
         if ((countOption != null) && countOption.getValue()) {
-            entityCollection.setCount(unfilteredEntities.size());
+            entityCollection.setCount(filteredEntities.size());
         }
     }
 

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataReadEntitiesTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataReadEntitiesTest.java
@@ -112,6 +112,19 @@ class ODataReadEntitiesTest extends ODataEndpointTestBase {
 
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("Respond with 200 if the service is existing and has test entities including correct inline count with applied filters")
+    void existingEntitiesWithInlineCountAndFilterTest(VertxTestContext testContext) {
+        List<JsonObject> expectedEntities = List.of(EXPECTED_ENTITY_DATA_2, EXPECTED_ENTITY_DATA_4);
+        Map<String, String> query = Map.of("$filter", "KeyPropertyString in ('id.3', 'id-1')", "$count", "true");
+
+        Future<HttpResponse<Buffer>> response = requestOData(new ODataRequest(TEST_ENTITY_SET_FQN).setQuery(query));
+        assertOData(response, body -> assertThat(body.toJsonObject().getMap()).containsAtLeast("@odata.count", 2),
+                testContext).compose(v -> assertODataEntitySetContainsExactly(response, expectedEntities, testContext))
+                        .onComplete(testContext.succeedingThenComplete());
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Respond with 200 and the correct count of entities")
     void existingEntitiesCountTest(VertxTestContext testContext) {
         assertOData(requestOData(new ODataRequest(TEST_ENTITY_SET_FQN).setCount()), "5", testContext)


### PR DESCRIPTION
Mistakenly it was assumed that also filters are ignored when calculating
the system query count.