### PR TITLE
refactor: made the ClassPathScanner non-blocking

### DIFF
--- a/src/main/java/io/neonbee/internal/scanner/HookScanner.java
+++ b/src/main/java/io/neonbee/internal/scanner/HookScanner.java
@@ -1,11 +1,9 @@
 package io.neonbee.internal.scanner;
 
+import static io.neonbee.internal.deploy.NeonBeeModule.NEONBEE_HOOKS;
 import static io.neonbee.internal.scanner.ClassPathScanner.getClassLoader;
 
-import java.io.IOException;
 import java.lang.annotation.ElementType;
-import java.net.URISyntaxException;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -17,6 +15,9 @@ import com.google.common.collect.Streams;
 import io.neonbee.hook.Hook;
 import io.neonbee.hook.Hooks;
 import io.neonbee.logging.LoggingFacade;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 
 public class HookScanner {
     private static final LoggingFacade LOGGER = LoggingFacade.create();
@@ -36,42 +37,47 @@ public class HookScanner {
     }
 
     /**
-     * This method will scan for classes containing hook-annotations on the classpath and in jars and will return a
-     * collection of classes which contains hook.
+     * This method will scan for classes containing hook-annotations on the classpath and in jars and will return a set
+     * of classes which contains hook.
      *
-     * @return the set of classes, containing hook annotations
+     * @param vertx the Vert.x instance
+     * @return a future to a set of classes, containing hook annotations
      */
-    public Collection<Class<?>> scanForHooks() {
-        try {
-            return scanForClassesContainingHooks();
-        } catch (IOException | URISyntaxException e) {
-            LOGGER.warn("An error has occurred when trying to scan for hook.", e);
+    public Future<Set<Class<?>>> scanForHooks(Vertx vertx) {
+        return scanForClassesContainingHooks(vertx).otherwise(throwable -> {
+            LOGGER.warn("An error has occurred when trying to scan for hook.", throwable);
             return Set.of();
-        }
+        });
     }
 
     @VisibleForTesting
-    Set<Class<?>> scanForClassesContainingHooks() throws IOException, URISyntaxException {
+    Future<Set<Class<?>>> scanForClassesContainingHooks(Vertx vertx) {
         ClassPathScanner scanner = new ClassPathScanner(classLoader);
 
-        Collection<String> hookClassesWithAnnotations =
-                scanner.scanForAnnotation(List.of(Hook.class, Hooks.class), ElementType.METHOD);
-        LOGGER.info("Annotated hook classes on classpath {}.", String.join(",", hookClassesWithAnnotations));
-
+        Future<List<String>> hookClassesWithAnnotations =
+                scanner.scanForAnnotation(vertx, List.of(Hook.class, Hooks.class), ElementType.METHOD);
         // add .class, because Hooks are only the FQN
-        Collection<String> hooksFromManifest = scanner.scanManifestFiles("NeonBee-Hooks").stream()
-                .map(name -> name + ".class").collect(Collectors.toList());
-        LOGGER.info("Hook classes from manifest files on classpath {}.", String.join(", ", hooksFromManifest));
+        Future<List<String>> hooksFromManifest = scanner.scanManifestFiles(vertx, NEONBEE_HOOKS)
+                .map(names -> names.stream().map(name -> name + ".class").collect(Collectors.toList()));
 
-        // Use distinct because the hook mentioned in the manifest could also exist as file.
-        return Streams.concat(hookClassesWithAnnotations.stream()).filter(Objects::nonNull).distinct()
-                .map(className -> {
-                    try {
-                        return (Class<?>) classLoader.loadClass(className);
-                    } catch (ClassNotFoundException e) {
-                        // Should never happen, since the class name is read from the class path
-                        throw new IllegalStateException(e);
-                    }
-                }).collect(Collectors.toSet());
+        return CompositeFuture.all(hookClassesWithAnnotations, hooksFromManifest)
+                .compose(compositeResult -> vertx.executeBlocking(promise -> {
+                    LOGGER.info("Annotated hook classes on classpath {}.",
+                            String.join(",", hookClassesWithAnnotations.result()));
+                    LOGGER.info("Hook classes from manifest files on classpath {}.",
+                            String.join(", ", hooksFromManifest.result()));
+
+                    // Use distinct because the hook mentioned in the manifest could also exist as file.
+                    promise.complete(Streams
+                            .concat(hookClassesWithAnnotations.result().stream(), hooksFromManifest.result().stream())
+                            .filter(Objects::nonNull).distinct().map(className -> {
+                                try {
+                                    return (Class<?>) classLoader.loadClass(className);
+                                } catch (ClassNotFoundException e) {
+                                    // Should never happen, since the class name is read from the class path
+                                    throw new IllegalStateException(e);
+                                }
+                            }).collect(Collectors.toSet()));
+                }));
     }
 }

--- a/src/test/java/io/neonbee/internal/scanner/ClassPathScannerTest.java
+++ b/src/test/java/io/neonbee/internal/scanner/ClassPathScannerTest.java
@@ -7,7 +7,6 @@ import static java.lang.annotation.ElementType.TYPE;
 
 import java.beans.Transient;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -19,15 +18,24 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.google.common.collect.Streams;
-import io.neonbee.internal.BasicJar;
 
+import io.neonbee.internal.BasicJar;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
 class ClassPathScannerTest {
+    Vertx vertx = Vertx.vertx();
 
     @Test
     @DisplayName("Should find passed attribute in all Manifest files")
-    void scanManifestFilesTest() throws IOException {
+    void scanManifestFilesTest(VertxTestContext testContext) throws IOException {
         String attribute1Name = "Attr1";
         String attribute2Name = "Attr2";
         List<String> manifest1Attribute1Values = List.of("M1A1V1", "M1A1V2");
@@ -48,40 +56,50 @@ class ClassPathScannerTest {
         List<String> expected = Streams.concat(manifest1Attribute1Values.stream(), manifest2Attribute1Values.stream())
                 .collect(Collectors.toList());
 
-        assertThat(new ClassPathScanner(urlc).scanManifestFiles(attribute1Name)).containsExactlyElementsIn(expected);
+        new ClassPathScanner(urlc).scanManifestFiles(vertx, attribute1Name)
+                .onComplete(testContext.succeeding(list -> testContext.verify(() -> {
+                    assertThat(list).containsExactlyElementsIn(expected);
+                    testContext.completeNow();
+                })));
     }
 
     @Test
     @DisplayName("Should find files on the class path that match the passed prediction")
-    void scanWithPredicateTest() throws IOException {
+    void scanWithPredicateTest(VertxTestContext testContext) throws IOException {
         List<String> expected = List.of(ClassPathScanner.class.getName().replace(".", "/") + ".class",
                 ClassPathScannerTest.class.getName().replace(".", "/") + ".class");
 
-        List<String> paths = new ClassPathScanner(ClassLoader.getSystemClassLoader()).scanWithPredicate(name -> {
-            return name.startsWith(ClassPathScanner.class.getName().replace(".", "/"));
-        });
-        paths.forEach(path -> {
-            assertThat(expected.stream().anyMatch(path::endsWith)).isTrue();
-        });
+        new ClassPathScanner(ClassLoader.getSystemClassLoader())
+                .scanWithPredicate(vertx, name -> name.startsWith(ClassPathScanner.class.getName().replace(".", "/")))
+                .onComplete(testContext.succeeding(paths -> testContext.verify(() -> {
+                    paths.forEach(path -> {
+                        assertThat(expected.stream().anyMatch(path::endsWith)).isTrue();
+                    });
+                    testContext.completeNow();
+                })));
+
     }
 
     @Test
     @DisplayName("Should find files on the class path that are inside of a JAR file")
-    void scanWithPredicateJarFile() throws IOException, URISyntaxException {
+    void scanWithPredicateJarFile(VertxTestContext testContext) throws IOException, URISyntaxException {
         String ressourceToFind = "MyCoolResource";
         byte[] dummyContent = "lol".getBytes(StandardCharsets.UTF_8);
         BasicJar bj = new BasicJar(Map.of(ressourceToFind, dummyContent, "somethingElse", dummyContent));
         URLClassLoader urlc = new URLClassLoader(bj.writeToTempURL(), ClassLoader.getSystemClassLoader());
 
         String expectedUriString = urlc.getResource(ressourceToFind).toURI().toString().replace("file:/", "file:///");
-        List<URI> uris = new ClassPathScanner(urlc).scanJarFilesWithPredicate(name -> name.startsWith(ressourceToFind));
-        assertThat(uris).hasSize(1);
-        assertThat(uris.get(0).toString()).isEqualTo(expectedUriString);
+        new ClassPathScanner(urlc).scanJarFilesWithPredicate(vertx, name -> name.startsWith(ressourceToFind))
+                .onComplete(testContext.succeeding(uris -> testContext.verify(() -> {
+                    assertThat(uris).hasSize(1);
+                    assertThat(uris.get(0).toString()).isEqualTo(expectedUriString);
+                    testContext.completeNow();
+                })));
     }
 
     @Test
     @DisplayName("Should find classes which the class or any field or method within is annotated with a given annotation")
-    void scanForAnnotation() throws IOException, URISyntaxException {
+    void scanForAnnotation(VertxTestContext testContext) throws IOException, URISyntaxException {
         BasicJar jarWithTypeAnnotatedClass =
                 new AnnotatedClassTemplate("Hodor", "type").setTypeAnnotation("@Deprecated").asJar();
         BasicJar jarWithFieldAnnotatedClass =
@@ -98,13 +116,29 @@ class ClassPathScannerTest {
                 .flatMap(Stream::of).toArray(URL[]::new);
         ClassPathScanner cps = new ClassPathScanner(new URLClassLoader(urlc, null));
 
-        assertThat(cps.scanForAnnotation(Deprecated.class, TYPE)).containsExactly("type.Hodor");
-        assertThat(cps.scanForAnnotation(Deprecated.class, FIELD)).containsExactly("field.Hodor");
-        assertThat(cps.scanForAnnotation(Deprecated.class, METHOD)).containsExactly("method.Hodor");
-        assertThat(cps.scanForAnnotation(Deprecated.class, TYPE, FIELD, METHOD)).containsExactly("type.Hodor",
-                "field.Hodor", "method.Hodor");
+        Checkpoint annotationsScanned = testContext.checkpoint(5);
 
-        assertThat(cps.scanForAnnotation(List.of(Transient.class, Deprecated.class), METHOD))
-                .containsExactly("method.Hodor2", "method.Hodor");
+        futureContainsExactly(testContext, annotationsScanned, cps.scanForAnnotation(vertx, Deprecated.class, TYPE),
+                "type.Hodor");
+
+        futureContainsExactly(testContext, annotationsScanned, cps.scanForAnnotation(vertx, Deprecated.class, FIELD),
+                "field.Hodor");
+        futureContainsExactly(testContext, annotationsScanned, cps.scanForAnnotation(vertx, Deprecated.class, METHOD),
+                "method.Hodor");
+        futureContainsExactly(testContext, annotationsScanned,
+                cps.scanForAnnotation(vertx, Deprecated.class, TYPE, FIELD, METHOD), "type.Hodor", "field.Hodor",
+                "method.Hodor");
+
+        futureContainsExactly(testContext, annotationsScanned,
+                cps.scanForAnnotation(vertx, List.of(Transient.class, Deprecated.class), METHOD), "method.Hodor2",
+                "method.Hodor");
+    }
+
+    private static void futureContainsExactly(VertxTestContext testContext, Checkpoint checkpoint,
+            Future<List<String>> future, Object... varargs) {
+        future.onComplete(testContext.succeeding(list -> testContext.verify(() -> {
+            assertThat(list).containsExactly(varargs);
+            checkpoint.flag();
+        })));
     }
 }


### PR DESCRIPTION
Followed by the the DeployableScanner and the HookScanner, resulting in unblocking NeonBeeModule, the EntityModelManager and the NeonBee bootstrap overall.

Nicer implementation of closing the NeonBeeModule's associated SelfFirstClassLoader and fixing a bug in the HookScanner, which previously ignored hooks in the manifest file.