### PR TITLE
feat: add temporary vertx instance

### DIFF
--- a/src/main/java/io/neonbee/LauncherPreProcessor.java
+++ b/src/main/java/io/neonbee/LauncherPreProcessor.java
@@ -2,6 +2,9 @@ package io.neonbee;
 
 import java.nio.file.Path;
 
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
 /**
  * A pre-processor, which will be executed before NeonBee initialization.
  */
@@ -9,9 +12,21 @@ import java.nio.file.Path;
 public interface LauncherPreProcessor {
 
     /**
-     * Executed the launcher pre-processor.
+     * Execute the launcher pre-processor.
      *
      * @param options the NeonBeeOptions to retrieve e.g.: the {@link Path} of the configuration folder.
      */
     void execute(NeonBeeOptions options);
+
+    /**
+     * Execute the launcher pre-processor.
+     *
+     * @param vertx   {@link Vertx} instance
+     * @param options the NeonBeeOptions to retrieve e.g.: the {@link Path} of the configuration folder.
+     * @param promise a promise which should be called when the LauncherPreProcessor is complete.
+     */
+    default void execute(Vertx vertx, NeonBeeOptions options, Promise<Void> promise) {
+        execute(options);
+        promise.complete();
+    }
 }

--- a/src/main/java/io/neonbee/config/metrics/MicrometerRegistryLoader.java
+++ b/src/main/java/io/neonbee/config/metrics/MicrometerRegistryLoader.java
@@ -1,6 +1,8 @@
 package io.neonbee.config.metrics;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.micrometer.MicrometerMetricsOptions;
 
@@ -19,4 +21,15 @@ public interface MicrometerRegistryLoader {
      * @return the {@link MeterRegistry} to add to the {@link MicrometerMetricsOptions}
      */
     MeterRegistry load(JsonObject config);
+
+    /**
+     * Executes the launcher pre-processor.
+     *
+     * @param vertx   {@link Vertx} instance
+     * @param config  the configuration as a {@link JsonObject}. The config object can be null.
+     * @param promise a promise which should be called when the MicrometerRegistryLoader is complete.
+     */
+    default void load(Vertx vertx, JsonObject config, Promise<MeterRegistry> promise) {
+        promise.complete(load(config));
+    }
 }

--- a/src/test/java/io/neonbee/NeonBeeMockHelper.java
+++ b/src/test/java/io/neonbee/NeonBeeMockHelper.java
@@ -182,7 +182,7 @@ public final class NeonBeeMockHelper {
      * @return the mocked NeonBee instance
      */
     public static Future<NeonBee> createNeonBee(Vertx vertx, NeonBeeOptions options) {
-        return NeonBee.create((vertxOptions) -> succeededFuture(vertx), options);
+        return NeonBee.create((vertxOptions) -> succeededFuture(vertx), options, null);
     }
 
     /**
@@ -243,11 +243,7 @@ public final class NeonBeeMockHelper {
      */
     public static NeonBee registerNeonBeeMock(Vertx vertx, NeonBeeOptions options, NeonBeeConfig config) {
         createLogger(); // the logger is only created internally, create one manually if required
-
-        NeonBee neonBee = new NeonBee(vertx, options, new CompositeMeterRegistry());
-        neonBee.config = config;
-
-        return neonBee;
+        return new NeonBee(vertx, options, config, new CompositeMeterRegistry());
     }
 
     @SuppressWarnings({ "CatchAndPrintStackTrace", "PMD.AvoidPrintStackTrace" })


### PR DESCRIPTION
Add a temporary Vert.x instance to load the NeonBeeConfig in the Launcher. This Vert.x instance is also passed to the new LauncherPreProcessor execute method. The MicrometerRegistryLoader has been modified accordingly to add the ability to pass a Vert.x instance to the load method.

see https://github.com/SAP/neonbee/issues/95