### PR TITLE
fix: null values queried with contains

### DIFF
--- a/src/main/java/io/neonbee/endpoint/odatav4/internal/olingo/expression/operators/StringFunctionMethodCallOperator.java
+++ b/src/main/java/io/neonbee/endpoint/odatav4/internal/olingo/expression/operators/StringFunctionMethodCallOperator.java
@@ -8,6 +8,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Supplier;
 
 import org.apache.olingo.commons.api.edm.EdmType;
 import org.apache.olingo.commons.api.http.HttpStatusCode;
@@ -99,7 +100,8 @@ public class StringFunctionMethodCallOperator extends MethodCallOperator {
     }
 
     public ExpressionVisitorOperand contains() throws ODataApplicationException {
-        return stringFunction(parameters -> parameters.get(0).contains(parameters.get(1)), PRIMITIVE_BOOLEAN);
+        return stringFunction(parameters -> parameters.get(0).contains(parameters.get(1)), PRIMITIVE_BOOLEAN,
+                () -> new ExpressionVisitorOperand(routingContext, false, PRIMITIVE_BOOLEAN));
     }
 
     private List<String> getParametersAsString() throws ODataApplicationException {
@@ -122,9 +124,15 @@ public class StringFunctionMethodCallOperator extends MethodCallOperator {
 
     private ExpressionVisitorOperand stringFunction(StringFunction stringFunction, EdmType returnValue)
             throws ODataApplicationException {
+        return stringFunction(stringFunction, returnValue,
+                () -> new ExpressionVisitorOperand(routingContext, null, EdmPrimitiveNull.getInstance()));
+    }
+
+    private ExpressionVisitorOperand stringFunction(StringFunction stringFunction, EdmType returnValue,
+            Supplier<ExpressionVisitorOperand> nullParameterOperandSupplier) throws ODataApplicationException {
         List<String> stringParameters = getParametersAsString();
         if (stringParameters.contains(null)) {
-            return new ExpressionVisitorOperand(routingContext, null, EdmPrimitiveNull.getInstance());
+            return nullParameterOperandSupplier.get();
         } else {
             return new ExpressionVisitorOperand(routingContext, stringFunction.perform(stringParameters), returnValue);
         }

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataFilterTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataFilterTest.java
@@ -5,6 +5,7 @@ import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle
 import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.EXPECTED_ENTITY_DATA_3;
 import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.EXPECTED_ENTITY_DATA_4;
 import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.EXPECTED_ENTITY_DATA_5;
+import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.EXPECTED_ENTITY_DATA_6;
 import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.getDeclaredEntityModel;
 
 import java.nio.file.Path;
@@ -73,10 +74,12 @@ class ODataFilterTest extends ODataEndpointTestBase {
                         List.of(EXPECTED_ENTITY_DATA_5)),
                 Arguments.of(filterOf("trim(PropertyString100) ne 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"),
                         List.of(EXPECTED_ENTITY_DATA_1, EXPECTED_ENTITY_DATA_2, EXPECTED_ENTITY_DATA_3,
-                                EXPECTED_ENTITY_DATA_4)),
+                                EXPECTED_ENTITY_DATA_4, EXPECTED_ENTITY_DATA_6)),
                 Arguments.of(filterOf(
                         "concat(concat(PropertyString100, '-DELIMITER-'), PropertyString) eq '     ABCDEFGHIJKLMNOPQRSTUVWXYZ -DELIMITER-D'"),
-                        List.of(EXPECTED_ENTITY_DATA_5)));
+                        List.of(EXPECTED_ENTITY_DATA_5)),
+                Arguments.of(filterOf("(contains(PropertyString100,'asdf') or contains(PropertyString100,'asdf'))"),
+                        List.of()));
 
         Stream<Arguments> comperatorsDouble = Stream.of(
                 Arguments.of(filterOf("PropertyDouble eq 0.15 or PropertyDouble eq 2.35"),
@@ -85,8 +88,8 @@ class ODataFilterTest extends ODataEndpointTestBase {
                         List.of(EXPECTED_ENTITY_DATA_4, EXPECTED_ENTITY_DATA_5)),
                 Arguments.of(filterOf("PropertyDouble ge 2.35"),
                         List.of(EXPECTED_ENTITY_DATA_3, EXPECTED_ENTITY_DATA_4, EXPECTED_ENTITY_DATA_5)),
-                Arguments.of(filterOf("PropertyDouble le 2.35"),
-                        List.of(EXPECTED_ENTITY_DATA_1, EXPECTED_ENTITY_DATA_2, EXPECTED_ENTITY_DATA_3)));
+                Arguments.of(filterOf("PropertyDouble le 2.35"), List.of(EXPECTED_ENTITY_DATA_1, EXPECTED_ENTITY_DATA_2,
+                        EXPECTED_ENTITY_DATA_3, EXPECTED_ENTITY_DATA_6)));
 
         Stream<Arguments> comperatorsDate = Stream.of(
                 Arguments.of(filterOf("year(PropertyDate) eq 2010"), List.of(EXPECTED_ENTITY_DATA_5)),
@@ -104,13 +107,13 @@ class ODataFilterTest extends ODataEndpointTestBase {
                         List.of(EXPECTED_ENTITY_DATA_2)),
                 Arguments.of(filterOf("PropertyDateTime eq 2010-01-20T11:30:05Z"), List.of(EXPECTED_ENTITY_DATA_5)));
 
-        Stream<Arguments> comperatorsInteger =
-                Stream.of(Arguments.of(filterOf("PropertyInt32 gt 3"), List.of(EXPECTED_ENTITY_DATA_5)),
-                        Arguments.of(filterOf("PropertyInt32 lt 4"), List.of(EXPECTED_ENTITY_DATA_1,
-                                EXPECTED_ENTITY_DATA_2, EXPECTED_ENTITY_DATA_3, EXPECTED_ENTITY_DATA_4)));
+        Stream<Arguments> comperatorsInteger = Stream.of(
+                Arguments.of(filterOf("PropertyInt32 gt 3"), List.of(EXPECTED_ENTITY_DATA_5, EXPECTED_ENTITY_DATA_6)),
+                Arguments.of(filterOf("PropertyInt32 lt 4"), List.of(EXPECTED_ENTITY_DATA_1, EXPECTED_ENTITY_DATA_2,
+                        EXPECTED_ENTITY_DATA_3, EXPECTED_ENTITY_DATA_4)));
 
-        Stream<Arguments> comperatorsBoolean = Stream.of(Arguments.of(filterOf("PropertyBoolean eq false"),
-                List.of(EXPECTED_ENTITY_DATA_1, EXPECTED_ENTITY_DATA_3, EXPECTED_ENTITY_DATA_5)));
+        Stream<Arguments> comperatorsBoolean = Stream.of(Arguments.of(filterOf("PropertyBoolean eq false"), List
+                .of(EXPECTED_ENTITY_DATA_1, EXPECTED_ENTITY_DATA_3, EXPECTED_ENTITY_DATA_5, EXPECTED_ENTITY_DATA_6)));
 
         return Stream.of(inFunction, stringFunctions, comperatorsDouble, comperatorsDate, comperatorsInteger,
                 comperatorsBoolean).flatMap(i -> i);

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataOrderTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataOrderTest.java
@@ -6,6 +6,7 @@ import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle
 import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.EXPECTED_ENTITY_DATA_3;
 import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.EXPECTED_ENTITY_DATA_4;
 import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.EXPECTED_ENTITY_DATA_5;
+import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.EXPECTED_ENTITY_DATA_6;
 import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.TEST_ENTITY_SET_FQN;
 import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.getDeclaredEntityModel;
 
@@ -47,7 +48,7 @@ class ODataOrderTest extends ODataEndpointTestBase {
 
         assertODataEntitySet(requestOData(request), entities -> {
             assertThat(entities).containsExactly(EXPECTED_ENTITY_DATA_1, EXPECTED_ENTITY_DATA_3, EXPECTED_ENTITY_DATA_4,
-                    EXPECTED_ENTITY_DATA_2, EXPECTED_ENTITY_DATA_5).inOrder();
+                    EXPECTED_ENTITY_DATA_2, EXPECTED_ENTITY_DATA_5, EXPECTED_ENTITY_DATA_6).inOrder();
         }, testContext).onComplete(testContext.succeedingThenComplete());
     }
 
@@ -58,8 +59,8 @@ class ODataOrderTest extends ODataEndpointTestBase {
         request.setQuery(Map.of("$orderby", "PropertyString desc,PropertyInt32 desc"));
 
         assertODataEntitySet(requestOData(request), entities -> {
-            assertThat(entities).containsExactly(EXPECTED_ENTITY_DATA_5, EXPECTED_ENTITY_DATA_2, EXPECTED_ENTITY_DATA_4,
-                    EXPECTED_ENTITY_DATA_3, EXPECTED_ENTITY_DATA_1).inOrder();
+            assertThat(entities).containsExactly(EXPECTED_ENTITY_DATA_6, EXPECTED_ENTITY_DATA_5, EXPECTED_ENTITY_DATA_2,
+                    EXPECTED_ENTITY_DATA_4, EXPECTED_ENTITY_DATA_3, EXPECTED_ENTITY_DATA_1).inOrder();
         }, testContext).onComplete(testContext.succeedingThenComplete());
     }
 
@@ -71,7 +72,7 @@ class ODataOrderTest extends ODataEndpointTestBase {
 
         assertODataEntitySet(requestOData(request), entities -> {
             assertThat(entities).containsExactly(EXPECTED_ENTITY_DATA_5, EXPECTED_ENTITY_DATA_4, EXPECTED_ENTITY_DATA_3,
-                    EXPECTED_ENTITY_DATA_2, EXPECTED_ENTITY_DATA_1).inOrder();
+                    EXPECTED_ENTITY_DATA_2, EXPECTED_ENTITY_DATA_1, EXPECTED_ENTITY_DATA_6).inOrder();
         }, testContext).onComplete(testContext.succeedingThenComplete());
     }
 
@@ -82,8 +83,8 @@ class ODataOrderTest extends ODataEndpointTestBase {
         request.setQuery(Map.of("$orderby", "PropertyDateTime desc"));
 
         assertODataEntitySet(requestOData(request), entities -> {
-            assertThat(entities).containsExactly(EXPECTED_ENTITY_DATA_1, EXPECTED_ENTITY_DATA_2, EXPECTED_ENTITY_DATA_3,
-                    EXPECTED_ENTITY_DATA_4, EXPECTED_ENTITY_DATA_5).inOrder();
+            assertThat(entities).containsExactly(EXPECTED_ENTITY_DATA_6, EXPECTED_ENTITY_DATA_1, EXPECTED_ENTITY_DATA_2,
+                    EXPECTED_ENTITY_DATA_3, EXPECTED_ENTITY_DATA_4, EXPECTED_ENTITY_DATA_5).inOrder();
         }, testContext).onComplete(testContext.succeedingThenComplete());
     }
 }

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataReadEntitiesTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataReadEntitiesTest.java
@@ -11,6 +11,7 @@ import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle
 import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.EXPECTED_ENTITY_DATA_3;
 import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.EXPECTED_ENTITY_DATA_4;
 import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.EXPECTED_ENTITY_DATA_5;
+import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.EXPECTED_ENTITY_DATA_6;
 import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.TEST_ENTITY_SET_FQN;
 import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.getDeclaredEntityModel;
 
@@ -46,7 +47,7 @@ import io.vertx.junit5.VertxTestContext;
 
 class ODataReadEntitiesTest extends ODataEndpointTestBase {
     private static final List<JsonObject> ALL_ENTITIES = List.of(EXPECTED_ENTITY_DATA_1, EXPECTED_ENTITY_DATA_2,
-            EXPECTED_ENTITY_DATA_3, EXPECTED_ENTITY_DATA_4, EXPECTED_ENTITY_DATA_5);
+            EXPECTED_ENTITY_DATA_3, EXPECTED_ENTITY_DATA_4, EXPECTED_ENTITY_DATA_5, EXPECTED_ENTITY_DATA_6);
 
     @Override
     protected List<Path> provideEntityModels() {
@@ -112,7 +113,7 @@ class ODataReadEntitiesTest extends ODataEndpointTestBase {
         Map<String, String> countQuery = Map.of("$count", "true");
         Future<HttpResponse<Buffer>> response =
                 requestOData(new ODataRequest(TEST_ENTITY_SET_FQN).setQuery(countQuery));
-        assertOData(response, body -> assertThat(body.toJsonObject().getMap()).containsAtLeast("@odata.count", 5),
+        assertOData(response, body -> assertThat(body.toJsonObject().getMap()).containsAtLeast("@odata.count", 6),
                 testContext).compose(v -> assertODataEntitySetContainsExactly(response, ALL_ENTITIES, testContext))
                         .onComplete(testContext.succeedingThenComplete());
     }
@@ -134,7 +135,7 @@ class ODataReadEntitiesTest extends ODataEndpointTestBase {
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Respond with 200 and the correct count of entities")
     void existingEntitiesCountTest(VertxTestContext testContext) {
-        assertOData(requestOData(new ODataRequest(TEST_ENTITY_SET_FQN).setCount()), "5", testContext)
+        assertOData(requestOData(new ODataRequest(TEST_ENTITY_SET_FQN).setCount()), "6", testContext)
                 .onComplete(testContext.succeedingThenComplete());
     }
 
@@ -174,7 +175,7 @@ class ODataReadEntitiesTest extends ODataEndpointTestBase {
     // Please note that the test method name contains "LooseUri" and therefore the behavior is different.
     void existingEntitiesCountWithoutFilterLooseUriConversionTest(VertxTestContext testContext) {
         FullQualifiedName looseFQN = new FullQualifiedName("io-neonbee-test-test-service1", "AllPropertiesNullable");
-        assertOData(requestOData(new ODataRequest(looseFQN).setCount()), "5", testContext)
+        assertOData(requestOData(new ODataRequest(looseFQN).setCount()), "6", testContext)
                 .onComplete(testContext.succeedingThenComplete());
     }
 }

--- a/src/test/java/io/neonbee/test/endpoint/odata/verticle/TestService1EntityVerticle.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/verticle/TestService1EntityVerticle.java
@@ -81,8 +81,17 @@ public class TestService1EntityVerticle extends EntityVerticle {
                     .put("PropertyBinary", NULL).put("PropertyBinary100", NULL).put("PropertyLargeBinary", NULL)
                     .put("PropertyBoolean", false).put("PropertyDate", "2010-01-20").put("PropertyTime", NULL)
                     .put("PropertyDateTime", "2010-01-20T11:30:05Z").put("PropertyTimestamp", NULL)
-                    .put("PropertyDecimal", NULL).put("PropertyDecimalFloat", NULL).put("PropertyDouble", 1337.0815)
+                    .put("PropertyDecimal", NULL).put("PropertyDecimalFloat", NULL).put("PropertyDouble", 1337.0815d)
                     .put("PropertyUuid", NULL).put("PropertyInt32", 4).put("PropertyInt64", NULL);
+
+    public static final JsonObject EXPECTED_ENTITY_DATA_6 =
+            new JsonObject().put("KeyPropertyString", "id-6").put("PropertyString", "X").put("PropertyChar", NULL)
+                    .put("PropertyString100", NULL).put("PropertyLargeString", NULL).put("PropertyBinary", NULL)
+                    .put("PropertyBinary100", NULL).put("PropertyLargeBinary", NULL).put("PropertyBoolean", false)
+                    .put("PropertyDate", "2022-02-01").put("PropertyTime", NULL)
+                    .put("PropertyDateTime", "2022-02-01T15:45:23.000004Z").put("PropertyTimestamp", NULL)
+                    .put("PropertyDecimal", NULL).put("PropertyDecimalFloat", NULL).put("PropertyDouble", 1.23456d)
+                    .put("PropertyUuid", NULL).put("PropertyInt32", 42).put("PropertyInt64", NULL);
 
     @Override
     public Future<Set<FullQualifiedName>> entityTypeNames() {
@@ -139,6 +148,17 @@ public class TestService1EntityVerticle extends EntityVerticle {
                 .addProperty(new Property(null, "PropertyDouble", ValueType.PRIMITIVE, Double.MAX_VALUE))
                 .addProperty(new Property(null, "PropertyBoolean", ValueType.PRIMITIVE, true));
 
+        Entity entity6 = new Entity() //
+                .addProperty(new Property(null, "KeyPropertyString", ValueType.PRIMITIVE, "id-6"))
+                .addProperty(new Property(null, "PropertyString100", ValueType.PRIMITIVE, null))
+                .addProperty(new Property(null, "PropertyString", ValueType.PRIMITIVE, "X"))
+                .addProperty(new Property(null, "PropertyInt32", ValueType.PRIMITIVE, 42))
+                .addProperty(new Property(null, "PropertyDate", ValueType.PRIMITIVE, LocalDate.of(2022, 2, 1)))
+                .addProperty(new Property(null, "PropertyDateTime", ValueType.PRIMITIVE,
+                        LocalDateTime.of(2022, 2, 1, 15, 45, 23, 4000).toInstant(ZoneOffset.UTC)))
+                .addProperty(new Property(null, "PropertyDouble", ValueType.PRIMITIVE, 1.23456d))
+                .addProperty(new Property(null, "PropertyBoolean", ValueType.PRIMITIVE, false));
+
         Entity entity5 = new Entity();
         try {
             entity5 = entity5.addProperty(new Property(null, "KeyPropertyString", ValueType.PRIMITIVE, "id-4"))
@@ -150,11 +170,11 @@ public class TestService1EntityVerticle extends EntityVerticle {
                             new SimpleDateFormat("yyyy-MM-dd", Locale.US).parse("2010-01-20")))
                     .addProperty(new Property(null, "PropertyDateTime", ValueType.PRIMITIVE,
                             Instant.parse("2010-01-20T11:30:05Z")))
-                    .addProperty(new Property(null, "PropertyDouble", ValueType.PRIMITIVE, Double.valueOf(1337.0815)))
+                    .addProperty(new Property(null, "PropertyDouble", ValueType.PRIMITIVE, 1337.0815d))
                     .addProperty(new Property(null, "PropertyBoolean", ValueType.PRIMITIVE, false));
 
-            return Future.succeededFuture(
-                    new EntityWrapper(TEST_ENTITY_SET_FQN, List.of(entity1, entity2, entity3, entity4, entity5)));
+            return Future.succeededFuture(new EntityWrapper(TEST_ENTITY_SET_FQN,
+                    List.of(entity1, entity2, entity3, entity4, entity5, entity6)));
         } catch (ParseException e) {
             return Future.failedFuture(e);
         }


### PR DESCRIPTION
This fixes the problem that if an entity attribute can contain null values, it was not possible to query this attribute with a query like contains(x,'y') or contains(x,'Y').