### PR TITLE
chore: bump jacoco tool version and update deprecated config prop

### DIFF
--- a/gradle/codeCoverage.gradle
+++ b/gradle/codeCoverage.gradle
@@ -1,6 +1,6 @@
 jacoco {
-    toolVersion = '0.8.5'
-    reportsDir = file("${buildDir}/reports/jacoco")
+    toolVersion = '0.8.7'
+    reportsDirectory = file("${buildDir}/reports/jacoco")
 }
 
 consoleReporter {


### PR DESCRIPTION
Bump jacoco tool version from 0.8.5 to 0.8.7. Furthermore as jacoco's
"reportsDir" property is deprecated it is now updated to
"reportsDirectory" as mentioned in the documentation (see [1]).

[1] https://docs.gradle.org/current/userguide/jacoco_plugin.html#sec:configuring_the_jacoco_plugin