### PR TITLE
feat: offer a new ErrorHandler which can be initialized asynchronously

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,7 +191,8 @@ clean {
 // ############ Test Phase
 
 test {
-    if (!org.gradle.nativeplatform.platform.internal.DefaultNativePlatform.getCurrentOperatingSystem().isMacOsX()) {
+    // deactivate parallel execution of tests temporary until parallel execution works again
+    if (false && !org.gradle.nativeplatform.platform.internal.DefaultNativePlatform.getCurrentOperatingSystem().isMacOsX()) {
         systemProperties = [
             'junit.jupiter.execution.parallel.enabled' : 'true',
             'junit.jupiter.execution.parallel.mode.default' : 'concurrent',

--- a/src/main/java/io/neonbee/NeonBee.java
+++ b/src/main/java/io/neonbee/NeonBee.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 
 import io.neonbee.config.NeonBeeConfig;
+import io.neonbee.config.ServerConfig;
 import io.neonbee.data.DataQuery;
 import io.neonbee.entity.EntityWrapper;
 import io.neonbee.hook.HookRegistry;
@@ -590,6 +591,15 @@ public class NeonBee {
      */
     public void unregisterLocalConsumer(String verticleAddress) {
         localConsumers.remove(verticleAddress);
+    }
+
+    /**
+     * Returns the ServerConfig if NeonBee is started with WEB profile.
+     *
+     * @return the ServerConfig or null if ServerVerticle is not started.
+     */
+    public ServerConfig getServerConfig() {
+        return new ServerConfig((JsonObject) getLocalMap().get(ServerVerticle.SERVER_CONFIG_KEY));
     }
 
     /**

--- a/src/main/java/io/neonbee/handler/ErrorHandler.java
+++ b/src/main/java/io/neonbee/handler/ErrorHandler.java
@@ -1,0 +1,21 @@
+package io.neonbee.handler;
+
+import io.neonbee.NeonBee;
+import io.vertx.core.Future;
+
+/**
+ * The class which implements this interface MUST have a default constructor. Otherwise NeonBee can't instantiate the
+ * class during bootstrap phase.
+ */
+@SuppressWarnings("NM_SAME_SIMPLE_NAME_AS_INTERFACE")
+public interface ErrorHandler extends io.vertx.ext.web.handler.ErrorHandler {
+
+    /**
+     * The purpose of this method is to offer the possibility to also executed blocking code during the initialization
+     * of the ErrorHandler. This is beneficial in case that the error template needs to be read from a database or file.
+     *
+     * @param neonBee The related NeonBee instance
+     * @return a Future with a reference of this ErrorHandler
+     */
+    Future<ErrorHandler> initialize(NeonBee neonBee);
+}

--- a/src/main/java/io/neonbee/internal/helper/BufferHelper.java
+++ b/src/main/java/io/neonbee/internal/helper/BufferHelper.java
@@ -1,10 +1,7 @@
 package io.neonbee.internal.helper;
 
-import static io.neonbee.internal.scanner.ClassPathScanner.getClassLoader;
-
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.NoSuchFileException;
 
 import io.vertx.core.buffer.Buffer;
 
@@ -45,26 +42,6 @@ public final class BufferHelper {
         }
 
         return buffer;
-    }
-
-    /**
-     * Read a given resource into a buffer.
-     *
-     * @param resource The resource to read
-     * @return a Vert.x {@link Buffer}
-     * @throws IOException in case of an issue whilst reading the resource
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
-            justification = "False positive in Spotbugs, see https://github.com/spotbugs/spotbugs/issues/1338")
-    public static Buffer readResourceToBuffer(String resource) throws IOException {
-        ClassLoader classLoader = getClassLoader();
-        try (InputStream input = classLoader.getResourceAsStream(resource)) {
-            if (input == null) {
-                throw new NoSuchFileException(resource);
-            }
-
-            return inputStreamToBuffer(input);
-        }
     }
 
     /**

--- a/src/test/java/io/neonbee/internal/handler/DefaultErrorHandlerTest.java
+++ b/src/test/java/io/neonbee/internal/handler/DefaultErrorHandlerTest.java
@@ -1,0 +1,38 @@
+package io.neonbee.internal.handler;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.neonbee.NeonBee;
+import io.neonbee.config.ServerConfig;
+import io.vertx.core.Vertx;
+import io.vertx.core.file.FileSystemException;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class DefaultErrorHandlerTest {
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    void testGetErrorHandlerDefault(Vertx vertx, VertxTestContext testContext) throws Exception {
+        NeonBee neonBee = mock(NeonBee.class);
+        ServerConfig config = mock(ServerConfig.class);
+        when(config.getErrorHandlerTemplate()).thenReturn("Hodor");
+        when(neonBee.getServerConfig()).thenReturn(config);
+        when(neonBee.getVertx()).thenReturn(vertx);
+
+        new DefaultErrorHandler().initialize(neonBee).onComplete(testContext.failing(t -> testContext.verify(() -> {
+            assertThat(t).isInstanceOf(FileSystemException.class);
+            assertThat(t).hasMessageThat().contains("Hodor");
+            testContext.completeNow();
+        })));
+    }
+}


### PR DESCRIPTION
A class that implements the new ErrorHandler interface MUST have a
default constructor. Otherwise NeonBee can't instantiate the class
during bootstrap phase.

The purpose of the initialize method is to allow the execution of
blocking code.