### PR TITLE
fix: allow no active profile, make ALL the default

### DIFF
--- a/src/main/java/io/neonbee/NeonBeeOptions.java
+++ b/src/main/java/io/neonbee/NeonBeeOptions.java
@@ -1,5 +1,6 @@
 package io.neonbee;
 
+import static io.neonbee.NeonBeeProfile.parseProfiles;
 import static io.neonbee.internal.helper.StringHelper.EMPTY;
 import static java.util.Objects.requireNonNull;
 
@@ -191,6 +192,11 @@ public interface NeonBeeOptions {
          */
         public static final String DEFAULT_CLUSTER_CONFIG = "hazelcast-cf.xml";
 
+        /**
+         * The default active profiles.
+         */
+        public static final String DEFAULT_ACTIVE_PROFILES = "ALL";
+
         private int eventLoopPoolSize = VertxOptions.DEFAULT_EVENT_LOOP_POOL_SIZE;
 
         private int workerPoolSize = VertxOptions.DEFAULT_WORKER_POOL_SIZE;
@@ -213,7 +219,7 @@ public interface NeonBeeOptions {
 
         private Integer serverPort;
 
-        private Set<NeonBeeProfile> activeProfiles = Set.of(NeonBeeProfile.ALL);
+        private Set<NeonBeeProfile> activeProfiles = parseProfiles(DEFAULT_ACTIVE_PROFILES);
 
         private List<Path> moduleJarPaths = Collections.emptyList();
 
@@ -477,6 +483,7 @@ public interface NeonBeeOptions {
          * @return this instance for chaining
          */
         @Option(longName = "active-profiles", shortName = "ap", acceptMultipleValues = true)
+        @DefaultValue(DEFAULT_ACTIVE_PROFILES)
         @Description("Set the active deployment profiles")
         public Mutable setActiveProfiles(String... activeProfiles) {
             return setActiveProfiles(Arrays.stream(activeProfiles).map(NeonBeeProfile::parseProfiles)

--- a/src/main/java/io/neonbee/NeonBeeProfile.java
+++ b/src/main/java/io/neonbee/NeonBeeProfile.java
@@ -2,6 +2,7 @@ package io.neonbee;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -52,6 +53,6 @@ public enum NeonBeeProfile {
         return Optional.ofNullable(profiles)
                 .map(nonNullProfiles -> Arrays.stream(nonNullProfiles.split(",")).filter(Predicate.not(String::isBlank))
                         .map(NeonBeeProfile::getProfile).filter(Objects::nonNull).collect(Collectors.toSet()))
-                .filter(Predicate.not(Collection::isEmpty)).orElse(Set.of(ALL));
+                .orElse(Collections.emptySet());
     }
 }

--- a/src/test/java/io/neonbee/LauncherTest.java
+++ b/src/test/java/io/neonbee/LauncherTest.java
@@ -65,6 +65,41 @@ class LauncherTest {
     }
 
     @Test
+    @DisplayName("should have NeonBeeProfile ALL by default")
+    void testDefaultActiveProfiles() {
+        args = new String[] {};
+        assertThat(parseArgs().getActiveProfiles()).containsExactly(NeonBeeProfile.ALL);
+    }
+
+    @Test
+    @DisplayName("should have WEB as active profile")
+    void testSingleActiveProfiles() {
+        args = new String[] { "-ap", "WEB" };
+        assertThat(parseArgs().getActiveProfiles()).containsExactly(NeonBeeProfile.WEB);
+    }
+
+    @Test
+    @DisplayName("should have ALL and WEB as active profiles")
+    void testMultiStringActiveProfiles() {
+        args = new String[] { "-ap", "WEB,ALL" };
+        assertThat(parseArgs().getActiveProfiles()).containsExactly(NeonBeeProfile.WEB, NeonBeeProfile.ALL);
+    }
+
+    @Test
+    @DisplayName("should have no NeonBeeProfile if empty")
+    void testMultiValueActiveProfiles() {
+        args = new String[] { "-ap", "WEB", "ALL" };
+        assertThat(parseArgs().getActiveProfiles()).containsExactly(NeonBeeProfile.WEB, NeonBeeProfile.ALL);
+    }
+
+    @Test
+    @DisplayName("should have no NeonBeeProfile if empty")
+    void testEmptyActiveProfiles() {
+        args = new String[] { "-ap", "" };
+        assertThat(parseArgs().getActiveProfiles()).isEmpty();
+    }
+
+    @Test
     @DisplayName("should throw an error, if instance-name is empty")
     void throwErrorIfInstanceNameIsEmpty() {
         args = new String[] { "-cwd", workDir, "-name", "" };

--- a/src/test/java/io/neonbee/NeonBeeOptionsTest.java
+++ b/src/test/java/io/neonbee/NeonBeeOptionsTest.java
@@ -107,12 +107,16 @@ class NeonBeeOptionsTest {
     @Test
     @DisplayName("Test server profiles set correctly")
     void checkProfiles() {
-        Mutable opts = new NeonBeeOptions.Mutable().setActiveProfiles("CORE,WEB");
+        Mutable opts = new NeonBeeOptions.Mutable();
+        assertThat(opts.getActiveProfiles()).containsExactly(ALL);
+        opts = new NeonBeeOptions.Mutable().setActiveProfiles("CORE,WEB");
         assertThat(opts.getActiveProfiles()).containsExactly(CORE, WEB);
         opts = new NeonBeeOptions.Mutable().setActiveProfiles(List.of(CORE, WEB));
         assertThat(opts.getActiveProfiles()).containsExactly(CORE, WEB);
+        opts = new NeonBeeOptions.Mutable().setActiveProfiles();
+        assertThat(opts.getActiveProfiles()).isEmpty();
         opts = new NeonBeeOptions.Mutable().setActiveProfiles("anything");
-        assertThat(opts.getActiveProfiles()).containsExactly(ALL);
+        assertThat(opts.getActiveProfiles()).isEmpty();
 
         opts = new NeonBeeOptions.Mutable().setActiveProfiles(List.of(CORE, WEB, WEB, CORE));
         assertThat(opts.getActiveProfiles()).containsExactly(CORE, WEB);

--- a/src/test/java/io/neonbee/NeonBeeProfileTest.java
+++ b/src/test/java/io/neonbee/NeonBeeProfileTest.java
@@ -46,24 +46,11 @@ class NeonBeeProfileTest {
 
     @Test
     void parseActiveProfile() {
-        Set<NeonBeeProfile> profiles = parseProfiles("");
-        assertThat(profiles).contains(ALL);
-        assertThat(profiles).hasSize(1);
-        profiles = parseProfiles("CORE");
-        assertThat(profiles).contains(CORE);
-        assertThat(profiles).hasSize(1);
-        profiles = parseProfiles("CORE,STABLE");
-        assertThat(profiles).contains(CORE);
-        assertThat(profiles).contains(STABLE);
-        assertThat(profiles).hasSize(2);
-        profiles = parseProfiles("CORE,anything");
-        assertThat(profiles).contains(CORE);
-        assertThat(profiles).hasSize(1);
-        profiles = parseProfiles("anything");
-        assertThat(profiles).contains(ALL);
-        assertThat(profiles).hasSize(1);
-        profiles = parseProfiles("");
-        assertThat(profiles).contains(ALL);
-        assertThat(profiles).hasSize(1);
+        assertThat(parseProfiles("ALL")).containsExactly(ALL);
+        assertThat(parseProfiles("CORE")).containsExactly(CORE);
+        assertThat(parseProfiles("CORE,STABLE")).containsExactly(CORE, STABLE);
+        assertThat(parseProfiles("CORE,anything")).containsExactly(CORE);
+        assertThat(parseProfiles("anything")).isEmpty();
+        assertThat(parseProfiles("")).isEmpty();
     }
 }


### PR DESCRIPTION
Allow to set null / an empty list as active profiles, which means that no profiles are to be deployed and NeonBee will start with the system verticles only.