### PR TITLE
feat: move MetricOptions to NeonBeeOptions

### DIFF
--- a/src/main/java/io/neonbee/NeonBee.java
+++ b/src/main/java/io/neonbee/NeonBee.java
@@ -73,8 +73,6 @@ import io.vertx.core.impl.ConcurrentHashSet;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.AsyncMap;
 import io.vertx.core.shareddata.LocalMap;
-import io.vertx.micrometer.MicrometerMetricsOptions;
-import io.vertx.micrometer.VertxPrometheusOptions;
 import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
 
 public class NeonBee {
@@ -254,8 +252,7 @@ public class NeonBee {
     @VisibleForTesting
     static Future<Vertx> newVertx(NeonBeeOptions options) {
         VertxOptions vertxOptions = new VertxOptions().setEventLoopPoolSize(options.getEventLoopPoolSize())
-                .setWorkerPoolSize(options.getWorkerPoolSize()).setMetricsOptions(new MicrometerMetricsOptions()
-                        .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true)).setEnabled(true));
+                .setWorkerPoolSize(options.getWorkerPoolSize()).setMetricsOptions(options.getMetricsOptions());
 
         if (!options.isClustered()) {
             return succeededFuture(Vertx.vertx(vertxOptions));

--- a/src/main/java/io/neonbee/NeonBeeOptions.java
+++ b/src/main/java/io/neonbee/NeonBeeOptions.java
@@ -19,8 +19,18 @@ import io.neonbee.internal.verticle.WatchVerticle;
 import io.neonbee.job.JobVerticle;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.eventbus.EventBusOptions;
+import io.vertx.core.metrics.MetricsOptions;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.VertxPrometheusOptions;
 
 public interface NeonBeeOptions {
+    /**
+     * Get the {@link MetricsOptions}.
+     *
+     * @return the {@link MetricsOptions}
+     */
+    MetricsOptions getMetricsOptions();
+
     /**
      * Get the maximum number of worker threads to be used by the NeonBee instance.
      * <p>
@@ -181,11 +191,30 @@ public interface NeonBeeOptions {
 
         private Set<NeonBeeProfile> activeProfiles = Set.of(ALL);
 
+        private MetricsOptions metricsOptions = new MicrometerMetricsOptions()
+                .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true)).setEnabled(true);
+
         /**
          * Instantiates a mutable {@link NeonBeeOptions} instance.
          */
         public Mutable() {
             instanceName = generateName();
+        }
+
+        /**
+         * Set the {@link MetricsOptions}.
+         *
+         * @param metricsOptions the {@link MetricsOptions}
+         * @return a reference to this, so the API can be used fluently
+         */
+        public Mutable setMetricsOptions(MetricsOptions metricsOptions) {
+            this.metricsOptions = metricsOptions;
+            return this;
+        }
+
+        @Override
+        public MetricsOptions getMetricsOptions() {
+            return this.metricsOptions;
         }
 
         @Override

--- a/src/test/java/io/neonbee/NeonBeeOptionsTest.java
+++ b/src/test/java/io/neonbee/NeonBeeOptionsTest.java
@@ -21,6 +21,8 @@ import io.neonbee.NeonBeeOptions.Mutable;
 import io.neonbee.test.helper.FileSystemHelper;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.eventbus.EventBusOptions;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.VertxPrometheusOptions;
 
 class NeonBeeOptionsTest {
     @Test
@@ -171,5 +173,19 @@ class NeonBeeOptionsTest {
 
         mutable = new NeonBeeOptions.Mutable().setClusterConfig(localConfig);
         assertThat(mutable.getClusterConfig().getNetworkConfig().getPort()).isEqualTo(20000);
+    }
+
+    @Test
+    @DisplayName("Test MetricsOptions getter and setter")
+    void test() {
+        NeonBeeOptions.Mutable mutable = new NeonBeeOptions.Mutable();
+        assertThat(mutable.getMetricsOptions()).isInstanceOf(MicrometerMetricsOptions.class);
+
+        MicrometerMetricsOptions mmo = (MicrometerMetricsOptions) mutable.getMetricsOptions();
+        assertThat(mmo.getPrometheusOptions()).isInstanceOf(VertxPrometheusOptions.class);
+        assertThat(mmo.isEnabled()).isTrue();
+
+        mutable.setMetricsOptions(null);
+        assertThat(mutable.getMetricsOptions()).isNull();
     }
 }


### PR DESCRIPTION
By moving the MetricOptions to the NeonBeeOptions, we are able to change the MetricOptions in a LauncherPreProcessor.