### PR TITLE
refactor: improve wildcard handling in SelfFirstClassLoader

### DIFF
--- a/src/main/java/io/neonbee/config/NeonBeeConfig.java
+++ b/src/main/java/io/neonbee/config/NeonBeeConfig.java
@@ -51,7 +51,7 @@ public class NeonBeeConfig {
 
     private String trackingDataHandlingStrategy = DEFAULT_TRACKING_DATA_HANDLING_STRATEGY;
 
-    private List<String> platformClasses = List.of();
+    private List<String> platformClasses = List.of("io.vertx.*", "io.neonbee.*", "org.slf4j.*", "org.apache.olingo.*");
 
     private String timeZone = DEFAULT_TIME_ZONE;
 
@@ -198,15 +198,15 @@ public class NeonBeeConfig {
     }
 
     /**
-     * The idea of this method is to define, which classes are considered as platform classes. This is important to know
-     * to avoid potential class loading issues during the load of a NeonBee Module. Because generally a class which is
-     * already loaded by the platform shouldn't also be loaded by the class loader which loads the classes for the
-     * NeonBee Module.<br>
-     * <br>
+     * Platform classes are classes to be considered "provided" by the system class loader. NeonBee modules will attempt
+     * to find platform classes in the system class loader first, before loading them (self-first) from their own (so
+     * called) module class-loader. This way, you can prevent incompatibility issues across modules and also have
+     * modules with a much smaller runtime footprint.
      *
-     * Example values: [io.vertx.core.json.JsonObject, io.neonbee.data*, com.foo.bar*]
+     * Example values: io.vertx.core.json.JsonObject, io.neonbee.data.*, com.foo.bar.*
      *
-     * @return a list of Strings that could contain full qualified class names, or prefixes marked with a *;
+     * @return a list of strings that either contains a full qualified class names, or class names with * als a wildcard
+     *         character sequence. By default all NeonBee and Vert.x classes are considered platform classes.
      */
     public List<String> getPlatformClasses() {
         return platformClasses;
@@ -215,6 +215,7 @@ public class NeonBeeConfig {
     /**
      * Sets classes available by the platform.
      *
+     * @see #getPlatformClasses()
      * @param platformClasses a list of class names
      * @return the {@linkplain NeonBeeConfig} for fluent use
      */

--- a/src/test/java/io/neonbee/config/NeonBeeConfigTest.java
+++ b/src/test/java/io/neonbee/config/NeonBeeConfigTest.java
@@ -138,7 +138,8 @@ class NeonBeeConfigTest extends NeonBeeTestBase {
         assertThat(defaultConfig.getTrackingDataHandlingStrategy()).isEqualTo(DEFAULT_TRACKING_DATA_HANDLING_STRATEGY);
         assertThat(defaultConfig.getTimeZone()).isEqualTo(DEFAULT_TIME_ZONE);
         assertThat(defaultConfig.getEventBusCodecs()).isEmpty();
-        assertThat(defaultConfig.getPlatformClasses()).isEmpty();
+        assertThat(defaultConfig.getPlatformClasses()).containsExactly("io.vertx.*", "io.neonbee.*", "org.slf4j.*",
+                "org.apache.olingo.*");
     }
 
     @Test


### PR DESCRIPTION
So far the SelfFirstClassLoader only allowed to specify parentPreferred className if the wildcard was at the end of the string like:

io.neonbee.*

If the wildcard was in any other position, the check failed. In additional the general implementation of the check was implemented inefficiently, because of a list traversal, on every check, which is, for modules, every class that is to be loaded.

This change improves the wildcard logic, by compiling a pattern on initialization of the SelfFirstClassLoader, also allowing more complex patterns like:

io.neonbee.*.TestClass