### PR TITLE
feat: allow multiple MANIFST.MF files when parsing NeonBee-Module

### DIFF
--- a/src/main/java/io/neonbee/internal/scanner/ClassPathScanner.java
+++ b/src/main/java/io/neonbee/internal/scanner/ClassPathScanner.java
@@ -87,28 +87,6 @@ public class ClassPathScanner {
 
     /**
      * Scans the class path for MANIFEST.MF files (in JARs), in case the manifest file contains the given attribute,
-     * returns the value.
-     *
-     * This method should be invoked on a {@link ClassLoader} with a single jat file only.
-     *
-     * @param attributeName The name of the attribute in the MANIFEST.MF to search for.
-     * @return value of the attribute
-     *
-     * @throws IOException exception
-     */
-    public String retrieveManifestAttribute(String attributeName) throws IOException {
-        List<URL> manifestResourceURLs = getManifestResourceURLs();
-        if (manifestResourceURLs.size() != 1) {
-            throw new IllegalStateException("Only one MANIFEST.MF expected, but found " + manifestResourceURLs.size());
-        }
-        try (InputStream inputStream = manifestResourceURLs.get(0).openStream()) {
-            // Attribute looks like: Attribute-Name: package.Resource1; package.Resource2
-            return new Manifest(inputStream).getMainAttributes().getValue(attributeName);
-        }
-    }
-
-    /**
-     * Scans the class path for MANIFEST.MF files (in JARs), in case the manifest file contains the given attribute,
      * parses the attribute and returns the values as a list of string.
      *
      * This allows to e.g. denote certain classes or resources of the JAR files to be exposed.

--- a/src/test/java/io/neonbee/internal/scanner/ClassPathScannerTest.java
+++ b/src/test/java/io/neonbee/internal/scanner/ClassPathScannerTest.java
@@ -107,19 +107,4 @@ class ClassPathScannerTest {
         assertThat(cps.scanForAnnotation(List.of(Transient.class, Deprecated.class), METHOD))
                 .containsExactly("method.Hodor2", "method.Hodor");
     }
-
-    @Test
-    @DisplayName("Should find passed attribute in all Manifest files")
-    void retrieveManifestAttribute() throws IOException {
-        String attribute1Name = "Attr1";
-        String attribute2Name = "Attr2";
-        String manifest1Attribute1Value = "M1A1V1";
-        BasicJar jarWithManifest1 = new BasicJar(Map.of(attribute1Name, manifest1Attribute1Value), Map.of());
-        URLClassLoader urlClassLoader =
-                new URLClassLoader(new URL[] { jarWithManifest1.writeToTempPath().toUri().toURL() }, null);
-        ClassPathScanner classPathScanner = new ClassPathScanner(urlClassLoader);
-
-        assertThat(classPathScanner.retrieveManifestAttribute(attribute1Name)).isEqualTo(manifest1Attribute1Value);
-        assertThat(classPathScanner.retrieveManifestAttribute(attribute2Name)).isNull();
-    }
 }


### PR DESCRIPTION
Normally there is exactly one MANIFEST.MF on the classpath, because when
parsing a NeonBee-Module a complete isolated classloader is used. But at
the end it doesn't matter how many MANIFEST.MF files are existing as
long as there is only one that contains the NeonBee-Module attributes.
Therefore this change adds more tolerance to the NeonBee-Module
validation.

This also helps in case that a third party library (like Dynatrace)
manipulates the classpath of every URLClassloader by adding own JARs.