### PR TITLE
build(deps): replace cds-services-impl with cds4j-core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     }
     implementation group: 'org.apache.olingo', name: 'odata-server-core-ext', version: olingo_version
 
-    implementation group: 'com.sap.cds', name: 'cds-services-impl', version: '1.9.0'
+    implementation group: 'com.sap.cds', name: 'cds4j-core', version: '1.19.0'
     implementation group: 'io.micrometer', name: 'micrometer-registry-prometheus', version: '1.3.1'
     implementation group: 'org.ow2.asm', name: 'asm', version: '7.2'
 


### PR DESCRIPTION
cds4j-core is a dependency of cds-services-impl, but in NeonBee only
functionality from cds4j-core is used. With refining this dependency it
is possible to save ~1 MB of unnecessary dependencies.