### PR TITLE
feat: make usage of createQualifiedName more resilient

### DIFF
--- a/src/main/java/io/neonbee/data/DataVerticle.java
+++ b/src/main/java/io/neonbee/data/DataVerticle.java
@@ -17,6 +17,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -342,7 +343,7 @@ public abstract class DataVerticle<T> extends AbstractVerticle implements DataAd
      * @return Qualified name of namespace and verticle name
      */
     public static String createQualifiedName(String namespace, String verticleName) {
-        return String.format("%s/%s", namespace, verticleName);
+        return String.format("%s/%s", namespace.toLowerCase(Locale.ROOT), verticleName);
     }
 
     /**

--- a/src/test/java/io/neonbee/data/DataVerticleTest.java
+++ b/src/test/java/io/neonbee/data/DataVerticleTest.java
@@ -121,6 +121,7 @@ class DataVerticleTest extends DataVerticleTestBase {
     @Test
     void createQualifiedName() {
         assertThat(DataVerticle.createQualifiedName("namespace", "verticle")).isEqualTo("namespace/verticle");
+        assertThat(DataVerticle.createQualifiedName("nameSpace", "verticle")).isEqualTo("namespace/verticle");
     }
 
     private static class DataVerticleImpl0 extends DataVerticle<String> {


### PR DESCRIPTION
When defining a name space via annotation, it is automatically casted to
lower case. Now createQualifiedName follows the same rules by casting
passed name spaces automatically to lower case.