### PR TITLE
build(commitlint): allow pascal-case scopes

### DIFF
--- a/.github/workflows/.commitlintrc.json
+++ b/.github/workflows/.commitlintrc.json
@@ -30,6 +30,14 @@
                 "style",
                 "test"
             ]
+        ],
+        "scope-case": [
+            0,
+            "always",
+            [
+                "lower-case",
+                "pascal-case"
+            ]
         ]
     }
 }


### PR DESCRIPTION
Allowing pascal-case in the scope for the sake of setting Java classes
as scope of the commit message.