### PR TITLE
fix: rephrase error handler properties in config

### DIFF
--- a/resources/config/io.neonbee.internal.verticle.ServerVerticle.example.yaml
+++ b/resources/config/io.neonbee.internal.verticle.ServerVerticle.example.yaml
@@ -34,7 +34,7 @@ config:
     # the maximum initial line length of the HTTP header (e.g. "GET / HTTP/1.0"), defaults to 4096 bytes
     maxInitialLineLength: 4096
 
-    # configure the error handler. If not specified, defaults to io.neonbee.internal.handler.ErrorHandler
+    # configure the error handler. If not specified, defaults to io.neonbee.internal.handler.DefaultErrorHandler
     errorHandler: io.neonbee.internal.handler.DefaultErrorHandler
 
     # specific endpoint configuration, defaults to the object seen below

--- a/src/main/java/io/neonbee/config/ServerConfig.java
+++ b/src/main/java/io/neonbee/config/ServerConfig.java
@@ -196,7 +196,8 @@ public class ServerConfig extends HttpServerOptions {
             .map(endpointClass -> new EndpointConfig().setType(endpointClass.getName())).collect(Collectors.toList()));
 
     private static final ImmutableBiMap<String, String> REPHRASE_MAP =
-            ImmutableBiMap.of("endpointConfigs", "endpoints", "authChainConfig", "authenticationChain");
+            ImmutableBiMap.of("endpointConfigs", "endpoints", "authChainConfig", "authenticationChain",
+                    "errorHandlerClassName", "errorHandler", "errorHandlerTemplate", "errorTemplate");
 
     private int timeout = DEFAULT_TIMEOUT;
 

--- a/src/test/java/io/neonbee/config/ServerConfigTest.java
+++ b/src/test/java/io/neonbee/config/ServerConfigTest.java
@@ -37,6 +37,9 @@ import io.vertx.core.net.TrustOptions;
 import io.vertx.core.tracing.TracingPolicy;
 
 class ServerConfigTest {
+    private static final String ERROR_HANDLER = "io.neonbee.CustomErrorHandler";
+
+    private static final String ERROR_TEMPLATE = "custom-template.html";
 
     @Test
     @DisplayName("test toJson")
@@ -55,11 +58,13 @@ class ServerConfigTest {
         sc.setTimeout(timeout).setSessionHandling(sessionHandling).setSessionCookieName(sessionCookieName);
         sc.setCorrelationStrategy(correlationStrategy).setTimeoutStatusCode(timeoutStatusCode);
         sc.setEndpointConfigs(endpointConfigs).setAuthChainConfig(authHandlerConfig);
+        sc.setErrorHandlerClassName(ERROR_HANDLER).setErrorHandlerTemplate(ERROR_TEMPLATE);
 
         JsonObject expected = new JsonObject().put("timeout", timeout).put("sessionHandling", sessionHandling.name());
         expected.put("sessionCookieName", sessionCookieName).put("correlationStrategy", correlationStrategy.name());
         expected.put("timeoutStatusCode", timeoutStatusCode).put("endpoints", new JsonArray().add(epc.toJson()));
         expected.put("authenticationChain", new JsonArray().add(ahc.toJson()));
+        expected.put("errorHandler", ERROR_HANDLER).put("errorTemplate", ERROR_TEMPLATE);
 
         assertThat(sc.toJson()).containsAtLeastElementsIn(expected);
     }
@@ -79,6 +84,8 @@ class ServerConfigTest {
         json.put("sessionCookieName", sessionCookieName).put("correlationStrategy", correlationStrategy.name());
         json.put("timeoutStatusCode", timeoutStatusCode).put("endpoints", new JsonArray().add(epc.toJson()));
         json.put("authenticationChain", new JsonArray().add(ahc.toJson()));
+        json.put("errorHandler", ERROR_HANDLER);
+        json.put("errorTemplate", ERROR_TEMPLATE);
 
         ServerConfig sc = new ServerConfig(json);
         assertThat(sc.getTimeout()).isEqualTo(timeout);
@@ -88,6 +95,8 @@ class ServerConfigTest {
         assertThat(sc.getTimeoutStatusCode()).isEqualTo(timeoutStatusCode);
         assertThat(sc.getEndpointConfigs()).contains(epc);
         assertThat(sc.getAuthChainConfig()).contains(ahc);
+        assertThat(sc.getErrorHandlerClassName()).isEqualTo(ERROR_HANDLER);
+        assertThat(sc.getErrorHandlerTemplate()).isEqualTo(ERROR_TEMPLATE);
     }
 
     @Test
@@ -131,6 +140,12 @@ class ServerConfigTest {
         List<AuthHandlerConfig> authHandlerConfig = List.of(new AuthHandlerConfig());
         assertThat(sc.setAuthChainConfig(authHandlerConfig)).isSameInstanceAs(sc);
         assertThat(sc.getAuthChainConfig()).containsExactlyElementsIn(authHandlerConfig);
+
+        assertThat(sc.setErrorHandlerClassName(ERROR_HANDLER)).isSameInstanceAs(sc);
+        assertThat(sc.getErrorHandlerClassName()).isEqualTo(ERROR_HANDLER);
+
+        assertThat(sc.setErrorHandlerTemplate(ERROR_TEMPLATE)).isSameInstanceAs(sc);
+        assertThat(sc.getErrorHandlerTemplate()).isEqualTo(ERROR_TEMPLATE);
     }
 
     @Test


### PR DESCRIPTION
With this fix, the properties `errorHandler` and `errorTemplate`, which
can be configured in the ServerVerticle config, will be working again. A
regression in the ServerConfig caused that these properties are ignored.