### PR TITLE
feat: add custom micrometer registries via NeonBeeConfig

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     testImplementation group: 'com.google.truth.extensions', name: 'truth-java8-extension', version: truth_version
 
     def mockito_version = '4.2.0'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: mockito_version
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version: mockito_version
     testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: mockito_version
 
     def jupiter_version = '5.8.2'

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,70 @@
+# Metrics Concept
+
+## Content
+
+- [Metrics](#Metrics)
+  - [configure additional metrics registries](#configure-additional-metrics-registries)
+    - [when launching NeonBee](#when-launching-NeonBee)
+    - [during runtime](#during-runtime)
+  - [add metrics to your code](#add-metrics-to-your-code)
+
+
+## Metrics
+In NeonBee, Micrometer is used to provide reporting to various backends. Micrometer provides a facade for the most
+common monitoring systems.
+Micrometer `MeterRegistry` objects can be registered at runtime. For this purpose, a `CompositeMeterRegistry` is added in
+the `VertxOptions`. Additional `MeterRegistry` can be added to this `CompositeMeterRegistry` at runtime.
+
+The `MetricsEndpoint`, which by default provides the Prometheus metrics under the /metrics path, registers the
+`PrometheusMeterRegistry` when the `MetricsEndpoint` router is created.
+
+## configure additional metrics registries
+### when launching NeonBee
+To register own Micrometer MeterRegistry interface `MicrometerRegistryLoader` must be implemented
+and the implementing class must be specified in the configuration `io.neonbee.NeonBee.yaml` in the `micrometerRegistries`
+array.
+
+Example MicrometerRegistryLoader implementation:
+```java
+package io.neonbee.config.examples;
+
+import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
+import io.neonbee.config.metrics.MicrometerRegistryLoader;
+
+public static class LoggingMeterMicrometerRegistryLoader implements MicrometerRegistryLoader {
+    @Override
+    public MeterRegistry load(JsonObject config) {
+        return new LoggingMeterRegistry();
+    }
+}
+```
+
+Example io.neonbee.NeonBee.yaml configuration:
+```yaml
+---
+  // Omitted other configuration values
+  micrometerRegistries:
+  - className: io.neonbee.config.examples.LoggingMeterMicrometerRegistryLoader
+    config:
+      key: value
+```
+
+### during runtime
+If you want to add a MeterRegistry during runtime, you can do it using the `NeonBeeConfig#getCompositeMeterRegistry()`
+method.
+
+```java
+MeterRegistry yourRegistry; // Your registry to be added.
+CompositeMeterRegistry compositeMeterRegistry = NeonBee.get(vertx).getConfig().getCompositeMeterRegistry();
+compositeMeterRegistry.add(yourRegistry);
+```
+## add metrics to your code
+
+To provide metrics in your code, here is an example of a counter:
+```java
+MeterRegistry registry = BackendRegistries.getDefaultNow();
+Counter counter = registry.counter("TestEndpointCounter", "TestTag1", "TestValue");
+counter.increment();
+count = counter.count();
+```
+For more information, see [user defined metrics](https://vertx.io/docs/vertx-micrometer-metrics/java/#_user_defined_metrics)

--- a/src/generated/java/io/neonbee/config/MicrometerRegistryConfigConverter.java
+++ b/src/generated/java/io/neonbee/config/MicrometerRegistryConfigConverter.java
@@ -1,0 +1,47 @@
+package io.neonbee.config;
+
+import java.util.Base64;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.impl.JsonUtil;
+
+/**
+ * Converter and mapper for {@link io.neonbee.config.MicrometerRegistryConfig}. NOTE: This class has been automatically
+ * generated from the {@link io.neonbee.config.MicrometerRegistryConfig} original class using Vert.x codegen.
+ */
+public class MicrometerRegistryConfigConverter {
+
+    private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
+
+    private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+
+    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, MicrometerRegistryConfig obj) {
+        for (java.util.Map.Entry<String, Object> member : json) {
+            switch (member.getKey()) {
+            case "className":
+                if (member.getValue() instanceof String) {
+                    obj.setClassName((String) member.getValue());
+                }
+                break;
+            case "config":
+                if (member.getValue() instanceof JsonObject) {
+                    obj.setConfig(((JsonObject) member.getValue()).copy());
+                }
+                break;
+            }
+        }
+    }
+
+    static void toJson(MicrometerRegistryConfig obj, JsonObject json) {
+        toJson(obj, json.getMap());
+    }
+
+    static void toJson(MicrometerRegistryConfig obj, java.util.Map<String, Object> json) {
+        if (obj.getClassName() != null) {
+            json.put("className", obj.getClassName());
+        }
+        if (obj.getConfig() != null) {
+            json.put("config", obj.getConfig());
+        }
+    }
+}

--- a/src/generated/java/io/neonbee/config/NeonBeeConfigConverter.java
+++ b/src/generated/java/io/neonbee/config/NeonBeeConfigConverter.java
@@ -34,6 +34,17 @@ public class NeonBeeConfigConverter {
                     obj.setEventBusTimeout(((Number) member.getValue()).intValue());
                 }
                 break;
+            case "micrometerRegistries":
+                if (member.getValue() instanceof JsonArray) {
+                    java.util.ArrayList<io.neonbee.config.MicrometerRegistryConfig> list = new java.util.ArrayList<>();
+                    ((Iterable<Object>) member.getValue()).forEach(item -> {
+                        if (item instanceof JsonObject)
+                            list.add(new io.neonbee.config.MicrometerRegistryConfig(
+                                    (io.vertx.core.json.JsonObject) item));
+                    });
+                    obj.setMicrometerRegistries(list);
+                }
+                break;
             case "platformClasses":
                 if (member.getValue() instanceof JsonArray) {
                     java.util.ArrayList<java.lang.String> list = new java.util.ArrayList<>();
@@ -69,6 +80,11 @@ public class NeonBeeConfigConverter {
             json.put("eventBusCodecs", map);
         }
         json.put("eventBusTimeout", obj.getEventBusTimeout());
+        if (obj.getMicrometerRegistries() != null) {
+            JsonArray array = new JsonArray();
+            obj.getMicrometerRegistries().forEach(item -> array.add(item.toJson()));
+            json.put("micrometerRegistries", array);
+        }
         if (obj.getPlatformClasses() != null) {
             JsonArray array = new JsonArray();
             obj.getPlatformClasses().forEach(item -> array.add(item));

--- a/src/main/java/io/neonbee/NeonBeeOptions.java
+++ b/src/main/java/io/neonbee/NeonBeeOptions.java
@@ -19,18 +19,8 @@ import io.neonbee.internal.verticle.WatchVerticle;
 import io.neonbee.job.JobVerticle;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.eventbus.EventBusOptions;
-import io.vertx.core.metrics.MetricsOptions;
-import io.vertx.micrometer.MicrometerMetricsOptions;
-import io.vertx.micrometer.VertxPrometheusOptions;
 
 public interface NeonBeeOptions {
-    /**
-     * Get the {@link MetricsOptions}.
-     *
-     * @return the {@link MetricsOptions}
-     */
-    MetricsOptions getMetricsOptions();
-
     /**
      * Get the maximum number of worker threads to be used by the NeonBee instance.
      * <p>
@@ -191,30 +181,11 @@ public interface NeonBeeOptions {
 
         private Set<NeonBeeProfile> activeProfiles = Set.of(ALL);
 
-        private MetricsOptions metricsOptions = new MicrometerMetricsOptions()
-                .setPrometheusOptions(new VertxPrometheusOptions().setEnabled(true)).setEnabled(true);
-
         /**
          * Instantiates a mutable {@link NeonBeeOptions} instance.
          */
         public Mutable() {
             instanceName = generateName();
-        }
-
-        /**
-         * Set the {@link MetricsOptions}.
-         *
-         * @param metricsOptions the {@link MetricsOptions}
-         * @return a reference to this, so the API can be used fluently
-         */
-        public Mutable setMetricsOptions(MetricsOptions metricsOptions) {
-            this.metricsOptions = metricsOptions;
-            return this;
-        }
-
-        @Override
-        public MetricsOptions getMetricsOptions() {
-            return this.metricsOptions;
         }
 
         @Override

--- a/src/main/java/io/neonbee/config/MicrometerRegistryConfig.java
+++ b/src/main/java/io/neonbee/config/MicrometerRegistryConfig.java
@@ -1,0 +1,79 @@
+package io.neonbee.config;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.core.json.JsonObject;
+
+@DataObject(generateConverter = true, publicConverter = false)
+public class MicrometerRegistryConfig {
+    private String className;
+
+    private JsonObject config = new JsonObject();
+
+    /**
+     * Creates a {@linkplain MicrometerRegistryConfig}.
+     */
+    public MicrometerRegistryConfig() {}
+
+    /**
+     * Creates a {@linkplain MicrometerRegistryConfig} parsing a given JSON object.
+     *
+     * @param json the JSON object to parse
+     */
+    public MicrometerRegistryConfig(JsonObject json) {
+        MicrometerRegistryConfigConverter.fromJson(json, this);
+    }
+
+    /**
+     * Transforms this configuration object into JSON.
+     *
+     * @return a JSON representation of this configuration
+     */
+    public JsonObject toJson() {
+        JsonObject json = new JsonObject();
+        MicrometerRegistryConfigConverter.toJson(this, json);
+        return json;
+    }
+
+    /**
+     * Get the class name.
+     *
+     * @return the class name
+     */
+    public String getClassName() {
+        return className;
+    }
+
+    /**
+     * The name of the class.
+     *
+     * @param className the name of the class
+     * @return the {@linkplain MicrometerRegistryConfig} for fluent use
+     */
+    @Fluent
+    public MicrometerRegistryConfig setClassName(String className) {
+        this.className = className;
+        return this;
+    }
+
+    /**
+     * Get the configuration.
+     *
+     * @return the configuration
+     */
+    public JsonObject getConfig() {
+        return config;
+    }
+
+    /**
+     * Set the configuration.
+     *
+     * @param config the configuration
+     * @return the {@linkplain MicrometerRegistryConfig} for fluent use
+     */
+    @Fluent
+    public MicrometerRegistryConfig setConfig(JsonObject config) {
+        this.config = config;
+        return this;
+    }
+}

--- a/src/main/java/io/neonbee/config/metrics/MicrometerRegistryLoader.java
+++ b/src/main/java/io/neonbee/config/metrics/MicrometerRegistryLoader.java
@@ -1,0 +1,22 @@
+package io.neonbee.config.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.vertx.core.json.JsonObject;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+
+/**
+ * Interface to implement if you want to add a {@link MeterRegistry} to the {@link MicrometerMetricsOptions}.
+ * <p>
+ * The implementing class MUST have a constructor without any arguments.
+ */
+@FunctionalInterface
+public interface MicrometerRegistryLoader {
+
+    /**
+     * This method is called to load the {@link MeterRegistry} Object.
+     *
+     * @param config the configuration as a {@link JsonObject}. The config object can be null.
+     * @return the {@link MeterRegistry} to add to the {@link MicrometerMetricsOptions}
+     */
+    MeterRegistry load(JsonObject config);
+}

--- a/src/main/java/io/neonbee/endpoint/metrics/NeonBeePrometheusMeterRegistry.java
+++ b/src/main/java/io/neonbee/endpoint/metrics/NeonBeePrometheusMeterRegistry.java
@@ -1,0 +1,16 @@
+package io.neonbee.endpoint.metrics;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.CollectorRegistry;
+
+class NeonBeePrometheusMeterRegistry extends PrometheusMeterRegistry {
+    NeonBeePrometheusMeterRegistry(PrometheusConfig config) {
+        super(config);
+    }
+
+    NeonBeePrometheusMeterRegistry(PrometheusConfig config, CollectorRegistry registry, Clock clock) {
+        super(config, registry, clock);
+    }
+}

--- a/src/main/java/io/neonbee/endpoint/metrics/PrometheusScrapingHandler.java
+++ b/src/main/java/io/neonbee/endpoint/metrics/PrometheusScrapingHandler.java
@@ -1,0 +1,63 @@
+package io.neonbee.endpoint.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.neonbee.logging.LoggingFacade;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.prometheus.client.exporter.common.TextFormat;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.micrometer.backends.BackendRegistries;
+import io.vertx.micrometer.impl.PrometheusScrapingHandlerImpl;
+
+/**
+ * A Vert.x Web {@link io.vertx.ext.web.Route} handler for Prometheus metrics scraping.
+ * <p>
+ * The original Implementation doesn't work with {@link CompositeMeterRegistry}. This implementation fixes this.
+ */
+public class PrometheusScrapingHandler extends PrometheusScrapingHandlerImpl {
+    private static final LoggingFacade LOGGER = LoggingFacade.create();
+
+    private final String registryName;
+
+    /**
+     * Constructs a new instance of NeonBeePrometheusHandler.
+     *
+     * @param registryName The name of the micrometer registry
+     */
+    public PrometheusScrapingHandler(String registryName) {
+        super(registryName);
+        this.registryName = registryName;
+    }
+
+    private static void noPrometheusMeterRegistryPresent(RoutingContext rc) {
+        LOGGER.warn("Could not find a PrometheusMeterRegistry in the CompositeMeterRegistry");
+        rc.response().setStatusCode(HttpResponseStatus.INTERNAL_SERVER_ERROR.code())
+                .setStatusMessage("Could not find a PrometheusMeterRegistry").end();
+    }
+
+    private static void handleWithPrometheusMeterRegistry(RoutingContext rc, PrometheusMeterRegistry pmr) {
+        rc.response().putHeader(HttpHeaders.CONTENT_TYPE, TextFormat.CONTENT_TYPE_004).end(pmr.scrape());
+    }
+
+    @Override
+    public void handle(RoutingContext rc) {
+        MeterRegistry meterRegistry;
+        if (registryName == null) {
+            meterRegistry = BackendRegistries.getDefaultNow();
+        } else {
+            meterRegistry = BackendRegistries.getNow(registryName);
+        }
+
+        if (meterRegistry instanceof CompositeMeterRegistry) {
+            CompositeMeterRegistry cmr = (CompositeMeterRegistry) meterRegistry;
+            cmr.getRegistries().stream().filter(registry -> registry instanceof NeonBeePrometheusMeterRegistry)
+                    .findAny().map(PrometheusMeterRegistry.class::cast)
+                    .ifPresentOrElse(pmr -> handleWithPrometheusMeterRegistry(rc, pmr),
+                            () -> noPrometheusMeterRegistryPresent(rc));
+        } else {
+            super.handle(rc);
+        }
+    }
+}

--- a/src/main/java/io/neonbee/internal/helper/ConfigHelper.java
+++ b/src/main/java/io/neonbee/internal/helper/ConfigHelper.java
@@ -89,7 +89,7 @@ public final class ConfigHelper {
     }
 
     /**
-     * Collects the additional configuration out of an configuration object.
+     * Collects the additional configuration out of a configuration object.
      *
      * What this method actually does is to extract all values of a configuration object, which are not part of a given
      * set of keys. The properties are then returned as a new (additional configuration) JSON object.

--- a/src/test/java/io/neonbee/NeonBeeMockHelper.java
+++ b/src/test/java/io/neonbee/NeonBeeMockHelper.java
@@ -14,6 +14,7 @@ import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.neonbee.config.NeonBeeConfig;
 import io.neonbee.test.helper.OptionsHelper;
 import io.neonbee.test.helper.ReflectionHelper;
@@ -134,7 +135,7 @@ public final class NeonBeeMockHelper {
      * @return the mocked NeonBee instance
      */
     public static Future<NeonBee> createNeonBee(Vertx vertx, NeonBeeOptions options) {
-        return NeonBee.create(() -> succeededFuture(vertx), options);
+        return NeonBee.create((vertxOptions) -> succeededFuture(vertx), options);
     }
 
     /**
@@ -196,7 +197,8 @@ public final class NeonBeeMockHelper {
     public static NeonBee registerNeonBeeMock(Vertx vertx, NeonBeeOptions options, NeonBeeConfig config) {
         createLogger(); // the logger is only created internally, create one manually if required
 
-        NeonBee neonBee = new NeonBee(vertx, Optional.ofNullable(options).orElseGet(OptionsHelper::defaultOptions));
+        NeonBee neonBee = new NeonBee(vertx, Optional.ofNullable(options).orElseGet(OptionsHelper::defaultOptions),
+                new CompositeMeterRegistry());
         if (config != null) {
             neonBee.config = config;
         }

--- a/src/test/java/io/neonbee/NeonBeeOptionsTest.java
+++ b/src/test/java/io/neonbee/NeonBeeOptionsTest.java
@@ -21,8 +21,6 @@ import io.neonbee.NeonBeeOptions.Mutable;
 import io.neonbee.test.helper.FileSystemHelper;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.eventbus.EventBusOptions;
-import io.vertx.micrometer.MicrometerMetricsOptions;
-import io.vertx.micrometer.VertxPrometheusOptions;
 
 class NeonBeeOptionsTest {
     @Test
@@ -173,19 +171,5 @@ class NeonBeeOptionsTest {
 
         mutable = new NeonBeeOptions.Mutable().setClusterConfig(localConfig);
         assertThat(mutable.getClusterConfig().getNetworkConfig().getPort()).isEqualTo(20000);
-    }
-
-    @Test
-    @DisplayName("Test MetricsOptions getter and setter")
-    void test() {
-        NeonBeeOptions.Mutable mutable = new NeonBeeOptions.Mutable();
-        assertThat(mutable.getMetricsOptions()).isInstanceOf(MicrometerMetricsOptions.class);
-
-        MicrometerMetricsOptions mmo = (MicrometerMetricsOptions) mutable.getMetricsOptions();
-        assertThat(mmo.getPrometheusOptions()).isInstanceOf(VertxPrometheusOptions.class);
-        assertThat(mmo.isEnabled()).isTrue();
-
-        mutable.setMetricsOptions(null);
-        assertThat(mutable.getMetricsOptions()).isNull();
     }
 }

--- a/src/test/java/io/neonbee/config/NeonBeeConfigTest.java
+++ b/src/test/java/io/neonbee/config/NeonBeeConfigTest.java
@@ -4,17 +4,27 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.neonbee.config.NeonBeeConfig.DEFAULT_EVENT_BUS_TIMEOUT;
 import static io.neonbee.config.NeonBeeConfig.DEFAULT_TIME_ZONE;
 import static io.neonbee.config.NeonBeeConfig.DEFAULT_TRACKING_DATA_HANDLING_STRATEGY;
+import static org.junit.Assert.assertThrows;
 
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.neonbee.config.metrics.MicrometerRegistryLoader;
 import io.neonbee.test.base.NeonBeeTestBase;
 import io.neonbee.test.helper.WorkingDirectoryBuilder;
 import io.vertx.core.Vertx;
@@ -34,10 +44,13 @@ class NeonBeeConfigTest extends NeonBeeTestBase {
 
     private static final List<String> DUMMY_PLATFORM_CLASSES = List.of("Hodor");
 
+    private static final List<MicrometerRegistryConfig> DUMMY_MICROMETER_REGISTRIES = List.of();
+
     private static final NeonBeeConfig DUMMY_NEONBEE_CONFIG =
             new NeonBeeConfig().setEventBusTimeout(DUMMY_EVENT_BUS_TIMEOUT)
                     .setTrackingDataHandlingStrategy(DUMMY_TRACKING_DATA_HANDLING_STRATEGY).setTimeZone(DUMMY_TIME_ZONE)
-                    .setEventBusCodecs(DUMMY_EVENT_BUS_CODECS).setPlatformClasses(DUMMY_PLATFORM_CLASSES);
+                    .setEventBusCodecs(DUMMY_EVENT_BUS_CODECS).setPlatformClasses(DUMMY_PLATFORM_CLASSES)
+                    .setMicrometerRegistries(DUMMY_MICROMETER_REGISTRIES);
 
     @Override
     protected WorkingDirectoryBuilder provideWorkingDirectoryBuilder(TestInfo testInfo, VertxTestContext testContext) {
@@ -46,6 +59,42 @@ class NeonBeeConfigTest extends NeonBeeTestBase {
         } else {
             return super.provideWorkingDirectoryBuilder(testInfo, testContext);
         }
+    }
+
+    @Test
+    @DisplayName("Test loading the MeterRegistry")
+    void testLoadingMeterRegistry() throws Exception {
+        NeonBeeConfig config = new NeonBeeConfig();
+        CompositeMeterRegistry registry = new CompositeMeterRegistry();
+        config.setMicrometerRegistries(List.of(new MicrometerRegistryConfig()
+                .setClassName(TestMicrometerRegistryLoaderImpl.class.getName()).setConfig(new JsonObject())));
+        config.createMicrometerRegistries().forEach(registry::add);
+        Set<MeterRegistry> registries = registry.getRegistries();
+        assertThat(registries).hasSize(1);
+        assertThat(registries.stream().anyMatch(PrometheusMeterRegistry.class::isInstance)).isTrue();
+    }
+
+    static Stream<Arguments> testNotImplementingMicrometerRegistryLoaderArguments() {
+        return Stream.of(
+                Arguments.of("java.lang.String",
+                        "java.lang.String must implement io.neonbee.config.metrics.MicrometerRegistryLoader",
+                        IllegalArgumentException.class),
+                Arguments.of("doesn't exist", "doesn't exist", ClassNotFoundException.class),
+                Arguments.of("io.neonbee.config.NeonBeeConfigTest$TestFaultyMicrometerRegistryLoaderImpl",
+                        "io.neonbee.config.NeonBeeConfigTest$TestFaultyMicrometerRegistryLoaderImpl.<init>()",
+                        NoSuchMethodException.class));
+    }
+
+    @ParameterizedTest(name = "{index}: {0} expected exception message: {1}")
+    @MethodSource("testNotImplementingMicrometerRegistryLoaderArguments")
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("Test MicrometerRegistryLoader with incorrect configuration")
+    void testNotImplementingMicrometerRegistryLoader(String className, String exceptionMessage,
+            Class expectedException) {
+        NeonBeeConfig config = new NeonBeeConfig();
+        config.setMicrometerRegistries(List.of(new MicrometerRegistryConfig().setClassName(className)));
+        Throwable throwable = assertThrows(expectedException, config::createMicrometerRegistries);
+        assertThat(throwable).hasMessageThat().isEqualTo(exceptionMessage);
     }
 
     @Test
@@ -104,5 +153,25 @@ class NeonBeeConfigTest extends NeonBeeTestBase {
         assertThat(nbc.getTimeZone()).isEqualTo(DUMMY_TIME_ZONE);
         assertThat(nbc.getEventBusCodecs()).isEqualTo(DUMMY_EVENT_BUS_CODECS);
         assertThat(nbc.getPlatformClasses()).isEqualTo(DUMMY_PLATFORM_CLASSES);
+        assertThat(nbc.getMicrometerRegistries()).isEqualTo(DUMMY_MICROMETER_REGISTRIES);
+    }
+
+    public static class TestMicrometerRegistryLoaderImpl implements MicrometerRegistryLoader {
+
+        @Override
+        public MeterRegistry load(JsonObject config) {
+            return new PrometheusMeterRegistry(config::getString);
+        }
+    }
+
+    public static class TestFaultyMicrometerRegistryLoaderImpl implements MicrometerRegistryLoader {
+
+        @SuppressWarnings("PMD.UnusedFormalParameter")
+        TestFaultyMicrometerRegistryLoaderImpl(String required) {}
+
+        @Override
+        public MeterRegistry load(JsonObject config) {
+            return new PrometheusMeterRegistry(config::getString);
+        }
     }
 }

--- a/src/test/java/io/neonbee/endpoint/metrics/NeonBeeMetricsTest.java
+++ b/src/test/java/io/neonbee/endpoint/metrics/NeonBeeMetricsTest.java
@@ -1,0 +1,117 @@
+package io.neonbee.endpoint.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.neonbee.NeonBee;
+import io.neonbee.NeonBeeOptions;
+import io.neonbee.config.EndpointConfig;
+import io.neonbee.endpoint.Endpoint;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.micrometer.backends.BackendRegistries;
+
+@ExtendWith(VertxExtension.class)
+@SuppressWarnings("PMD.AvoidUnnecessaryTestClassesModifier")
+public class NeonBeeMetricsTest {
+    private static final int PORT = 10808;
+
+    private static final String HOST = "localhost";
+
+    private static final String TEST_ENDPOINT_URI = "/testendpoint/";
+
+    private static final String METRICS_ENDPOINT_URI = "/metrics/";
+
+    private static TestEndpointHandler testEndpointHandler;
+
+    private static final int OK = HttpResponseStatus.OK.code();
+
+    @BeforeEach
+    void init() {
+        testEndpointHandler = new TestEndpointHandler();
+    }
+
+    @AfterEach
+    @SuppressWarnings("PMD.NullAssignment")
+    void reset() {
+        testEndpointHandler = null;
+    }
+
+    @Test
+    @Timeout(value = 1, timeUnit = TimeUnit.MINUTES)
+    void testCustomMetric(Vertx vertx, VertxTestContext context) {
+        Checkpoint prometheusCheckpoint = context.checkpoint(1);
+
+        NeonBeeOptions.Mutable mutable = new NeonBeeOptions.Mutable();
+        mutable.setServerPort(PORT);
+        mutable.setWorkingDirectory(Path.of("src", "test", "resources", "io", "neonbee", "endpoint", "metrics"));
+
+        NeonBee.create(mutable).onComplete(context.succeeding(event -> httpGet(vertx, TEST_ENDPOINT_URI)
+                .onComplete(response -> context.succeeding(
+                        httpResponse -> context.verify(() -> assertThat(response.result().statusCode()).isEqualTo(OK))))
+                .compose(
+                        response -> httpGet(vertx, METRICS_ENDPOINT_URI).onComplete(context.succeeding(httpResponse -> {
+                            context.verify(() -> assertThat(httpResponse.statusCode()).isEqualTo(OK));
+
+                            httpResponse.bodyHandler(bodyBuffer -> context.verify(() -> {
+                                assertThat(bodyBuffer.toString())
+                                        .contains("TestEndpointCounter_total{TestTag1=\"TestValue\",} 1.0");
+                                prometheusCheckpoint.flag();
+                            }));
+                        })))));
+    }
+
+    static Future<HttpClientResponse> httpGet(Vertx vertx, String requestUri) {
+        return vertx.createHttpClient().request(HttpMethod.GET, PORT, HOST, requestUri)
+                .compose(HttpClientRequest::send);
+    }
+
+    public static class TestEndpoint implements Endpoint {
+
+        @Override
+        public EndpointConfig getDefaultConfig() {
+            return new EndpointConfig().setType(MetricsEndpoint.class.getName()).setBasePath(TEST_ENDPOINT_URI);
+        }
+
+        @Override
+        public Router createEndpointRouter(Vertx vertx, String basePath, JsonObject config) {
+            return Endpoint.createRouter(vertx, testEndpointHandler);
+        }
+    }
+
+    private static class TestEndpointHandler implements Handler<RoutingContext> {
+
+        @Override
+        public void handle(RoutingContext rc) {
+            MeterRegistry backendRegistry = BackendRegistries.getDefaultNow();
+            double count = Double.NaN;
+            if (backendRegistry != null) {
+                Counter counter = backendRegistry.counter("TestEndpointCounter", "TestTag1", "TestValue");
+                counter.increment();
+                count = counter.count();
+            }
+            rc.response().setStatusCode(OK).end(Double.toString(count));
+        }
+    }
+}

--- a/src/test/java/io/neonbee/endpoint/metrics/PrometheusScrapingHandlerTest.java
+++ b/src/test/java/io/neonbee/endpoint/metrics/PrometheusScrapingHandlerTest.java
@@ -1,0 +1,74 @@
+package io.neonbee.endpoint.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.prometheus.client.exporter.common.TextFormat;
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.micrometer.backends.BackendRegistries;
+
+@ExtendWith({ VertxExtension.class, MockitoExtension.class })
+class PrometheusScrapingHandlerTest {
+    @Test
+    void testWithoutPrometheusMeterRegistry() {
+        PrometheusScrapingHandler nph = new PrometheusScrapingHandler(null);
+        try (MockedStatic<BackendRegistries> br = mockStatic(BackendRegistries.class)) {
+            br.when(BackendRegistries::getDefaultNow).thenReturn(new CompositeMeterRegistry());
+
+            ArgumentCaptor<Integer> statusCodeCaptor = ArgumentCaptor.forClass(Integer.class);
+            ArgumentCaptor<String> statusMessageCaptor = ArgumentCaptor.forClass(String.class);
+
+            RoutingContext rcMock = mock(RoutingContext.class);
+            HttpServerResponse responseMock = mock(HttpServerResponse.class);
+            when(rcMock.response()).thenReturn(responseMock);
+            when(responseMock.setStatusCode(statusCodeCaptor.capture())).thenReturn(responseMock);
+            when(responseMock.setStatusMessage(statusMessageCaptor.capture())).thenReturn(responseMock);
+            when(responseMock.end()).thenReturn(Future.succeededFuture());
+            nph.handle(rcMock);
+
+            assertThat(statusCodeCaptor.getValue()).isEqualTo(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+            assertThat(statusMessageCaptor.getValue()).isEqualTo("Could not find a PrometheusMeterRegistry");
+        }
+    }
+
+    @Test
+    void testPrometheusMeterRegistry() {
+        PrometheusScrapingHandler nph = new PrometheusScrapingHandler("something");
+        try (MockedStatic<BackendRegistries> br = mockStatic(BackendRegistries.class)) {
+            br.when(() -> BackendRegistries.getNow(any()))
+                    .thenReturn(new PrometheusMeterRegistry(PrometheusConfig.DEFAULT));
+
+            ArgumentCaptor<CharSequence> contentTypeCaptor = ArgumentCaptor.forClass(CharSequence.class);
+            ArgumentCaptor<CharSequence> contentTypeCaptor004 = ArgumentCaptor.forClass(CharSequence.class);
+
+            RoutingContext rcMock = mock(RoutingContext.class);
+            HttpServerResponse responseMock = mock(HttpServerResponse.class);
+            when(rcMock.response()).thenReturn(responseMock);
+            when(responseMock.putHeader(contentTypeCaptor.capture(), contentTypeCaptor004.capture()))
+                    .thenReturn(responseMock);
+            when(responseMock.end(ArgumentMatchers.<String>any())).thenReturn(Future.succeededFuture());
+            nph.handle(rcMock);
+
+            assertThat(contentTypeCaptor.getValue().toString()).isEqualTo(HttpHeaders.CONTENT_TYPE.toString());
+            assertThat(contentTypeCaptor004.getValue().toString()).isEqualTo(TextFormat.CONTENT_TYPE_004);
+        }
+    }
+}

--- a/src/test/java/io/neonbee/entity/EntityModelManagerTest.java
+++ b/src/test/java/io/neonbee/entity/EntityModelManagerTest.java
@@ -130,9 +130,9 @@ class EntityModelManagerTest extends NeonBeeTestBase {
     }
 
     @Test
-    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @Timeout(value = 4, timeUnit = TimeUnit.SECONDS)
     @DisplayName("check if the models from classpath can be loaded ")
-    void loadFromClassPathTest(Vertx vertx, VertxTestContext testContext) throws IOException {
+    void loadFromClassPathTest(Vertx vertx, VertxTestContext testContext) {
         Loader loader = new EntityModelManager.Loader(vertx);
         loader.scanClassPath().onComplete(testContext.succeeding(result -> testContext.verify(() -> {
             assertThat(loader.models.get("io.neonbee.test1").getEdmx().getEdm().getEntityContainer().getNamespace())

--- a/src/test/resources/io/neonbee/config/io.neonbee.NeonBee.json
+++ b/src/test/resources/io/neonbee/config/io.neonbee.NeonBee.json
@@ -1,0 +1,15 @@
+{
+    "eventBusCodecs": {},
+    "eventBusTimeout": 90,
+    "micrometerRegistries": [
+        {
+            "className" : "io.neonbee.config.NeonBeeConfigTest.TestMicrometerRegistryLoaderImpl",
+            "config" : {
+                "key": "value"
+            }
+        }
+    ],
+    "platformClasses": [],
+    "timeZone": "UTC",
+    "trackingDataHandlingStrategy": "io.neonbee.internal.tracking.TrackingDataLoggingStrategy"
+}

--- a/src/test/resources/io/neonbee/endpoint/metrics/config/io.neonbee.internal.verticle.ServerVerticle.yaml
+++ b/src/test/resources/io/neonbee/endpoint/metrics/config/io.neonbee.internal.verticle.ServerVerticle.yaml
@@ -1,0 +1,21 @@
+---
+# the configuration for the NeonBee server verticle
+config:
+    # the port number to use for the HTTP server, defaults to 8080
+    port: 8080
+    # specific endpoint configuration, defaults to the object seen below
+    endpoints:
+        # provides an Prometheus scraping endpoint for Micrometer.io metrics
+        - type: io.neonbee.endpoint.metrics.MetricsEndpoint
+          # enable the metrics endpoint, defaults to true
+          enabled: true
+          # the base path to map this endpoint to, defaults to /metrics/
+          basePath: /metrics/
+          # endpoint specific authentication chain, (special case!) defaults to an empty array [] and no authentication required
+          authenticationChain: [ ]
+        # TestEndpoint
+        - type: io.neonbee.endpoint.metrics.NeonBeeMetricsTest$TestEndpoint
+          basePath: /testendpoint/
+          # endpoint specific authentication chain, (special case!) defaults to an empty array [] and no authentication required
+          authenticationChain: []
+


### PR DESCRIPTION
With this change the config parameter `micrometerRegistries` is
introduced which allows the user to specify a list of (full qualified) class
names, which must implement the `load()` method of the functional interface
`MicrometerRegistryLoader`. The load method must return a
`MeterRegistry`, which will be added to the micrometer registries by
NeonBee. The `PrometheusMeterRegistry` will be the default
registry, which is only available when the `MetricsEndpoint` is loaded.