### PR TITLE
feat!: introduce exposedEntities/Verticles allow/block lists

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,7 +40,7 @@ At the time of open sourcing to GitHub.com, NeonBee at version 0.2 still has to 
 
 ### 🚀 Milestones + Progress
 
-**ONGOING** 📉 0 / 11 milestones completed (0%) 📅 2022
+**ONGOING** 📉 1 / 11 milestones completed (9%) 📅 2022
 
 | Status | 🚀 Milestone | [Types](https://www.conventionalcommits.org/) |
 | :---: | :--- | --- |
@@ -49,7 +49,7 @@ At the time of open sourcing to GitHub.com, NeonBee at version 0.2 still has to 
 | ❌ | [Improve error handling and logging](milestones/E1_MS03_error_handling.md) | `feat` |
 | ⚡ | [Full OASIS OData V4 support](milestones/E1_MS04_odata_support.md) | `feat` |
 | ❌ | [New deployables concept](milestones/E1_MS05_new_deployables_concept.md) | `feat` |
-| ⚡ | [Configurable modular endpoints](milestones/E1_MS06_configurable_endpoints.md) | `feat`, `build` |
+| ✔️ | [Configurable modular endpoints](milestones/E1_MS06_configurable_endpoints.md) | `feat`, `build` |
 | ❌ | [Documentation and homepage](milestones/E1_MS07_documentation.md) | `docs` |
 | ❌ | [Gradle build tooling](milestones/E1_MS08_build_tooling.md) | `build` |
 | ❌ | [Admin console / administrative user interface](milestones/E1_MS09_admin_console.md) | `feat` |

--- a/resources/config/io.neonbee.internal.verticle.ServerVerticle.example.yaml
+++ b/resources/config/io.neonbee.internal.verticle.ServerVerticle.example.yaml
@@ -10,7 +10,7 @@ config:
     # sets whether to use application-layer protocol negotiation or not, defaults to true
     useAlpn: true
     # one of: NONE, LOCAL or CLUSTERED, defaults to NONE
-    sessionHandling: none
+    sessionHandling: NONE
     # the name of the session cookie, defaults to neonbee-web.session
     sessionCookieName: neonbee-web.session
 
@@ -49,6 +49,11 @@ config:
         authenticationChain: ~
         # namespace and service name URI mapping (STRICT, or LOOSE based on CDS)
         uriConversion: STRICT
+        # a block / allow list of verticles to expose via this endpoint (defaults to empty / all entities exposed)
+        # the value of block / allow must be an array with Strings representing a regexp.
+        exposedEntities:
+          block: [any_allow_list_of_regexp_here]
+          allow: [any_block_list_of_regexp_here]
 
       # provides a REST endpoint (JSON, text, binary), for accessing data verticles
       - type: io.neonbee.endpoint.raw.RawEndpoint
@@ -60,6 +65,11 @@ config:
         authenticationChain: ~
         # whether or not to expose hidden verticles, defaults to false
         exposeHiddenVerticles: false
+        # a block / allow list of verticles to expose via this endpoint (defaults to empty all verticles exposed)
+        # the value of block / allow must be an array with Strings representing a regexp.
+        exposedVerticles:
+          block: [any_allow_list_of_regexp_here]
+          allow: [any_block_list_of_regexp_here]
 
       # provides an Prometheus scraping endpoint for Micrometer.io metrics
       - type: io.neonbee.endpoint.metrics.MetricsEndpoint

--- a/src/main/java/io/neonbee/endpoint/odatav4/ODataV4Endpoint.java
+++ b/src/main/java/io/neonbee/endpoint/odatav4/ODataV4Endpoint.java
@@ -1,5 +1,6 @@
 package io.neonbee.endpoint.odatav4;
 
+import static com.google.common.base.Strings.emptyToNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Strings.nullToEmpty;
 import static io.neonbee.endpoint.odatav4.ODataV4Endpoint.UriConversion.STRICT;
@@ -8,28 +9,35 @@ import static io.neonbee.entity.EntityModelManager.getSharedModels;
 import static io.neonbee.internal.helper.FunctionalHelper.entryConsumer;
 import static io.neonbee.internal.helper.FunctionalHelper.entryFunction;
 import static io.neonbee.internal.helper.StringHelper.EMPTY;
+import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 import static io.vertx.core.Future.succeededFuture;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
 
+import com.google.common.base.MoreObjects;
+
 import io.neonbee.config.EndpointConfig;
 import io.neonbee.endpoint.Endpoint;
 import io.neonbee.endpoint.odatav4.internal.olingo.OlingoEndpointHandler;
 import io.neonbee.entity.EntityModel;
+import io.neonbee.internal.RegexBlockList;
 import io.neonbee.internal.SharedDataAccessor;
 import io.neonbee.logging.LoggingFacade;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
 
 public class ODataV4Endpoint implements Endpoint {
     /**
@@ -43,6 +51,8 @@ public class ODataV4Endpoint implements Endpoint {
     public static final String DEFAULT_BASE_PATH = "/odata/";
 
     private static final LoggingFacade LOGGER = LoggingFacade.create();
+
+    private static final String NORMALIZED_URI_CONTEXT_KEY = ODataV4Endpoint.class.getName() + "_normalizedUri";
 
     /**
      * Either STRICT (&lt;namespace&gt;.&lt;service&gt;), LOOSE (&lt;path mapping of namespace&gt;-&lt;path mapping of
@@ -155,7 +165,8 @@ public class ODataV4Endpoint implements Endpoint {
     @Override
     public EndpointConfig getDefaultConfig() {
         // as the EndpointConfig stays mutable, do not extract this to a static variable, but return a new object
-        return new EndpointConfig().setType(ODataV4Endpoint.class.getName()).setBasePath(DEFAULT_BASE_PATH);
+        return new EndpointConfig().setType(ODataV4Endpoint.class.getName()).setBasePath(DEFAULT_BASE_PATH)
+                .setAdditionalConfig(new JsonObject().put("uriConversion", STRICT.name()));
     }
 
     @Override
@@ -164,16 +175,22 @@ public class ODataV4Endpoint implements Endpoint {
         AtomicBoolean initialized = new AtomicBoolean(); // true if the router was initialized already
         AtomicReference<Map<String, EntityModel>> models = new AtomicReference<>();
 
+        // the URI convention used to expose the given service in the endpoint.
+        UriConversion uriConversion = UriConversion.byName(config.getString("uriConversion", STRICT.name()));
+
+        // a block / allow list of all entities that should be exposed via this endpoint. the entity name is always
+        // matched against the full qualified name of the entity in question (URI conversion is applied by NeonBee).
+        RegexBlockList exposedEntities = RegexBlockList.fromJson(config.getValue("exposedEntities"));
+
         // Register the event bus consumer first, otherwise it could happen that during initialization we are missing an
         // update to the data model, a refresh of the router will only be triggered in case it is already initialized.
         // This is a NON-local consumer, this means the reload could be triggered from anywhere, however currently the
         // reload is only triggered in case the EntityModelManager reloads the models locally (and triggers a local
         // publish of the message, thus only triggering the routers to be reloaded on the local instance).
-        UriConversion uriConversion = UriConversion.byName(config.getString(CONFIG_URI_CONVERSION, STRICT.name()));
         vertx.eventBus().consumer(EVENT_BUS_MODELS_LOADED_ADDRESS, message -> {
             // do not refresh the router if it wasn't even initialized
             if (initialized.get()) {
-                refreshRouter(vertx, router, basePath, uriConversion, models);
+                refreshRouter(vertx, router, basePath, uriConversion, exposedEntities, models);
             }
         });
 
@@ -186,9 +203,10 @@ public class ODataV4Endpoint implements Endpoint {
         initialRoute.handler(
                 routingContext -> new SharedDataAccessor(vertx, ODataV4Endpoint.class).getLocalLock(asyncLock ->
                 // immediately initialize the router, this will also "arm" the event bus listener
-                (!initialized.getAndSet(true) ? refreshRouter(vertx, router, basePath, uriConversion, models)
+                (!initialized.getAndSet(true)
+                        ? refreshRouter(vertx, router, basePath, uriConversion, exposedEntities, models)
                         : succeededFuture()).onComplete(handler -> {
-                            // Wait for the refresh to finish (the result doesn't matter), remove the initial route, as
+                            // wait for the refresh to finish (the result doesn't matter), remove the initial route, as
                             // this will redirect all requests to the registered service endpoint handlers (if non have
                             // been registered, e.g. due to a failure in model loading, it'll result in an 404). Could
                             // have been removed already by refreshRouter, we don't care!
@@ -198,7 +216,7 @@ public class ODataV4Endpoint implements Endpoint {
                                 asyncLock.result().release();
                             }
 
-                            // Let the router again handle the context again, now with either all service endpoints
+                            // let the router again handle the context again, now with either all service endpoints
                             // registered, or none in case there have been a failure while loading the models.
                             // NOTE: Re-route is the only elegant way I found to restart the current router to take
                             // the new routes! Might consider checking again with the Vert.x 4.0 release.
@@ -209,7 +227,7 @@ public class ODataV4Endpoint implements Endpoint {
     }
 
     private static Future<Void> refreshRouter(Vertx vertx, Router router, String basePath, UriConversion uriConversion,
-            AtomicReference<Map<String, EntityModel>> currentModels) {
+            RegexBlockList exposedEntities, AtomicReference<Map<String, EntityModel>> currentModels) {
         return getSharedModels(vertx).compose(models -> {
             if (models == currentModels.get()) {
                 return succeededFuture(); // no update needed
@@ -220,19 +238,38 @@ public class ODataV4Endpoint implements Endpoint {
             // before adding new routes, get a list of existing routes, to remove after the new routes have been added
             List<Route> existingRoutes = router.getRoutes();
 
-            // Register new routes first, this will avoid downtimes of already existing services. Register the shortest
+            // register new routes first, this will avoid downtimes of already existing services. Register the shortest
             // routes last, this will lead to some routes like the empty namespace / to be registered last.
             models.values().stream().flatMap(entityModel -> entityModel.getEdmxes().entrySet().stream())
                     .map(entryFunction(
                             (schemaNamespace, edmxModel) -> Map.entry(uriConversion.apply(schemaNamespace), edmxModel)))
                     .sorted(Map.Entry.comparingByKey(Comparator.comparingInt(String::length).reversed()))
                     .forEach(entryConsumer((uriPath, edmxModel) -> {
-                        // TODO depending on the config either create Olingo or CDS based OData V4 handlers here
+                        String schemaNamespace = edmxModel.getEdm().getEntityContainer().getNamespace();
                         router.route((uriPath.isEmpty() ? EMPTY : ("/" + uriPath)) + "/*")
+                                // some entities should not get exposed, register a handler, checking the block list
+                                .handler(routingContext -> {
+                                    // normalize the URI first
+                                    NormalizedUri normalizedUri = normalizeUri(routingContext, schemaNamespace);
+                                    if (LOGGER.isDebugEnabled()) {
+                                        LOGGER.correlateWith(routingContext).debug("Normalized OData V4 URI {}",
+                                                normalizedUri);
+                                    }
+
+                                    // if a entity is specified check it against the block list
+                                    // TODO: maybe also navigation properties have to be taken into account here?
+                                    if (normalizedUri.fullQualifiedName != null
+                                            && !exposedEntities.isAllowed(normalizedUri.fullQualifiedName)) {
+                                        routingContext.fail(FORBIDDEN.code());
+                                        return;
+                                    }
+
+                                    routingContext.next();
+                                })
+                                // TODO depending on the config either create Olingo or CDS based OData V4 handlers here
                                 .handler(new OlingoEndpointHandler(edmxModel));
-                        LOGGER.info("Serving OData service endpoint for {} at {}{} ({} URI mapping)",
-                                edmxModel.getEdm().getEntityContainer().getNamespace(), basePath, uriPath,
-                                uriConversion.name().toLowerCase(Locale.getDefault()));
+                        LOGGER.info("Serving OData service endpoint for {} at {}{} ({} URI mapping)", schemaNamespace,
+                                basePath, uriPath, uriConversion.name().toLowerCase(Locale.getDefault()));
                     }));
 
             // remove any of the old routes, so the old models will stop serving
@@ -242,5 +279,196 @@ public class ODataV4Endpoint implements Endpoint {
                     models.size(), existingRoutes.size());
             return succeededFuture();
         });
+    }
+
+    /**
+     * Normalize a given OData V4 request URI using a given {@link RoutingContext} and the schema namespace.
+     *
+     * A once parsed {@link NormalizedUri} is associated with the given {@link RoutingContext} so the same reference of
+     * the URI is returned if this method is invoked multiple times with the same {@link RoutingContext} given.
+     *
+     * @param routingContext  the routing context to parse the {@link NormalizedUri} from. Depending on the
+     *                        {@link UriConversion} the routing path / uri might not contain the right schema namespace
+     * @param schemaNamespace the schema namespace of the service in question
+     * @return a {@link NormalizedUri}
+     */
+    public static NormalizedUri normalizeUri(RoutingContext routingContext, String schemaNamespace) {
+        return Optional.<NormalizedUri>ofNullable(routingContext.get(NORMALIZED_URI_CONTEXT_KEY)).orElseGet(() -> {
+            NormalizedUri normalizedUri = new NormalizedUri(routingContext, schemaNamespace);
+            routingContext.put(NORMALIZED_URI_CONTEXT_KEY, normalizedUri);
+            return normalizedUri;
+        });
+    }
+
+    /* @formatter:off *//**
+     * This class represents a normalized OData V4 URI and helps to split it up in several path segments.
+     * <p>
+     * Asserting the most specific URI, given the following example from the OASIS OData URI specification:
+     *
+     * <pre>
+     *   http://host:port/path/SampleService.svc/Categories(1)/Products?&amp;top=2&amp;orderby=Name
+     * </pre>
+     *
+     * Assuming loose URI conversion is used, NeonBee will expose the service at:
+     *
+     * <pre>
+     *   http://host:port/path/sample-service-svc/Categories(1)/Products?&amp;top=2&amp;orderby=Name
+     * </pre>
+     *
+     * We get the following information from the handler configuration:
+     *
+     * <pre>
+     *   schemaNamespace = SampleService.svc
+     * </pre>
+     *
+     * We get the following information from the routing context / request:
+     *
+     * <pre>
+     *   requestUri      = http://host:port/path/sample-service-svc/Categories(1)/Products?&amp;top=2&amp;orderby=Name
+     *   requestPath     = /path/sample-service-svc/Categories(1)/Products
+     *   requestQuery    = &amp;top=2&amp;orderby=Name
+     *   routeMountPoint = /path/
+     *   routePath       = /sample-service-svc/
+     * </pre>
+     *
+     * The URI is normalized to the following components, note how the URI always will be normalized as if no
+     * URI conversion was performed:
+     *
+     * <pre>
+     *   requestUri        = http://host:port/path/SampleService.svc/Categories(1)/Products?&amp;top=2&amp;orderby=Name
+     *   requestPath       = /path/SampleService.svc/Categories(1)/Products
+     *   requestQuery      = &amp;top=2&amp;orderby=Name
+     *   baseUri           = http://host:port/path/
+     *   basePath          = /path/
+     *   schemaNamespace   = SampleService.svc
+     *   resourcePath      = /Categories(1)/Products
+     *   entityName        = Categories
+     *   fullQualifiedName = SampleService.svc.Categories
+     * </pre>
+     *//* @formatter:on */
+    public static class NormalizedUri {
+        /**
+         * The full request URI.
+         *
+         * <pre>
+         * http://host:port/path/SampleService.svc/Categories(1)/Products?&amp;top=2&amp;orderby=Name
+         * </pre>
+         */
+        public final String requestUri;
+
+        /**
+         * The requests path.
+         *
+         * <pre>
+         * /path/SampleService.svc/Categories(1)/Products
+         * </pre>
+         */
+        public final String requestPath;
+
+        /**
+         * The requests query.
+         *
+         * <pre>
+         * &amp;top=2&amp;orderby=Name
+         * </pre>
+         */
+        public final String requestQuery;
+
+        /**
+         * The base URI of the OData endpoint.
+         *
+         * <pre>
+         * http://host:port/path/
+         * </pre>
+         */
+        public final String baseUri;
+
+        /**
+         * The base path of the OData endpoint.
+         *
+         * <pre>
+         * /path/
+         * </pre>
+         */
+        public final String basePath;
+
+        /**
+         * The schema namespace of the OData model the request was made for.
+         *
+         * <pre>
+         * SampleService.svc
+         * </pre>
+         */
+        public final String schemaNamespace;
+
+        /**
+         * The full resource path of the OData request.
+         *
+         * <pre>
+         * /Categories(1)/Products
+         * </pre>
+         */
+        public final String resourcePath;
+
+        /**
+         * The entity name of the requested entity (if any or null).
+         *
+         * <pre>
+         * Categories
+         * </pre>
+         */
+        public final String entityName;
+
+        /**
+         * The full qualified name of the requested entity (if any or null).
+         *
+         * <pre>
+         * Categories
+         * </pre>
+         */
+        public final String fullQualifiedName;
+
+        private NormalizedUri(RoutingContext routingContext, String schemaNamespace) {
+            // the (unconverted) schema namespace is a input to the constructor
+            this.schemaNamespace = schemaNamespace;
+
+            Route route = routingContext.currentRoute();
+            // note that getPath() returns *only* the path prefix, so essentially the base path and converted schema
+            // namespace with leading and tailing slashes w/o the tailing *, which is handled and stripped by the router
+            String routeMountPoint = routingContext.mountPoint();
+            String routePath = // routePath w/ exactly one tailing slash
+                    Optional.ofNullable(route).map(Route::getPath).orElse(EMPTY).replaceAll("/+$", EMPTY) + "/";
+
+            HttpServerRequest request = routingContext.request();
+            String requestPath = request.path();
+            if (!requestPath.contains(routePath)) {
+                // special case if calling the service root at /path/SampleService.svc, always append a forward slash
+                // for easier handling, so to make it /path/SampleService.svc/
+                requestPath += '/';
+            }
+
+            // parse out the base URI and path
+            String hostUri = request.scheme() + "://" + request.host();
+            baseUri = hostUri + (basePath = routeMountPoint);
+
+            // parse out the resource path and entity name
+            resourcePath = requestPath.substring((routeMountPoint + routePath).replaceAll("/{2,}", "/").length() - 1);
+            entityName = emptyToNull(resourcePath.split("\\W", 2)[0]); // assume the first non-word char separates it
+
+            // if an entity name is provided, concatenate the full qualified name
+            fullQualifiedName = entityName != null ? schemaNamespace + '.' + entityName : null;
+
+            // construct the full request path and URI, the query is provided by the request
+            requestUri = hostUri + (this.requestPath = basePath + schemaNamespace + resourcePath)
+                    + (!(requestQuery = nullToEmpty(request.query())).isEmpty() ? "?" + requestQuery : EMPTY);
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this).add("requestUri", requestUri).add("requestPath", requestPath)
+                    .add("requestQuery", requestQuery).add("baseUri", baseUri).add("basePath", basePath)
+                    .add("schemaNamespace", schemaNamespace).add("resourcePath", resourcePath)
+                    .add("entityName", entityName).add("fullQualifiedName", fullQualifiedName).toString();
+        }
     }
 }

--- a/src/main/java/io/neonbee/endpoint/raw/RawEndpoint.java
+++ b/src/main/java/io/neonbee/endpoint/raw/RawEndpoint.java
@@ -26,6 +26,7 @@ import static java.lang.Character.isUpperCase;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -37,6 +38,7 @@ import io.neonbee.data.DataQuery;
 import io.neonbee.data.DataRequest;
 import io.neonbee.data.internal.DataContextImpl;
 import io.neonbee.endpoint.Endpoint;
+import io.neonbee.internal.RegexBlockList;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -60,10 +62,18 @@ public class RawEndpoint implements Endpoint {
      */
     public static final String DEFAULT_BASE_PATH = "/raw/";
 
+    /**
+     * Hidden verticles are those verticles not being exposed via the raw endpoint. To denounce a verticle as "hidden"
+     * the name of the verticle has to start with an underscore _ after the namespace part. In the default configuration
+     * of the raw endpoint the "exposeHiddenVerticles" parameter is set to {@code false}.
+     */
+    private static final Pattern HIDDEN_VERTICLES_PATTERN = Pattern.compile("(?:^|/)(?!.*/)_");
+
     @Override
     public EndpointConfig getDefaultConfig() {
         // as the EndpointConfig stays mutable, do not extract this to a static variable, but return a new object
-        return new EndpointConfig().setType(RawEndpoint.class.getName()).setBasePath(DEFAULT_BASE_PATH);
+        return new EndpointConfig().setType(RawEndpoint.class.getName()).setBasePath(DEFAULT_BASE_PATH)
+                .setAdditionalConfig(new JsonObject().put("exposeHiddenVerticles", false));
     }
 
     @Override
@@ -75,13 +85,24 @@ public class RawEndpoint implements Endpoint {
     static class RawHandler implements Handler<RoutingContext> {
         private final boolean exposeHiddenVerticles;
 
+        private final RegexBlockList exposedVerticles;
+
         /**
          * Creates a new RawDataEndpointHandler based on the given configuration.
          *
          * @param config the configuration
          */
         RawHandler(JsonObject config) {
-            exposeHiddenVerticles = config.getBoolean(CONFIG_EXPOSE_HIDDEN_VERTICLES, false);
+            // exposeHiddenVertices is a configuration which is explicitly additional to the "exposedVerticles" block
+            // list. this is due to the nature of the block list, blocking all verticles by default when only a allow
+            // list is specified. if we would add the HIDDEN_VERTICLES_PATTERN to the block list here, this might have
+            // side effects for the user of the block list, as if the user would add something only to the allow list
+            // the list would behave differently than expected. thus this parameter is checked in addition.
+            exposeHiddenVerticles = config.getBoolean("exposeHiddenVerticles", false);
+
+            // a block / allow list of all verticles that should be exposed via this endpoint (works in conjunction with
+            // the exposeHiddenVerticles flag, as described in the previous comment)
+            exposedVerticles = RegexBlockList.fromJson(config.getValue("exposedVerticles"));
         }
 
         @Override
@@ -100,11 +121,13 @@ public class RawEndpoint implements Endpoint {
                 routingContext.fail(BAD_REQUEST.code(),
                         new IllegalArgumentException("Missing the full qualified verticle name"));
                 return;
-            } else if (!exposeHiddenVerticles && qualifiedName.charAt(qualifiedName.lastIndexOf('/') + 1) == '_') {
-                // do not even start looking for a verticle, as _ verticle are not exposed publicly!
+            } else if ((!exposeHiddenVerticles && HIDDEN_VERTICLES_PATTERN.matcher(qualifiedName).find())
+                    || !exposedVerticles.isAllowed(qualifiedName)) {
+                // do not even start looking for a verticle, as the vert as _ verticle are not exposed publicly!
                 routingContext.fail(NOT_FOUND.code());
                 return;
             }
+
             String decodedQueryPath = null;
             try {
                 if (!Strings.isNullOrEmpty(request.query())) {

--- a/src/main/java/io/neonbee/internal/RegexBlockList.java
+++ b/src/main/java/io/neonbee/internal/RegexBlockList.java
@@ -1,0 +1,152 @@
+package io.neonbee.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A regex based block list, which primarily checks if an entry is blocked, but has a fallback to allow certain entries
+ * if they are blocked by the block list.
+ */
+public class RegexBlockList {
+    private final List<Pattern> blockList;
+
+    private final List<Pattern> allowList;
+
+    /**
+     * Create a empty (all allowing) RegexBlockList.
+     */
+    public RegexBlockList() {
+        blockList = new ArrayList<>();
+        allowList = new ArrayList<>();
+    }
+
+    /**
+     * This method is able to handle a JSON value and will perform initialization of the {@link RegexBlockList}
+     * according to the type of object passed to the method:
+     * <ul>
+     * <li>In case {@code null} is passed, an initial list will be created, allowing all checked elements.
+     * <li>In case a plain {@link String} is passed, the string is interpreted as the only regex describing what this
+     * list will allow.
+     * <li>In case a {@link JsonArray} is passed, it is assumed its items of type {@link String} are describing the
+     * allow list of this block list, meaning that only listed items will be allowed by this list.
+     * <li>In case a {@link JsonObject} is passed, the "allow" and "block" properties as {@link JsonArray} or
+     * {@link String} describe what is to be blocked / allowed by this list.
+     * <li>In case of any other type initialization will fail with a {@code IllegalArgumentException}
+     * </ul>
+     *
+     * @param json the JSON value to parse either a {@link JsonArray}, a {@link JsonObject} or a {@link String})
+     * @return a fully initialized {@link RegexBlockList}
+     * @throws IllegalArgumentException when a JSON type is passed which cannot be parsed
+     */
+    public static RegexBlockList fromJson(Object json) {
+        RegexBlockList blockList = new RegexBlockList();
+
+        if (json instanceof String) {
+            blockList.allow((String) json);
+        } else if (json instanceof JsonArray) {
+            ((JsonArray) json).stream().map(String.class::cast).forEach(blockList::allow);
+        } else if (json instanceof JsonObject) {
+            Object jsonBlock = ((JsonObject) json).getValue("block");
+            if (jsonBlock instanceof String) {
+                blockList.block((String) jsonBlock);
+            } else if (jsonBlock instanceof JsonArray) {
+                ((JsonArray) jsonBlock).stream().map(String.class::cast).forEach(blockList::block);
+            } else if (jsonBlock != null) {
+                throw new IllegalArgumentException("Cannot parse blocked type of JSON to initialize RegexBlockList");
+            }
+
+            Object jsonAllow = ((JsonObject) json).getValue("allow");
+            if (jsonAllow instanceof String) {
+                blockList.allow((String) jsonAllow);
+            } else if (jsonAllow instanceof JsonArray) {
+                ((JsonArray) jsonAllow).stream().map(String.class::cast).forEach(blockList::allow);
+            } else if (jsonAllow != null) {
+                throw new IllegalArgumentException("Cannot parse allowed type of JSON to initialize RegexBlockList");
+            }
+        } else if (json != null) {
+            throw new IllegalArgumentException("Cannot parse type of JSON to initialize RegexBlockList");
+        }
+
+        return blockList;
+    }
+
+    /**
+     * Block a certain regex pattern.
+     *
+     * @param regex the regex pattern to block
+     */
+    public void block(String regex) {
+        block(Pattern.compile(regex));
+    }
+
+    /**
+     * Block a certain regex pattern.
+     *
+     * @param pattern the regex pattern to block
+     */
+    public void block(Pattern pattern) {
+        blockList.add(pattern);
+    }
+
+    /**
+     * Allow a certain regex pattern.
+     *
+     * @param regex the regex pattern to allow
+     */
+    public void allow(String regex) {
+        allow(Pattern.compile(regex));
+    }
+
+    /**
+     * Allow a certain regex pattern.
+     *
+     * @param pattern the regex pattern to allow
+     */
+    public void allow(Pattern pattern) {
+        allowList.add(pattern);
+    }
+
+    /**
+     * Clear the block / allow lists.
+     */
+    public void clear() {
+        blockList.clear();
+        allowList.clear();
+    }
+
+    /**
+     * Check if a given input string is allowed, based on the currently populated block / allow list.
+     * <p>
+     * This method will first check whether the given input string is blocked. If so the allow list can revoke the block
+     * in a second check. In case only the allow list is populated, this method assumes everything is blocked and only
+     * the elements on the allow list are allowed.
+     *
+     * @param input the input string to check if it is allowed
+     * @return true if the element is allowed
+     */
+    public boolean isAllowed(String input) {
+        boolean allowed = true;
+
+        // special case: if only allow list is filled, assume also only those entries are permitted
+        if ((blockList.isEmpty() && !allowList.isEmpty()) || isOnList(blockList, input)) {
+            allowed = false;
+        }
+
+        // allow list always "overrules" the block list, meaning if an entry is blocked, it can anyways be allowed if
+        // specifically listed on the allow list
+        if (!allowed && isOnList(allowList, input)) {
+            allowed = true;
+        }
+
+        return allowed;
+    }
+
+    private static boolean isOnList(List<Pattern> list, String input) {
+        return list.stream().map(pattern -> pattern.matcher(input)).anyMatch(Matcher::matches);
+    }
+}

--- a/src/test/java/io/neonbee/endpoint/odatav4/ODataV4EndpointTest.java
+++ b/src/test/java/io/neonbee/endpoint/odatav4/ODataV4EndpointTest.java
@@ -100,6 +100,7 @@ class ODataV4EndpointTest extends ODataEndpointTestBase {
         assertThat(CDS.apply("concatenateWordsWith-.FOOBarBAZService")).isEqualTo("foobarbaz");
         assertThat(CDS.apply("everythingGoesLowerCase.FOO-BAR-BAZ")).isEqualTo("foo-bar-baz");
         assertThat(CDS.apply("replaceAny_With-.FOO_BAR")).isEqualTo("foo-bar");
+        assertThat(CDS.apply("Service")).isEqualTo("");
 
         // special case, naming a service in a namespace only "Service" will result in the empty name for the service
         assertThat(CDS.apply("any.namespace.Service")).isEqualTo("");
@@ -108,6 +109,7 @@ class ODataV4EndpointTest extends ODataEndpointTestBase {
         assertThat(LOOSE.apply("my.very.CatalogService")).isEqualTo("my-very-catalog");
         assertThat(LOOSE.apply("io.neonbee.test.TestService1")).isEqualTo("io-neonbee-test-test-service1");
         assertThat(LOOSE.apply("Frontend.Service")).isEqualTo("frontend");
+        assertThat(LOOSE.apply("Service")).isEqualTo("");
     }
 
     private Future<HttpResponse<Buffer>> requestMetadata(String namespace) {
@@ -134,7 +136,7 @@ class ODataV4EndpointTest extends ODataEndpointTestBase {
         all(assertOData(requestMetadata("io-neonbee-handler-test"), ODataV4EndpointTest::assertTS1Handler, testContext),
                 assertOData(requestMetadata("io-neonbee-handler2-test2"), ODataV4EndpointTest::assertTS2Handler,
                         testContext),
-                assertOData(requestMetadata("test-service3"), ODataV4EndpointTest::assertTS3Handler, testContext))
+                assertOData(requestMetadata(""), ODataV4EndpointTest::assertTS3Handler, testContext))
                         .onComplete(testContext.succeedingThenComplete());
     }
 

--- a/src/test/java/io/neonbee/endpoint/odatav4/internal/olingo/OlingoEndpointHandlerTest.java
+++ b/src/test/java/io/neonbee/endpoint/odatav4/internal/olingo/OlingoEndpointHandlerTest.java
@@ -82,18 +82,21 @@ class OlingoEndpointHandlerTest {
         HttpServerRequest request = mock(HttpServerRequest.class);
         when(request.path()).thenReturn(expectedPath);
         when(request.query()).thenReturn(expectedQuery);
-        when(request.scheme()).thenReturn("https");
+        when(request.scheme()).thenReturn("http");
+        when(request.host()).thenReturn("localhost");
         when(request.method()).thenReturn(HttpMethod.GET);
         when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
 
         RoutingContext routingContext = mock(RoutingContext.class);
         when(routingContext.request()).thenReturn(request);
         when(routingContext.getBody()).thenReturn(Buffer.buffer(""));
+        when(routingContext.mountPoint()).thenReturn("/");
         when(routingContext.currentRoute()).thenReturn(null);
         when(routingContext.get(CorrelationIdHandler.CORRELATION_ID)).thenReturn("correlId");
 
         ODataRequest odataReq = mapToODataRequest(routingContext, expectedNamespace);
-        assertThat(odataReq.getRawRequestUri()).isEqualTo("/" + expectedNamespace + expectedPath + "?" + expectedQuery);
+        assertThat(odataReq.getRawRequestUri())
+                .isEqualTo("http://localhost/" + expectedNamespace + expectedPath + "?" + expectedQuery);
         assertThat(odataReq.getRawODataPath()).isEqualTo(expectedPath);
         assertThat(odataReq.getRawQueryPath()).isEqualTo(expectedQuery);
     }

--- a/src/test/java/io/neonbee/endpoint/raw/RawEndpointTest.java
+++ b/src/test/java/io/neonbee/endpoint/raw/RawEndpointTest.java
@@ -100,6 +100,21 @@ class RawEndpointTest extends DataVerticleTestBase {
     }
 
     @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.HOURS)
+    @DisplayName("RawDataEndpoint must prohibit requests to DataVerticles starting with underscore by default")
+    void testProhibitRequestsToUnderScoreDVsByDefault(VertxTestContext testContext) {
+        String verticleName = "_TestVerticle" + UUID.randomUUID().toString();
+
+        DataVerticle<String> dummy =
+                createDummyDataVerticle(NEONBEE_NAMESPACE + '/' + verticleName).withStaticResponse("You have failed");
+        deployVerticle(dummy).compose(s -> sendRequest(verticleName, "", ""))
+                .onComplete(testContext.succeeding(res -> testContext.verify(() -> {
+                    assertThat(res.statusCode()).isEqualTo(404);
+                    testContext.completeNow();
+                })));
+    }
+
+    @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("RawDataEndpointHandler must set uriPath and query correct")
     void testPassQueryToDataQuery(VertxTestContext testContext) {

--- a/src/test/java/io/neonbee/internal/RegexBlockListTest.java
+++ b/src/test/java/io/neonbee/internal/RegexBlockListTest.java
@@ -1,0 +1,120 @@
+package io.neonbee.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RegexBlockListTest {
+    @Test
+    @DisplayName("Test if an empty list allows everything")
+    void testEmpty() {
+        RegexBlockList blockList = new RegexBlockList();
+
+        assertThat(blockList.isAllowed("Abc")).isTrue();
+        assertThat(blockList.isAllowed("Bcd")).isTrue();
+        assertThat(blockList.isAllowed("Cde")).isTrue();
+
+        assertThat(blockList.isAllowed("Efg")).isTrue();
+        assertThat(blockList.isAllowed("Fgh")).isTrue();
+        assertThat(blockList.isAllowed("Ghi")).isTrue();
+
+        assertThat(blockList.isAllowed("")).isTrue();
+        assertThat(blockList.isAllowed(".*")).isTrue();
+    }
+
+    @Test
+    @DisplayName("Test if the list blocks the right entries")
+    void testBlockList() {
+        RegexBlockList blockList = new RegexBlockList();
+
+        blockList.block("A.*");
+        blockList.block("B.*");
+        blockList.block(Pattern.compile("C.*"));
+
+        assertThat(blockList.isAllowed("Abc")).isFalse();
+        assertThat(blockList.isAllowed("Bcd")).isFalse();
+        assertThat(blockList.isAllowed("Cde")).isFalse();
+
+        assertThat(blockList.isAllowed("Efg")).isTrue();
+        assertThat(blockList.isAllowed("Fgh")).isTrue();
+        assertThat(blockList.isAllowed("Ghi")).isTrue();
+
+        assertThat(blockList.isAllowed("")).isTrue();
+        assertThat(blockList.isAllowed(".*")).isTrue();
+    }
+
+    @Test
+    @DisplayName("Test if the list allows the right entries")
+    void testAllowList() {
+        RegexBlockList blockList = new RegexBlockList();
+
+        blockList.allow("A.*");
+        blockList.allow("B.*");
+        blockList.allow(Pattern.compile("C.*"));
+
+        assertThat(blockList.isAllowed("Abc")).isTrue();
+        assertThat(blockList.isAllowed("Bcd")).isTrue();
+        assertThat(blockList.isAllowed("Cde")).isTrue();
+
+        assertThat(blockList.isAllowed("Efg")).isFalse();
+        assertThat(blockList.isAllowed("Fgh")).isFalse();
+        assertThat(blockList.isAllowed("Ghi")).isFalse();
+
+        assertThat(blockList.isAllowed("")).isFalse();
+        assertThat(blockList.isAllowed(".*")).isFalse();
+    }
+
+    @Test
+    @DisplayName("Test if the list block and allows the right entries")
+    void testBlockAllowList() {
+        RegexBlockList blockList = new RegexBlockList();
+
+        blockList.block("A.*");
+        blockList.allow("AA.*");
+
+        blockList.block("B.*");
+        blockList.allow("BB.*");
+
+        blockList.block(Pattern.compile("C.*"));
+        blockList.allow(Pattern.compile("CC.*"));
+
+        assertThat(blockList.isAllowed("Abc")).isFalse();
+        assertThat(blockList.isAllowed("Acb")).isFalse();
+        assertThat(blockList.isAllowed("AAx")).isTrue();
+
+        assertThat(blockList.isAllowed("Bcd")).isFalse();
+        assertThat(blockList.isAllowed("Bdc")).isFalse();
+        assertThat(blockList.isAllowed("BBx")).isTrue();
+
+        assertThat(blockList.isAllowed("Cde")).isFalse();
+        assertThat(blockList.isAllowed("Ced")).isFalse();
+        assertThat(blockList.isAllowed("CCx")).isTrue();
+
+        assertThat(blockList.isAllowed("Efg")).isTrue();
+        assertThat(blockList.isAllowed("Fgh")).isTrue();
+        assertThat(blockList.isAllowed("Ghi")).isTrue();
+
+        assertThat(blockList.isAllowed("")).isTrue();
+        assertThat(blockList.isAllowed(".*")).isTrue();
+    }
+
+    @Test
+    @DisplayName("Test if the list can be cleared")
+    void testClear() {
+        RegexBlockList blockList = new RegexBlockList();
+
+        blockList.block("A.*");
+        blockList.allow("AA.*");
+
+        assertThat(blockList.isAllowed("A")).isFalse();
+        assertThat(blockList.isAllowed("AA")).isTrue();
+        assertThat(blockList.isAllowed("B")).isTrue();
+
+        blockList.clear();
+
+        assertThat(blockList.isAllowed("A")).isTrue();
+    }
+}


### PR DESCRIPTION
This change introduces new properties exposedEntities for the
ODataV4Endpoint and exposedVerticles for the RawEndpoint. These settings
can be used to initialize a new RegexBlockList, which can be used to
limit the verticles / entities exposed from a given endpoint.