### PR TITLE
feat: add metrics to DataVerticle

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -68,3 +68,40 @@ counter.increment();
 count = counter.count();
 ```
 For more information, see [user defined metrics](https://vertx.io/docs/vertx-micrometer-metrics/java/#_user_defined_metrics)
+
+## DataVerticle metrics
+
+The DataVerticle collects four metrics:
+
+| metric | discription |
+|---|---|
+| Time | How long it takes to retrieve the data. |
+| Status counter | How many requests completed successfully, how many requests failed |
+| Number of requests | Total number of all requests |
+| Active requests | How many requests are currently open |
+
+### DataVerticle metrics configuration
+
+All metrics are disabled by default. You can enable the metrics globally for all DataVerticles by setting the `metrics.enabled` value to `true` in the `NeonBeeConfig`.
+
+**io.neonbee.NeonBee.yaml:**
+
+```yaml
+# Other settings omitted for simplicity.
+metrics:
+    enabled: true
+```
+
+The metrics can be also configured using the verticle configuration. To enable the metrics for an individual DataVerticle, it is necessary to add the `config.metrics.enabled` property with the value `true`. In addition, you can enable only specific metrics by specifying the metrics configuration name and a true value in the verticle configuration. If you have added a metrics configuration key, only the values with the specified `true` value are enabled. All others are disabled.
+Complete yaml example configuration to enable the metrics:
+```yaml
+config:
+    metrics:
+        enabled: true
+        meterRegistryName: SomeRegistryName
+        reportNumberOfRequests: true
+        reportActiveRequests: true
+        reportStatusCounter: true
+        reportTiming: true
+```
+

--- a/src/generated/java/io/neonbee/config/MetricsConfigConverter.java
+++ b/src/generated/java/io/neonbee/config/MetricsConfigConverter.java
@@ -1,0 +1,37 @@
+package io.neonbee.config;
+
+import java.util.Base64;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.impl.JsonUtil;
+
+/**
+ * Converter and mapper for {@link io.neonbee.config.MetricsConfig}. NOTE: This class has been automatically generated
+ * from the {@link io.neonbee.config.MetricsConfig} original class using Vert.x codegen.
+ */
+public class MetricsConfigConverter {
+
+    private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
+
+    private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+
+    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, MetricsConfig obj) {
+        for (java.util.Map.Entry<String, Object> member : json) {
+            switch (member.getKey()) {
+            case "enabled":
+                if (member.getValue() instanceof Boolean) {
+                    obj.setEnabled((Boolean) member.getValue());
+                }
+                break;
+            }
+        }
+    }
+
+    static void toJson(MetricsConfig obj, JsonObject json) {
+        toJson(obj, json.getMap());
+    }
+
+    static void toJson(MetricsConfig obj, java.util.Map<String, Object> json) {
+        json.put("enabled", obj.isEnabled());
+    }
+}

--- a/src/generated/java/io/neonbee/config/NeonBeeConfigConverter.java
+++ b/src/generated/java/io/neonbee/config/NeonBeeConfigConverter.java
@@ -40,6 +40,12 @@ public class NeonBeeConfigConverter {
                             new io.neonbee.config.HealthConfig((io.vertx.core.json.JsonObject) member.getValue()));
                 }
                 break;
+            case "metricsConfig":
+                if (member.getValue() instanceof JsonObject) {
+                    obj.setMetricsConfig(
+                            new io.neonbee.config.MetricsConfig((io.vertx.core.json.JsonObject) member.getValue()));
+                }
+                break;
             case "micrometerRegistries":
                 if (member.getValue() instanceof JsonArray) {
                     java.util.ArrayList<io.neonbee.config.MicrometerRegistryConfig> list = new java.util.ArrayList<>();
@@ -88,6 +94,9 @@ public class NeonBeeConfigConverter {
         json.put("eventBusTimeout", obj.getEventBusTimeout());
         if (obj.getHealthConfig() != null) {
             json.put("healthConfig", obj.getHealthConfig().toJson());
+        }
+        if (obj.getMetricsConfig() != null) {
+            json.put("metricsConfig", obj.getMetricsConfig().toJson());
         }
         if (obj.getMicrometerRegistries() != null) {
             JsonArray array = new JsonArray();

--- a/src/main/java/io/neonbee/config/MetricsConfig.java
+++ b/src/main/java/io/neonbee/config/MetricsConfig.java
@@ -1,0 +1,59 @@
+package io.neonbee.config;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Global metrics configuration.
+ */
+@DataObject(generateConverter = true, publicConverter = false)
+public class MetricsConfig {
+    private boolean enabled;
+
+    /**
+     * Creates a {@linkplain MicrometerRegistryConfig}.
+     */
+    public MetricsConfig() {}
+
+    /**
+     * Creates a {@linkplain MicrometerRegistryConfig} parsing a given JSON object.
+     *
+     * @param json the JSON object to parse
+     */
+    public MetricsConfig(JsonObject json) {
+        MetricsConfigConverter.fromJson(json, this);
+    }
+
+    /**
+     * Are the metrics enabled?
+     *
+     * @return true if the metrics are enabled, otherwise false.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Sets the value to enable, disable metrics.
+     *
+     * @param enabled true if the metrics should be enabled, false otherwise.
+     * @return the {@linkplain MetricsConfig} for fluent use
+     */
+    @Fluent
+    public MetricsConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    /**
+     * Transforms this configuration object into JSON.
+     *
+     * @return a JSON representation of this configuration
+     */
+    public JsonObject toJson() {
+        JsonObject json = new JsonObject();
+        MetricsConfigConverter.toJson(this, json);
+        return json;
+    }
+}

--- a/src/main/java/io/neonbee/config/NeonBeeConfig.java
+++ b/src/main/java/io/neonbee/config/NeonBeeConfig.java
@@ -53,7 +53,8 @@ public class NeonBeeConfig {
      */
     public static final String DEFAULT_TIME_ZONE = "UTC";
 
-    private static final ImmutableBiMap<String, String> REPHRASE_MAP = ImmutableBiMap.of("healthConfig", "health");
+    private static final ImmutableBiMap<String, String> REPHRASE_MAP =
+            ImmutableBiMap.of("healthConfig", "health", "metricsConfig", "metrics");
 
     private int eventBusTimeout = DEFAULT_EVENT_BUS_TIMEOUT;
 
@@ -68,6 +69,29 @@ public class NeonBeeConfig {
     private List<MicrometerRegistryConfig> micrometerRegistries = List.of();
 
     private HealthConfig healthConfig = new HealthConfig();
+
+    private MetricsConfig metricsConfig = new MetricsConfig();
+
+    /**
+     * Are the metrics enabled?
+     *
+     * @return true if the metrics are enabled, otherwise false.
+     */
+    public MetricsConfig getMetricsConfig() {
+        return metricsConfig;
+    }
+
+    /**
+     * Sets the value to enable, disable metrics.
+     *
+     * @param metricsConfig true if the metrics should be enabled, false otherwise.
+     * @return the {@linkplain NeonBeeConfig} for fluent use
+     */
+    @Fluent
+    public NeonBeeConfig setMetricsConfig(MetricsConfig metricsConfig) {
+        this.metricsConfig = metricsConfig;
+        return this;
+    }
 
     /**
      * Loads the NeonBee configuration from the config directory and converts it to a {@link NeonBeeConfig}.

--- a/src/main/java/io/neonbee/data/internal/metrics/ConfiguredDataVerticleMetrics.java
+++ b/src/main/java/io/neonbee/data/internal/metrics/ConfiguredDataVerticleMetrics.java
@@ -1,0 +1,160 @@
+package io.neonbee.data.internal.metrics;
+
+import java.util.List;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.neonbee.data.DataVerticle;
+import io.neonbee.logging.LoggingFacade;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import io.vertx.micrometer.MicrometerMetricsOptions;
+import io.vertx.micrometer.backends.BackendRegistries;
+
+/**
+ * This class configures the metrics to report for a {@link DataVerticle}.
+ */
+public class ConfiguredDataVerticleMetrics implements DataVerticleMetrics {
+
+    /**
+     * Key to enable metrics.
+     */
+    public static final String ENABLED = "enabled";
+
+    /**
+     * Key for the name of the registry to use.
+     */
+    public static final String METER_REGISTRY_NAME = "meterRegistryName";
+
+    /**
+     * Key for reporting the request count.
+     */
+    public static final String NUMBER_OF_REQUESTS = "reportNumberOfRequests";
+
+    /**
+     * Key for reporting the currently active requests.
+     */
+    public static final String ACTIVE_REQUESTS = "reportActiveRequests";
+
+    /**
+     * Key for reporting the status counter.
+     */
+    public static final String STATUS_COUNTER = "reportStatusCounter";
+
+    /**
+     * Key for reporting timing values.
+     */
+    public static final String TIMING = "reportTiming";
+
+    @VisibleForTesting
+    static final NoopDataVerticleMetrics DUMMY_IMPL = new NoopDataVerticleMetrics();
+
+    private static final LoggingFacade LOGGER = LoggingFacade.create();
+
+    @VisibleForTesting
+    final DataVerticleMetrics reportNumberOfRequests;
+
+    @VisibleForTesting
+    final DataVerticleMetrics reportActiveRequestsGauge;
+
+    @VisibleForTesting
+    final DataVerticleMetrics reportStatusCounter;
+
+    @VisibleForTesting
+    final DataVerticleMetrics reportTimingMetric;
+
+    ConfiguredDataVerticleMetrics(DataVerticleMetrics reportNumberOfRequests,
+            DataVerticleMetrics reportActiveRequestsGauge, DataVerticleMetrics reportStatusCounter,
+            DataVerticleMetrics reportTimingMetric) {
+        this.reportNumberOfRequests = reportNumberOfRequests;
+        this.reportActiveRequestsGauge = reportActiveRequestsGauge;
+        this.reportStatusCounter = reportStatusCounter;
+        this.reportTimingMetric = reportTimingMetric;
+    }
+
+    /**
+     * Configure the {@link DataVerticleMetrics} to report.
+     *
+     * To enable all metrics, you must specify the "enabled" key with the value true. Otherwise, no metrics will be
+     * reported. You can select the registry to use by specifying the meterRegistryName key with the name of the
+     * registry associated with the registry in the micrometer options.
+     *
+     * If you specify any of the configuration values "reportNumberOfRequests", "reportActiveRequests",
+     * "reportStatusCounter", "reportTiming", only the values configured as true will be reported. If you do not specify
+     * any of these values, all metrics are reported.
+     *
+     * Full example:
+     *
+     * <pre>
+     * {@code
+     * {
+     *     "enabled" : true,
+     *     "meterRegistryName" : "default",
+     *     "reportNumberOfRequests" : true,
+     *     "reportActiveRequests" : true
+     *     "reportStatusCounter" : true,
+     *     "reportTiming" : true
+     * }
+     * }
+     * </pre>
+     *
+     * @param metricsConfig {@link JsonObject} containing the metrics configuration.
+     * @return configured {@link DataVerticleMetrics}
+     */
+    public static DataVerticleMetrics configureMetricsReporting(JsonObject metricsConfig) {
+        if (metricsConfig == null || !Boolean.TRUE.equals(metricsConfig.getBoolean(ENABLED))) {
+            return DUMMY_IMPL;
+        }
+
+        String meterRegistryName =
+                metricsConfig.getString(METER_REGISTRY_NAME, MicrometerMetricsOptions.DEFAULT_REGISTRY_NAME);
+        MeterRegistry registry = BackendRegistries.getNow(meterRegistryName);
+
+        if (registry == null) {
+            LOGGER.error(
+                    "Micrometer registry hasn't been registered yet or it has been stopped. Metrics will not be sent.");
+            return DUMMY_IMPL;
+        } else {
+            DataVerticleMetrics metricsImpl = new DataVerticleMetricsImpl(registry);
+            return configureDataVericleMetrics(metricsConfig, metricsImpl);
+        }
+    }
+
+    private static DataVerticleMetrics configureDataVericleMetrics(JsonObject metricsConfig,
+            DataVerticleMetrics metricsImpl) {
+
+        int fieldNameSize = metricsConfig.containsKey(METER_REGISTRY_NAME) ? 2 : 1;
+        boolean activateAllMetrics = metricsConfig.size() == fieldNameSize;
+        if (activateAllMetrics) {
+            return metricsImpl;
+        } else {
+            return new ConfiguredDataVerticleMetrics(
+                    Boolean.TRUE.equals(metricsConfig.getBoolean(NUMBER_OF_REQUESTS)) ? metricsImpl : DUMMY_IMPL,
+                    Boolean.TRUE.equals(metricsConfig.getBoolean(ACTIVE_REQUESTS)) ? metricsImpl : DUMMY_IMPL,
+                    Boolean.TRUE.equals(metricsConfig.getBoolean(STATUS_COUNTER)) ? metricsImpl : DUMMY_IMPL,
+                    Boolean.TRUE.equals(metricsConfig.getBoolean(TIMING)) ? metricsImpl : DUMMY_IMPL);
+        }
+    }
+
+    @Override
+    public void reportNumberOfRequests(String name, String description, List<Tag> tags) {
+        reportNumberOfRequests.reportNumberOfRequests(name, description, tags);
+    }
+
+    @Override
+    public void reportActiveRequestsGauge(String name, String description, List<Tag> tags, Future<?> future) {
+        reportActiveRequestsGauge.reportActiveRequestsGauge(name, description, tags, future);
+    }
+
+    @Override
+    public void reportStatusCounter(String name, String description, Iterable<Tag> tags, Future<?> future) {
+        reportStatusCounter.reportStatusCounter(name, description, tags, future);
+    }
+
+    @Override
+    public void reportTimingMetric(String name, String description, Iterable<Tag> tags, Future<?> future) {
+        reportTimingMetric.reportTimingMetric(name, description, tags, future);
+    }
+}

--- a/src/main/java/io/neonbee/data/internal/metrics/DataVerticleMetrics.java
+++ b/src/main/java/io/neonbee/data/internal/metrics/DataVerticleMetrics.java
@@ -1,0 +1,50 @@
+package io.neonbee.data.internal.metrics;
+
+import java.util.List;
+
+import io.micrometer.core.instrument.Tag;
+import io.vertx.core.Future;
+
+public interface DataVerticleMetrics {
+
+    /**
+     * Reports the sum of all calls.
+     *
+     * @param name        name of the metric
+     * @param description description of the metric
+     * @param tags        dimensions of a meter used to classify the metric
+     */
+    void reportNumberOfRequests(String name, String description, List<Tag> tags);
+
+    /**
+     * Reports the number of requests waiting for a response.
+     *
+     * @param name        the name of the metric
+     * @param description description of the metric
+     * @param tags        dimensions of a meter used to classify the metric
+     * @param future      the future to measure
+     */
+    void reportActiveRequestsGauge(String name, String description, List<Tag> tags, Future<?> future);
+
+    /**
+     * Reports status metrics.
+     *
+     * For example, whether a call could be executed successfully or with errors.
+     *
+     * @param name        the name of the metric
+     * @param description description of the metric
+     * @param tags        dimensions of a meter used to classify the metric
+     * @param future      the future to measure
+     */
+    void reportStatusCounter(String name, String description, Iterable<Tag> tags, Future<?> future);
+
+    /**
+     * Reports timing metrics such as duration.
+     *
+     * @param name        the name of the metric
+     * @param description description of the metric
+     * @param tags        dimensions of a meter used to classify the metric
+     * @param future      the future to measure
+     */
+    void reportTimingMetric(String name, String description, Iterable<Tag> tags, Future<?> future);
+}

--- a/src/main/java/io/neonbee/data/internal/metrics/DataVerticleMetricsImpl.java
+++ b/src/main/java/io/neonbee/data/internal/metrics/DataVerticleMetricsImpl.java
@@ -1,0 +1,78 @@
+package io.neonbee.data.internal.metrics;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+
+import com.google.common.collect.Iterables;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.ImmutableTag;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.vertx.core.Future;
+
+public class DataVerticleMetricsImpl implements DataVerticleMetrics {
+
+    private static final ImmutableTag SUCCEEDED_TAG = new ImmutableTag("succeeded", "true");
+
+    private static final ImmutableTag FAILED_TAG = new ImmutableTag("succeeded", "false");
+
+    private final Map<Meter.Id, LongAdder> activeRequestsMap = new ConcurrentHashMap<>();
+
+    private final MeterRegistry registry;
+
+    DataVerticleMetricsImpl(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public void reportNumberOfRequests(String name, String description, List<Tag> tags) {
+        Counter.builder(name).description(description).tags(tags).register(registry).increment();
+    }
+
+    @Override
+    public void reportActiveRequestsGauge(String name, String description, List<Tag> tags, Future<?> future) {
+        LongAdder longAdder = getGaugeLongAdder(name, description, tags, registry);
+        longAdder.increment();
+        future.onComplete(event -> {
+            longAdder.decrement();
+        });
+    }
+
+    private LongAdder getGaugeLongAdder(String name, String description, List<Tag> tags, MeterRegistry registry) {
+        LongAdder longAdder = new LongAdder();
+        Gauge gauge = Gauge.builder(name, longAdder, LongAdder::doubleValue).description(description).tags(tags)
+                .register(registry);
+        activeRequestsMap.computeIfAbsent(gauge.getId(), id -> longAdder);
+        return longAdder;
+    }
+
+    @Override
+    public void reportStatusCounter(String name, String description, Iterable<Tag> tags, Future<?> future) {
+        future.onComplete(data -> {
+            Counter.builder(name).description("succeeded response count")
+                    .tags(Iterables.concat(tags, List.of(data.succeeded() ? SUCCEEDED_TAG : FAILED_TAG)))
+                    .register(registry).increment();
+        });
+    }
+
+    @Override
+    public void reportTimingMetric(String name, String description, Iterable<Tag> tags, Future<?> future) {
+        long start = System.nanoTime();
+        future.onComplete(data -> reportTimeMetric(name, description, tags, start));
+    }
+
+    private void reportTimeMetric(String name, String description, Iterable<Tag> tags, long start) {
+        long time = System.nanoTime() - start;
+
+        Timer timer = Timer.builder(name).description(description).tags(tags).register(registry);
+        timer.record(time, TimeUnit.NANOSECONDS);
+    }
+
+}

--- a/src/main/java/io/neonbee/data/internal/metrics/NoopDataVerticleMetrics.java
+++ b/src/main/java/io/neonbee/data/internal/metrics/NoopDataVerticleMetrics.java
@@ -1,0 +1,34 @@
+package io.neonbee.data.internal.metrics;
+
+import java.util.List;
+
+import io.micrometer.core.instrument.Tag;
+import io.vertx.core.Future;
+
+/**
+ * This implementation of the {@link DataVerticleMetrics} interface is used when metrics are disabled.
+ */
+public class NoopDataVerticleMetrics implements DataVerticleMetrics {
+
+    NoopDataVerticleMetrics() {}
+
+    @Override
+    public void reportNumberOfRequests(String name, String description, List<Tag> tags) {
+        // This method is intentionally empty.
+    }
+
+    @Override
+    public void reportActiveRequestsGauge(String name, String description, List<Tag> tags, Future<?> future) {
+        // This method is intentionally empty.
+    }
+
+    @Override
+    public void reportStatusCounter(String name, String description, Iterable<Tag> tags, Future<?> future) {
+        // This method is intentionally empty.
+    }
+
+    @Override
+    public void reportTimingMetric(String name, String description, Iterable<Tag> tags, Future<?> future) {
+        // This method is intentionally empty.
+    }
+}

--- a/src/test/java/io/neonbee/config/NeonBeeConfigTest.java
+++ b/src/test/java/io/neonbee/config/NeonBeeConfigTest.java
@@ -157,6 +157,23 @@ class NeonBeeConfigTest extends NeonBeeTestBase {
     }
 
     @Test
+    @DisplayName("should read the metrics configuration correctly")
+    void readMetricsConfig() {
+        NeonBeeConfig config =
+                new NeonBeeConfig(new JsonObject().put("metrics", new JsonObject().put("enabled", true)));
+        assertThat(config.getMetricsConfig().isEnabled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("should create the metrics configuration JSON correctly")
+    void metricsConfigToJson() {
+        NeonBeeConfig config = new NeonBeeConfig();
+        config.getMetricsConfig().setEnabled(true);
+        JsonObject actual = config.toJson();
+        assertThat(actual.getJsonObject("metrics")).isEqualTo(new JsonObject().put("enabled", true));
+    }
+
+    @Test
     @DisplayName("should read the platform classes correctly")
     void testGetPlatformClasses() {
         List<String> validListOfPlatformClasses = List.of("hodor");

--- a/src/test/java/io/neonbee/data/internal/metrics/ConfiguredDataVerticleMetricsTest.java
+++ b/src/test/java/io/neonbee/data/internal/metrics/ConfiguredDataVerticleMetricsTest.java
@@ -1,0 +1,184 @@
+package io.neonbee.data.internal.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import io.micrometer.core.instrument.ImmutableTag;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import io.vertx.micrometer.backends.BackendRegistries;
+
+class ConfiguredDataVerticleMetricsTest {
+
+    @Test
+    @DisplayName("Test null config")
+    void nullConfig() {
+        DataVerticleMetrics instance = ConfiguredDataVerticleMetrics.configureMetricsReporting(null);
+        assertThat(instance).isInstanceOf(NoopDataVerticleMetrics.class);
+    }
+
+    @Test
+    @DisplayName("Test no config")
+    void noConfig() {
+        DataVerticleMetrics instance = ConfiguredDataVerticleMetrics.configureMetricsReporting(new JsonObject());
+        assertThat(instance).isInstanceOf(NoopDataVerticleMetrics.class);
+    }
+
+    @Test
+    @DisplayName("Test metrics disabled")
+    void disabled() {
+        JsonObject config = new JsonObject().put(ConfiguredDataVerticleMetrics.ENABLED, false);
+        DataVerticleMetrics instance = ConfiguredDataVerticleMetrics.configureMetricsReporting(config);
+        assertThat(instance).isInstanceOf(NoopDataVerticleMetrics.class);
+    }
+
+    @Test
+    @DisplayName("Test metrics disabled, enabled is null")
+    void disabledNull() {
+        JsonObject config = new JsonObject().put(ConfiguredDataVerticleMetrics.ENABLED, null);
+        DataVerticleMetrics instance = ConfiguredDataVerticleMetrics.configureMetricsReporting(config);
+        assertThat(instance).isInstanceOf(NoopDataVerticleMetrics.class);
+    }
+
+    @Test
+    @DisplayName("backend meter registry is null")
+    void backendMeterRegistriesNull() {
+        JsonObject config = new JsonObject().put(ConfiguredDataVerticleMetrics.ENABLED, true);
+
+        DataVerticleMetrics instance = ConfiguredDataVerticleMetrics.configureMetricsReporting(config);
+        assertThat(instance).isInstanceOf(NoopDataVerticleMetrics.class);
+    }
+
+    @Test
+    @DisplayName("Test minimal config, all metrics should be reported")
+    void minimalEnabled() {
+        JsonObject config = new JsonObject().put(ConfiguredDataVerticleMetrics.ENABLED, true);
+
+        MeterRegistry mockRegistry = mock(MeterRegistry.class);
+        try (MockedStatic<BackendRegistries> registry = mockStatic(BackendRegistries.class)) {
+            registry.when(() -> BackendRegistries.getNow(anyString())).thenReturn(mockRegistry);
+
+            DataVerticleMetrics instance = ConfiguredDataVerticleMetrics.configureMetricsReporting(config);
+            assertThat(instance).isInstanceOf(DataVerticleMetricsImpl.class);
+        }
+    }
+
+    @Test
+    @DisplayName("Test config with all values provided")
+    void configWithAllValuesEnabled() {
+        JsonObject config = new JsonObject().put(ConfiguredDataVerticleMetrics.ENABLED, true)
+                .put(ConfiguredDataVerticleMetrics.METER_REGISTRY_NAME, "SomeRegistryName")
+                .put(ConfiguredDataVerticleMetrics.NUMBER_OF_REQUESTS, true)
+                .put(ConfiguredDataVerticleMetrics.ACTIVE_REQUESTS, true)
+                .put(ConfiguredDataVerticleMetrics.STATUS_COUNTER, true)
+                .put(ConfiguredDataVerticleMetrics.TIMING, true);
+
+        MeterRegistry mockRegistry = mock(MeterRegistry.class);
+        try (MockedStatic<BackendRegistries> registry = mockStatic(BackendRegistries.class)) {
+            registry.when(() -> BackendRegistries.getNow(anyString())).thenReturn(mockRegistry);
+
+            DataVerticleMetrics instance = ConfiguredDataVerticleMetrics.configureMetricsReporting(config);
+            assertThat(instance).isInstanceOf(ConfiguredDataVerticleMetrics.class);
+            ConfiguredDataVerticleMetrics configuredInstance = (ConfiguredDataVerticleMetrics) instance;
+
+            assertThat(configuredInstance.reportNumberOfRequests).isInstanceOf(DataVerticleMetricsImpl.class);
+            assertThat(configuredInstance.reportActiveRequestsGauge).isInstanceOf(DataVerticleMetricsImpl.class);
+            assertThat(configuredInstance.reportStatusCounter).isInstanceOf(DataVerticleMetricsImpl.class);
+            assertThat(configuredInstance.reportTimingMetric).isInstanceOf(DataVerticleMetricsImpl.class);
+        }
+    }
+
+    @Test
+    @DisplayName("Test config with all values provided but disabled")
+    void configWithAllValuesDisabled() {
+        JsonObject config = new JsonObject().put(ConfiguredDataVerticleMetrics.ENABLED, true)
+                .put(ConfiguredDataVerticleMetrics.METER_REGISTRY_NAME, "SomeRegistryName")
+                .put(ConfiguredDataVerticleMetrics.NUMBER_OF_REQUESTS, false)
+                .put(ConfiguredDataVerticleMetrics.ACTIVE_REQUESTS, false)
+                .put(ConfiguredDataVerticleMetrics.STATUS_COUNTER, false)
+                .put(ConfiguredDataVerticleMetrics.TIMING, false);
+
+        MeterRegistry mockRegistry = mock(MeterRegistry.class);
+        try (MockedStatic<BackendRegistries> registry = mockStatic(BackendRegistries.class)) {
+            registry.when(() -> BackendRegistries.getNow(anyString())).thenReturn(mockRegistry);
+
+            DataVerticleMetrics instance = ConfiguredDataVerticleMetrics.configureMetricsReporting(config);
+            assertThat(instance).isInstanceOf(ConfiguredDataVerticleMetrics.class);
+            ConfiguredDataVerticleMetrics configuredInstance = (ConfiguredDataVerticleMetrics) instance;
+
+            assertThat(configuredInstance.reportNumberOfRequests).isInstanceOf(NoopDataVerticleMetrics.class);
+            assertThat(configuredInstance.reportActiveRequestsGauge).isInstanceOf(NoopDataVerticleMetrics.class);
+            assertThat(configuredInstance.reportStatusCounter).isInstanceOf(NoopDataVerticleMetrics.class);
+            assertThat(configuredInstance.reportTimingMetric).isInstanceOf(NoopDataVerticleMetrics.class);
+
+            List<Tag> tags = List.of(new ImmutableTag("key", "value"));
+
+            configuredInstance.reportNumberOfRequests("name", "description", tags);
+            configuredInstance.reportActiveRequestsGauge("name", "description", tags, Future.succeededFuture());
+            configuredInstance.reportStatusCounter("name", "description", tags, Future.succeededFuture());
+            configuredInstance.reportTimingMetric("name", "description", tags, Future.succeededFuture());
+        }
+    }
+
+    @Test
+    @DisplayName("Test invocations")
+    void invocations() {
+        NoopDataVerticleMetrics spyReportNumberOfRequests = spy(ConfiguredDataVerticleMetrics.DUMMY_IMPL);
+        NoopDataVerticleMetrics spyReportActiveRequestsGauge = spy(ConfiguredDataVerticleMetrics.DUMMY_IMPL);
+        NoopDataVerticleMetrics spyReportStatusCounter = spy(ConfiguredDataVerticleMetrics.DUMMY_IMPL);
+        NoopDataVerticleMetrics spyReportTimingMetric = spy(ConfiguredDataVerticleMetrics.DUMMY_IMPL);
+
+        ConfiguredDataVerticleMetrics configuredInstance = new ConfiguredDataVerticleMetrics(spyReportNumberOfRequests,
+                spyReportActiveRequestsGauge, spyReportStatusCounter, spyReportTimingMetric);
+
+        List<Tag> tags = List.of(new ImmutableTag("key", "value"));
+
+        configuredInstance.reportNumberOfRequests("name", "description", tags);
+        configuredInstance.reportActiveRequestsGauge("name", "description", tags, Future.succeededFuture());
+        configuredInstance.reportStatusCounter("name", "description", tags, Future.succeededFuture());
+        configuredInstance.reportTimingMetric("name", "description", tags, Future.succeededFuture());
+
+        verify(spyReportNumberOfRequests, times(1)).reportNumberOfRequests(eq("name"), eq("description"), eq(tags));
+        verify(spyReportNumberOfRequests, never()).reportActiveRequestsGauge(eq("name"), eq("description"), eq(tags),
+                any());
+        verify(spyReportNumberOfRequests, never()).reportStatusCounter(eq("name"), eq("description"), eq(tags), any());
+        verify(spyReportNumberOfRequests, never()).reportTimingMetric(eq("name"), eq("description"), eq(tags), any());
+
+        verify(spyReportActiveRequestsGauge, times(1)).reportActiveRequestsGauge(eq("name"), eq("description"),
+                eq(tags), any());
+        verify(spyReportActiveRequestsGauge, never()).reportNumberOfRequests(eq("name"), eq("description"), eq(tags));
+        verify(spyReportActiveRequestsGauge, never()).reportStatusCounter(eq("name"), eq("description"), eq(tags),
+                any());
+        verify(spyReportActiveRequestsGauge, never()).reportTimingMetric(eq("name"), eq("description"), eq(tags),
+                any());
+
+        verify(spyReportStatusCounter, times(1)).reportStatusCounter(eq("name"), eq("description"), eq(tags), any());
+        verify(spyReportStatusCounter, never()).reportNumberOfRequests(eq("name"), eq("description"), eq(tags));
+        verify(spyReportStatusCounter, never()).reportActiveRequestsGauge(eq("name"), eq("description"), eq(tags),
+                any());
+        verify(spyReportStatusCounter, never()).reportTimingMetric(eq("name"), eq("description"), eq(tags), any());
+
+        verify(spyReportTimingMetric, times(1)).reportTimingMetric(eq("name"), eq("description"), eq(tags), any());
+        verify(spyReportTimingMetric, never()).reportNumberOfRequests(eq("name"), eq("description"), eq(tags));
+        verify(spyReportTimingMetric, never()).reportActiveRequestsGauge(eq("name"), eq("description"), eq(tags),
+                any());
+        verify(spyReportTimingMetric, never()).reportStatusCounter(eq("name"), eq("description"), eq(tags), any());
+    }
+
+}

--- a/src/test/java/io/neonbee/data/internal/metrics/DataVerticleMetricsImplTest.java
+++ b/src/test/java/io/neonbee/data/internal/metrics/DataVerticleMetricsImplTest.java
@@ -1,0 +1,114 @@
+package io.neonbee.data.internal.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.neonbee.NeonBee;
+import io.neonbee.NeonBeeOptions;
+import io.neonbee.config.NeonBeeConfig;
+import io.neonbee.data.DataVerticle;
+import io.neonbee.test.helper.SystemHelper;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class DataVerticleMetricsImplTest {
+
+    @Test
+    @Timeout(value = 1, timeUnit = TimeUnit.MINUTES)
+    void testMetricsOnPrometheusEndpoint(Vertx vertx, VertxTestContext context) throws Exception {
+        int port = SystemHelper.getFreePort();
+
+        NeonBeeOptions.Mutable options = new NeonBeeOptions.Mutable();
+        options.setServerPort(port);
+        options.setIgnoreClassPath(true);
+
+        NeonBeeConfig config = new NeonBeeConfig();
+        config.getMetricsConfig().setEnabled(true);
+
+        NeonBee.create(options, config).onComplete(context.succeeding(neonBee -> {
+
+            DeploymentOptions deploymentOptions = new DeploymentOptions();
+            deploymentOptions.setConfig(new JsonObject().put(DataVerticle.CONFIG_METRICS_KEY,
+                    new JsonObject().put(ConfiguredDataVerticleMetrics.ENABLED, true)));
+
+            CompositeFuture
+                    .all(neonBee.getVertx().deployVerticle(new TestSourceDataVerticle(), deploymentOptions),
+                            neonBee.getVertx().deployVerticle(new TestRequireDataVerticle(), deploymentOptions))
+                    .onComplete(context.succeeding(event -> {
+                        HttpRequest<Buffer> request = createRequest(neonBee, HttpMethod.GET,
+                                "/raw/" + TestRequireDataVerticle.QUALIFIED_NAME);
+                        request.send().onComplete(context.succeeding(resp -> {
+                            context.verify(() -> {
+                                assertThat(resp.statusCode()).isEqualTo(200);
+                                assertThat(resp.bodyAsString())
+                                        .isEqualTo("\"TestRequireDataVerticle[TestSourceDataVerticle content]\"");
+                            });
+                        })).compose(unused -> createRequest(neonBee, HttpMethod.GET, "/metrics").send()
+                                .onComplete(context.succeeding(resp -> {
+                                    context.verify(() -> {
+                                        assertThat(resp.statusCode()).isEqualTo(200);
+                                        assertThat(resp.bodyAsString()).contains(
+                                                "request_data_timer_test_TestSourceDataVerticle_seconds_count{query=\"\",} ");
+                                        assertThat(resp.bodyAsString()).contains(
+                                                "request_data_timer_test_TestSourceDataVerticle_seconds_sum{query=\"\",} ");
+                                        assertThat(resp.bodyAsString()).contains(
+                                                "request_data_timer_test_TestSourceDataVerticle_seconds_max{query=\"\",} ");
+
+                                        assertThat(resp.bodyAsString()).contains(
+                                                "request_data_counter_test_TestSourceDataVerticle_total{query=\"\",succeeded=\"true\",} 1.0");
+                                        assertThat(resp.bodyAsString()).contains(
+                                                "request_data_active_requests_test_TestSourceDataVerticle 0.0");
+                                        assertThat(resp.bodyAsString()).contains(
+                                                "request_counter_test_TestSourceDataVerticle_total{query=\"\",} 1.0");
+
+                                        assertThat(resp.bodyAsString()).contains(
+                                                "retrieve_data_timer_DataVerticle_test_TestSourceDataVerticle__seconds_max{name=\"TestSourceDataVerticle\",namespace=\"test\",} ");
+                                        assertThat(resp.bodyAsString()).contains(
+                                                "retrieve_data_counter_DataVerticle_test_TestSourceDataVerticle__total{name=\"TestSourceDataVerticle\",namespace=\"test\",succeeded=\"true\",} 1.0");
+                                        assertThat(resp.bodyAsString()).contains(
+                                                "retrieve_data_active_requests_DataVerticle_test_TestSourceDataVerticle_{name=\"TestSourceDataVerticle\",namespace=\"test\",} 0.0");
+                                        assertThat(resp.bodyAsString()).contains(
+                                                "retrieve_counter_DataVerticle_test_TestSourceDataVerticle__total{name=\"TestSourceDataVerticle\",namespace=\"test\",} 1.0");
+
+                                        assertThat(resp.bodyAsString()).contains(
+                                                "retrieve_data_timer_DataVerticle_test_TestRequireDataVerticle__seconds_count{name=\"TestRequireDataVerticle\",namespace=\"test\",} ");
+                                        assertThat(resp.bodyAsString()).contains(
+                                                "retrieve_data_timer_DataVerticle_test_TestRequireDataVerticle__seconds_sum{name=\"TestRequireDataVerticle\",namespace=\"test\",} ");
+                                        assertThat(resp.bodyAsString()).contains(
+                                                "retrieve_data_timer_DataVerticle_test_TestRequireDataVerticle__seconds_max{name=\"TestRequireDataVerticle\",namespace=\"test\",} ");
+
+                                        assertThat(resp.bodyAsString()).contains(
+                                                "retrieve_data_counter_DataVerticle_test_TestRequireDataVerticle__total{name=\"TestRequireDataVerticle\",namespace=\"test\",succeeded=\"true\",} 1.0");
+                                        assertThat(resp.bodyAsString()).contains(
+                                                "retrieve_data_active_requests_DataVerticle_test_TestRequireDataVerticle_{name=\"TestRequireDataVerticle\",namespace=\"test\",} 0.0");
+                                        assertThat(resp.bodyAsString()).contains(
+                                                "retrieve_counter_DataVerticle_test_TestRequireDataVerticle__total{name=\"TestRequireDataVerticle\",namespace=\"test\",} 1.0");
+
+                                        neonBee.getVertx().close(context.succeeding(e -> context.completeNow()));
+                                    });
+                                })));
+                    }));
+        }));
+    }
+
+    public HttpRequest<Buffer> createRequest(NeonBee neonBee, HttpMethod method, String path) {
+        WebClientOptions opts =
+                new WebClientOptions().setDefaultHost("localhost").setDefaultPort(neonBee.getOptions().getServerPort());
+        return WebClient.create(neonBee.getVertx(), opts).request(method, path);
+    }
+}

--- a/src/test/java/io/neonbee/data/internal/metrics/TestRequireDataVerticle.java
+++ b/src/test/java/io/neonbee/data/internal/metrics/TestRequireDataVerticle.java
@@ -1,0 +1,38 @@
+package io.neonbee.data.internal.metrics;
+
+import java.util.Collection;
+import java.util.List;
+
+import io.neonbee.NeonBeeDeployable;
+import io.neonbee.data.DataContext;
+import io.neonbee.data.DataMap;
+import io.neonbee.data.DataQuery;
+import io.neonbee.data.DataRequest;
+import io.neonbee.data.DataVerticle;
+import io.vertx.core.Future;
+
+@NeonBeeDeployable(namespace = TestRequireDataVerticle.NAMESPACE)
+public class TestRequireDataVerticle extends DataVerticle<String> {
+    private static final String NAME = TestRequireDataVerticle.class.getSimpleName();
+
+    public static final String NAMESPACE = "test";
+
+    public static final String QUALIFIED_NAME = createQualifiedName(NAMESPACE, NAME);
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Future<Collection<DataRequest>> requireData(DataQuery query, DataContext context) {
+        DataRequest request = new DataRequest(TestSourceDataVerticle.QUALIFIED_NAME);
+        return Future.succeededFuture(List.of(request));
+    }
+
+    @Override
+    public Future<String> retrieveData(DataQuery query, DataMap require, DataContext context) {
+        String requiredContent = require.resultFor(TestSourceDataVerticle.QUALIFIED_NAME);
+        return Future.succeededFuture(NAME + "[" + requiredContent + "]");
+    }
+}

--- a/src/test/java/io/neonbee/data/internal/metrics/TestSourceDataVerticle.java
+++ b/src/test/java/io/neonbee/data/internal/metrics/TestSourceDataVerticle.java
@@ -1,0 +1,28 @@
+package io.neonbee.data.internal.metrics;
+
+import io.neonbee.NeonBeeDeployable;
+import io.neonbee.data.DataContext;
+import io.neonbee.data.DataMap;
+import io.neonbee.data.DataQuery;
+import io.neonbee.data.DataVerticle;
+import io.vertx.core.Future;
+
+@NeonBeeDeployable(namespace = TestSourceDataVerticle.NAMESPACE)
+public class TestSourceDataVerticle extends DataVerticle<String> {
+
+    public static final String NAMESPACE = "test";
+
+    private static final String NAME = TestSourceDataVerticle.class.getSimpleName();
+
+    public static final String QUALIFIED_NAME = createQualifiedName(NAMESPACE, NAME);
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Future<String> retrieveData(DataQuery query, DataMap require, DataContext context) {
+        return Future.succeededFuture(NAME + " content");
+    }
+}


### PR DESCRIPTION
This feature adds metrics for the DataVertical methods requestData and retrieveData. Four metrics are implemented.

| metric | discription |
|---|---|
| Time metric | How long it takes to retrieve the data. |
| Status counter | How many requests completed successfully, how many requests failed |
| Number of requests | Total of all requests |
| Active requests | How many requests are currently open |

The metrics are disabled by default. You can enable the metrics for all DataVerticle by setting the NeonBeeConfig metrics.enabled value to true.
io.neonbee.NeonBee.yaml:
```yaml
# Other settings omitted.
metrics:
    enabled: true
```

The metrics can be also configured using the verticle configuration. To enable the metrics for a individual DataVerticle, it is necessary to add the config.metrics.enabled key with the value true. In addition, you can enable only specific metrics by specifying the metrics configuration name and a true value in the verticle configuration. If you have added a metrics configuration key, only the values with the specified true value are enabled. All others are disabled.

Complete yaml example configuration to enable the metrics:
```yaml
config:
  metrics:
    enabled: true
    meterRegistryName: SomeRegistryName
    reportNumberOfRequests: true
    reportActiveRequests: true
    reportStatusCounter: true
    reportTiming: true
```

