### PR TITLE
build(deps): bump com.sap.cds:cds4j-core from 1.19.0 to 1.22.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     }
     implementation group: 'org.apache.olingo', name: 'odata-server-core-ext', version: olingo_version
 
-    implementation group: 'com.sap.cds', name: 'cds4j-core', version: '1.19.0'
+    implementation group: 'com.sap.cds', name: 'cds4j-core', version: '1.22.1'
     implementation group: 'io.micrometer', name: 'micrometer-registry-prometheus', version: '1.3.1'
     implementation group: 'org.ow2.asm', name: 'asm', version: '7.2'
 


### PR DESCRIPTION
build(deps): Bump com.sap.cds:cds4j-core dependency to 1.22.1 (latest available version) to get rid of CVE in transitive dependency net.minidev:json-smart:2.3 CVE-2021-27568.