### PR TITLE
feat: add support for custom error handlers

### DIFF
--- a/resources/config/io.neonbee.internal.verticle.ServerVerticle.example.yaml
+++ b/resources/config/io.neonbee.internal.verticle.ServerVerticle.example.yaml
@@ -34,6 +34,9 @@ config:
     # the maximum initial line length of the HTTP header (e.g. "GET / HTTP/1.0"), defaults to 4096 bytes
     maxInitialLineLength: 4096
 
+    # configure the error handler. If not specified, defaults to io.neonbee.internal.handler.ErrorHandler
+    errorHandler: io.neonbee.internal.handler.DefaultErrorHandler
+
     # specific endpoint configuration, defaults to the object seen below
     endpoints:
       # provides a OData V4 compliant endpoint, for accessing entity verticle data

--- a/src/test/java/io/neonbee/internal/verticle/ServerVerticleTest.java
+++ b/src/test/java/io/neonbee/internal/verticle/ServerVerticleTest.java
@@ -2,6 +2,7 @@ package io.neonbee.internal.verticle;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.neonbee.internal.verticle.ServerVerticle.createSessionStore;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import io.neonbee.config.ServerConfig.SessionHandling;
+import io.neonbee.internal.handler.DefaultErrorHandler;
 import io.neonbee.test.base.NeonBeeTestBase;
 import io.neonbee.test.helper.WorkingDirectoryBuilder;
 import io.vertx.core.Vertx;
@@ -30,7 +32,7 @@ import io.vertx.junit5.VertxTestContext;
 class ServerVerticleTest extends NeonBeeTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
-    void testCreateSessionStore() throws InterruptedException {
+    void testCreateSessionStore() {
         Vertx mockedVertx = mock(Vertx.class);
         when(mockedVertx.isClustered()).thenReturn(false);
         when(mockedVertx.sharedData()).thenReturn(mock(SharedData.class));
@@ -43,7 +45,7 @@ class ServerVerticleTest extends NeonBeeTestBase {
 
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
-    void testCreateSessionStoreClustered() throws InterruptedException {
+    void testCreateSessionStoreClustered() {
         Vertx mockedVertx = mock(Vertx.class);
         when(mockedVertx.isClustered()).thenReturn(true);
         when(mockedVertx.sharedData()).thenReturn(mock(SharedData.class));
@@ -107,6 +109,16 @@ class ServerVerticleTest extends NeonBeeTestBase {
                     assertThat(response.statusCode()).isEqualTo(404);
                     checkpoint.flag();
                 })));
+    }
+
+    @Test
+    void testgGetErrorHandlerDefault() throws Exception {
+        JsonObject config = new JsonObject();
+        assertThat(ServerVerticle.getErrorHandler(config)).isInstanceOf(DefaultErrorHandler.class);
+
+        ClassNotFoundException exception = assertThrows(ClassNotFoundException.class,
+                () -> ServerVerticle.getErrorHandler(config.put("errorHandler", "Hugo")));
+        assertThat(exception).hasMessageThat().contains("Hugo");
     }
 
     @Override


### PR DESCRIPTION
- rename ErrorHandler to DefaultErrorHandler
- remove create() pattern from the handler, because the
DefaultErrorHandler is a class and not an interface like the
ErrorHandler in Vert.x
- As in Vert.x an ErrorHandler interface already exists, reuse this
interface when implementing our own error handler.
- add errorHandler property to the ServerVerticleConfig