### PR TITLE
feat: add health checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     implementation group: 'io.vertx', name: 'vertx-auth-jwt', version: vertx_version
     implementation group: 'io.vertx', name: 'vertx-auth-oauth2', version: vertx_version
     implementation group: 'io.vertx', name: 'vertx-hazelcast', version: vertx_version
+    implementation group: 'io.vertx', name: 'vertx-health-check', version: vertx_version
 
     def jackson_version = '2.13.1'
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: jackson_version

--- a/resources/config/io.neonbee.NeonBee.yaml
+++ b/resources/config/io.neonbee.NeonBee.yaml
@@ -1,6 +1,12 @@
 ---
-# the number of seconds before a event bus message times-out, defaults to 30
+# the number of seconds before an event bus message times-out, defaults to 30
 eventBusTimeout: 110
+
+health:
+    # whether health-checks should be enabled or not
+    enabled: true
+    # the number of seconds before health check procedures time-out
+    timeout: 1
 
 # configure the tracking strategy implementation.
 trackingDataHandlingStrategy: io.neonbee.internal.tracking.TrackingDataLoggingStrategy

--- a/src/generated/java/io/neonbee/config/HealthConfigConverter.java
+++ b/src/generated/java/io/neonbee/config/HealthConfigConverter.java
@@ -1,0 +1,43 @@
+package io.neonbee.config;
+
+import java.util.Base64;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.impl.JsonUtil;
+
+/**
+ * Converter and mapper for {@link io.neonbee.config.HealthConfig}. NOTE: This class has been automatically generated
+ * from the {@link io.neonbee.config.HealthConfig} original class using Vert.x codegen.
+ */
+public class HealthConfigConverter {
+
+    private static final Base64.Decoder BASE64_DECODER = JsonUtil.BASE64_DECODER;
+
+    private static final Base64.Encoder BASE64_ENCODER = JsonUtil.BASE64_ENCODER;
+
+    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, HealthConfig obj) {
+        for (java.util.Map.Entry<String, Object> member : json) {
+            switch (member.getKey()) {
+            case "enabled":
+                if (member.getValue() instanceof Boolean) {
+                    obj.setEnabled((Boolean) member.getValue());
+                }
+                break;
+            case "timeout":
+                if (member.getValue() instanceof Number) {
+                    obj.setTimeout(((Number) member.getValue()).intValue());
+                }
+                break;
+            }
+        }
+    }
+
+    static void toJson(HealthConfig obj, JsonObject json) {
+        toJson(obj, json.getMap());
+    }
+
+    static void toJson(HealthConfig obj, java.util.Map<String, Object> json) {
+        json.put("enabled", obj.isEnabled());
+        json.put("timeout", obj.getTimeout());
+    }
+}

--- a/src/generated/java/io/neonbee/config/NeonBeeConfigConverter.java
+++ b/src/generated/java/io/neonbee/config/NeonBeeConfigConverter.java
@@ -34,6 +34,12 @@ public class NeonBeeConfigConverter {
                     obj.setEventBusTimeout(((Number) member.getValue()).intValue());
                 }
                 break;
+            case "healthConfig":
+                if (member.getValue() instanceof JsonObject) {
+                    obj.setHealthConfig(
+                            new io.neonbee.config.HealthConfig((io.vertx.core.json.JsonObject) member.getValue()));
+                }
+                break;
             case "micrometerRegistries":
                 if (member.getValue() instanceof JsonArray) {
                     java.util.ArrayList<io.neonbee.config.MicrometerRegistryConfig> list = new java.util.ArrayList<>();
@@ -80,6 +86,9 @@ public class NeonBeeConfigConverter {
             json.put("eventBusCodecs", map);
         }
         json.put("eventBusTimeout", obj.getEventBusTimeout());
+        if (obj.getHealthConfig() != null) {
+            json.put("healthConfig", obj.getHealthConfig().toJson());
+        }
         if (obj.getMicrometerRegistries() != null) {
             JsonArray array = new JsonArray();
             obj.getMicrometerRegistries().forEach(item -> array.add(item.toJson()));

--- a/src/main/java/io/neonbee/config/HealthConfig.java
+++ b/src/main/java/io/neonbee/config/HealthConfig.java
@@ -1,0 +1,84 @@
+package io.neonbee.config;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Global metrics configuration.
+ */
+@DataObject(generateConverter = true, publicConverter = false)
+public class HealthConfig {
+    private static final int DEFAULT_TIMEOUT = 1;
+
+    private int timeout = DEFAULT_TIMEOUT;
+
+    private boolean enabled = true;
+
+    /**
+     * Constructs an instance of {@linkplain HealthConfig}.
+     */
+    public HealthConfig() {}
+
+    /**
+     * Creates a {@linkplain HealthConfig} parsing a given JSON object.
+     *
+     * @param json the JSON object to parse
+     */
+    public HealthConfig(JsonObject json) {
+        HealthConfigConverter.fromJson(json, this);
+    }
+
+    /**
+     * Are health checks enabled?
+     *
+     * @return true if the health checks are enabled, otherwise false.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Sets the value to enable, disable health-checks.
+     *
+     * @param enabled true if health-checks should be enabled, false otherwise.
+     * @return the {@linkplain HealthConfig} for fluent use
+     */
+    @Fluent
+    public HealthConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    /**
+     * Gets the timeout of health check procedures.
+     *
+     * @return the timeout in seconds
+     */
+    public int getTimeout() {
+        return timeout;
+    }
+
+    /**
+     * Sets the timeout (in seconds) of health check procedures.
+     *
+     * @param healthTimeout the health check timeout to set
+     * @return the {@linkplain HealthConfig} for fluent use
+     */
+    @Fluent
+    public HealthConfig setTimeout(int healthTimeout) {
+        this.timeout = healthTimeout;
+        return this;
+    }
+
+    /**
+     * Transforms this configuration object into JSON.
+     *
+     * @return a JSON representation of this configuration
+     */
+    public JsonObject toJson() {
+        JsonObject json = new JsonObject();
+        HealthConfigConverter.toJson(this, json);
+        return json;
+    }
+}

--- a/src/main/java/io/neonbee/health/AbstractHealthCheck.java
+++ b/src/main/java/io/neonbee/health/AbstractHealthCheck.java
@@ -1,0 +1,77 @@
+package io.neonbee.health;
+
+import static io.neonbee.internal.helper.ConfigHelper.readConfig;
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+
+import java.util.function.Function;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import io.neonbee.NeonBee;
+import io.neonbee.health.internal.HealthCheck;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.healthchecks.CheckResult;
+import io.vertx.ext.healthchecks.Status;
+
+public abstract class AbstractHealthCheck implements HealthCheck {
+
+    @VisibleForTesting
+    static final long DEFAULT_RETENTION_TIME = 0L;
+
+    /**
+     * The health check config as {@link JsonObject}.
+     */
+    public JsonObject config;
+
+    private final NeonBee neonBee;
+
+    /**
+     * Constructs an instance of {@link AbstractHealthCheck}.
+     *
+     * @param neonBee the current NeonBee instance
+     */
+    public AbstractHealthCheck(NeonBee neonBee) {
+        this.neonBee = neonBee;
+    }
+
+    /**
+     * Creates a health check procedure.
+     *
+     * @return a function which returns a handler with a Status
+     */
+    abstract Function<NeonBee, Handler<Promise<Status>>> createProcedure();
+
+    @Override
+    public long getRetentionTime() {
+        return DEFAULT_RETENTION_TIME;
+    }
+
+    @Override
+    public Future<CheckResult> result() {
+        return failedFuture(new HealthCheckException(
+                "Abstract health check must be registered in a health check registry, first."));
+    }
+
+    /**
+     * Registers the health check to a passed {@link HealthCheckRegistry}.
+     *
+     * @param registry the health check registry
+     * @return the {@link HealthCheck} for fluent use
+     */
+    public Future<HealthCheck> register(HealthCheckRegistry registry) {
+        return readConfig(neonBee.getVertx(), this.getClass().getName()).compose(c -> {
+            this.config = c;
+            try {
+                return succeededFuture(
+                        isGlobal() ? registry.registerGlobalCheck(getId(), getRetentionTime(), createProcedure(), c)
+                                : registry.registerNodeCheck(getId(), getRetentionTime(), createProcedure(), c));
+            } catch (HealthCheckException e) {
+                return failedFuture(e);
+            }
+        });
+    }
+}

--- a/src/main/java/io/neonbee/health/HazelcastClusterHealthCheck.java
+++ b/src/main/java/io/neonbee/health/HazelcastClusterHealthCheck.java
@@ -1,0 +1,65 @@
+package io.neonbee.health;
+
+import java.util.function.Function;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.hazelcast.core.HazelcastInstance;
+
+import io.neonbee.NeonBee;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.healthchecks.Status;
+import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
+
+public class HazelcastClusterHealthCheck extends AbstractHealthCheck {
+    /**
+     * Name of the health check.
+     */
+    public static final String NAME = "cluster/hazelcast";
+
+    @VisibleForTesting
+    static final String EXPECTED_CLUSTER_SIZE_KEY = "expectedClusterSize";
+
+    private final HazelcastClusterManager clusterManager;
+
+    /**
+     * Constructs an instance of {@link HazelcastClusterHealthCheck}.
+     *
+     * @param neonBee        the current NeonBee instance
+     * @param clusterManager the cluster manager of Hazelcast
+     */
+    public HazelcastClusterHealthCheck(NeonBee neonBee, HazelcastClusterManager clusterManager) {
+        super(neonBee);
+        this.clusterManager = clusterManager;
+    }
+
+    @Override
+    public String getId() {
+        return NAME;
+    }
+
+    @Override
+    public boolean isGlobal() {
+        return true;
+    }
+
+    @Override
+    Function<NeonBee, Handler<Promise<Status>>> createProcedure() {
+        return neonBee -> healthCheckPromise -> neonBee.getVertx().executeBlocking(promise -> {
+            HazelcastInstance instance = clusterManager.getHazelcastInstance();
+            boolean lifecycleServiceRunning = instance.getLifecycleService().isRunning();
+            boolean ok = instance.getPartitionService().isClusterSafe() && lifecycleServiceRunning;
+
+            int clusterSize = instance.getCluster().getMembers().size();
+            if (config.containsKey(EXPECTED_CLUSTER_SIZE_KEY)) {
+                ok = ok && config.getInteger(EXPECTED_CLUSTER_SIZE_KEY) == clusterSize;
+            }
+
+            promise.complete(new Status().setOk(ok)
+                    .setData(new JsonObject().put("clusterState", instance.getCluster().getClusterState())
+                            .put("clusterSize", clusterSize)
+                            .put("lifecycleServiceState", lifecycleServiceRunning ? "ACTIVE" : "INACTIVE")));
+        }, false, healthCheckPromise);
+    }
+}

--- a/src/main/java/io/neonbee/health/HealthCheckException.java
+++ b/src/main/java/io/neonbee/health/HealthCheckException.java
@@ -1,0 +1,24 @@
+package io.neonbee.health;
+
+public class HealthCheckException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a new instance of {@link HealthCheckException}.
+     *
+     * @param message the message
+     */
+    public HealthCheckException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance of {@link HealthCheckException}.
+     *
+     * @param cause the cause
+     */
+    @SuppressWarnings("unused")
+    public HealthCheckException(Exception cause) {
+        super(cause.getMessage(), cause);
+    }
+}

--- a/src/main/java/io/neonbee/health/HealthCheckRegistry.java
+++ b/src/main/java/io/neonbee/health/HealthCheckRegistry.java
@@ -1,0 +1,176 @@
+package io.neonbee.health;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import io.neonbee.NeonBee;
+import io.neonbee.health.internal.HealthCheck;
+import io.neonbee.logging.LoggingFacade;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.healthchecks.CheckResult;
+import io.vertx.ext.healthchecks.HealthChecks;
+import io.vertx.ext.healthchecks.Status;
+
+public class HealthCheckRegistry {
+    private static final LoggingFacade LOGGER = LoggingFacade.create();
+
+    @VisibleForTesting
+    HealthChecks healthChecks;
+
+    @VisibleForTesting
+    final Map<String, HealthCheck> checks;
+
+    private final Map<String, HealthCheck> immutableChecks;
+
+    private final Vertx vertx;
+
+    /**
+     * Constructs a new instance of {@link HealthCheckRegistry}.
+     *
+     * @param vertx the current Vert.x instance
+     */
+    public HealthCheckRegistry(Vertx vertx) {
+        this.vertx = vertx;
+        checks = new HashMap<>();
+        immutableChecks = Collections.unmodifiableMap(checks);
+        healthChecks = HealthChecks.create(vertx);
+    }
+
+    /**
+     * Get a map with all health checks registered on this node, with the id of the health check as key.
+     *
+     * @return the health checks map
+     */
+    public Map<String, HealthCheck> getHealthChecks() {
+        return immutableChecks;
+    }
+
+    /**
+     * Registers a global health check. A global health check is a check that theoretically could be performed by every
+     * node, and does not check node specific parameters like CPU or RAM, for instance.
+     *
+     * @param id            the id of the health check
+     * @param retentionTime the duration how long a cached health status should be returned
+     * @param procedure     the health check procedure that should be registered
+     * @param config        the health check config
+     * @return the registered health check, or null if health checks are disabled globally
+     * @throws HealthCheckException if the health check is already registered
+     */
+    public HealthCheck registerGlobalCheck(String id, long retentionTime,
+            Function<NeonBee, Handler<Promise<Status>>> procedure, JsonObject config) throws HealthCheckException {
+        return register(id, retentionTime, true, procedure, config);
+    }
+
+    /**
+     * Registers a node health check, which checks node specific parameters like CPU or RAM.
+     *
+     * @param id            the id of the health check
+     * @param retentionTime the duration how long a cached health status should be returned
+     * @param procedure     the health check procedure that should be registered
+     * @param config        the health check config
+     * @return the registered health check, or null if health checks are disabled globally
+     * @throws HealthCheckException if the health check is already registered
+     */
+    public HealthCheck registerNodeCheck(String id, long retentionTime,
+            Function<NeonBee, Handler<Promise<Status>>> procedure, JsonObject config) throws HealthCheckException {
+        String nodePrefix = "node/" + NeonBee.get(vertx).getNodeId().strip() + "/";
+        return register(nodePrefix + id, retentionTime, false, procedure, config);
+    }
+
+    /**
+     * Registers a passed health check to the registry.
+     *
+     * @param healthCheck the health check to register
+     * @return the health check instance for fluent use.
+     */
+    public Future<HealthCheck> register(AbstractHealthCheck healthCheck) {
+        return healthCheck.register(this);
+    }
+
+    /**
+     * Unregister a health check from the registry.
+     *
+     * @param healthCheck the health check that should be unregistered
+     */
+    public void unregister(HealthCheck healthCheck) {
+        unregister(healthCheck.getId());
+    }
+
+    /**
+     * Unregister a health check from the registry.
+     *
+     * @param id the id of the health check that should be unregistered
+     */
+    public void unregister(String id) {
+        healthChecks.unregister(id);
+        checks.remove(id);
+    }
+
+    @SuppressWarnings({ "PMD.AvoidSynchronizedAtMethodLevel", "checkstyle:OverloadMethodsDeclarationOrder" })
+    private synchronized HealthCheck register(String id, long retentionTime, boolean global,
+            Function<NeonBee, Handler<Promise<Status>>> procedure, JsonObject healthCheckConfig)
+            throws HealthCheckException {
+        if (healthCheckConfig != null && !healthCheckConfig.getBoolean("enabled", true)) {
+            LOGGER.warn("HealthCheck '{}' is inactive.", id);
+            return null;
+        }
+
+        if (checks.containsKey(id)) {
+            throw new HealthCheckException("HealthCheck '" + id + "' already registered.");
+        }
+
+        healthChecks.register(id, getTimeout(healthCheckConfig).toMillis(), procedure.apply(NeonBee.get(vertx)));
+        HealthCheck healthCheck = new HealthCheck() {
+            private Future<CheckResult> lastCheckResult;
+
+            private Instant lastCheck;
+
+            @Override
+            public synchronized Future<CheckResult> result() {
+                Instant now = Instant.now();
+                if (lastCheckResult == null || now.isAfter(lastCheck.plusSeconds(getRetentionTime()))) {
+                    lastCheck = now;
+                    return lastCheckResult = healthChecks.checkStatus(id);
+                }
+
+                return lastCheckResult;
+            }
+
+            @Override
+            public String getId() {
+                return id;
+            }
+
+            @Override
+            public long getRetentionTime() {
+                return retentionTime;
+            }
+
+            @Override
+            public boolean isGlobal() {
+                return global;
+            }
+        };
+
+        this.checks.put(id, healthCheck);
+
+        return healthCheck;
+    }
+
+    private Duration getTimeout(JsonObject healthCheckConfig) {
+        long globalTimeout = NeonBee.get(vertx).getConfig().getHealthConfig().getTimeout();
+        return Duration.ofSeconds(Optional.ofNullable(healthCheckConfig).map(c -> c.getLong("timeout", globalTimeout))
+                .orElse(globalTimeout));
+    }
+}

--- a/src/main/java/io/neonbee/health/MemoryHealthCheck.java
+++ b/src/main/java/io/neonbee/health/MemoryHealthCheck.java
@@ -1,0 +1,72 @@
+package io.neonbee.health;
+
+import java.util.function.Function;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.hazelcast.memory.MemorySize;
+
+import io.neonbee.NeonBee;
+import io.neonbee.health.internal.MemoryStats;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.healthchecks.Status;
+
+public class MemoryHealthCheck extends AbstractHealthCheck {
+
+    /**
+     * Name of the health check.
+     */
+    public static final String NAME = "os/memory";
+
+    @VisibleForTesting
+    static final String CRITICAL_THRESHOLD_PERCENTAGE_KEY = "criticalThresholdPercentage";
+
+    private static final Integer DEFAULT_CRITICAL_THRESHOLD_PERCENTAGE = 90;
+
+    private static final double PERCENTAGE_MULTIPLIER = 100d;
+
+    @VisibleForTesting
+    MemoryStats memoryStats;
+
+    /**
+     * Constructs an instance of {@link MemoryHealthCheck}.
+     *
+     * @param neonBee the current NeonBee instance
+     */
+    public MemoryHealthCheck(NeonBee neonBee) {
+        super(neonBee);
+        memoryStats = new MemoryStats();
+    }
+
+    @Override
+    public String getId() {
+        return NAME;
+    }
+
+    @Override
+    public boolean isGlobal() {
+        return true;
+    }
+
+    @Override
+    Function<NeonBee, Handler<Promise<Status>>> createProcedure() {
+        return neonBee -> healthCheckPromise -> {
+            long usedMemory = memoryStats.getUsedHeap();
+            double memoryUsedOfTotalPercentage = (PERCENTAGE_MULTIPLIER * usedMemory) / memoryStats.getCommittedHeap();
+            double memoryUsedOfMaxPercentage = (PERCENTAGE_MULTIPLIER * usedMemory) / memoryStats.getMaxHeap();
+            boolean critical = memoryUsedOfMaxPercentage > config.getInteger(CRITICAL_THRESHOLD_PERCENTAGE_KEY,
+                    DEFAULT_CRITICAL_THRESHOLD_PERCENTAGE);
+
+            healthCheckPromise.complete(new Status().setOk(!critical).setData(
+                    new JsonObject().put("freeHeapMemory", MemorySize.toPrettyString(memoryStats.getFreeHeap()))
+                            .put("freePhysicalMemory", MemorySize.toPrettyString(memoryStats.getFreePhysical()))
+                            .put("memoryUsedOfTotalPercentage", printPercentage(memoryUsedOfTotalPercentage))
+                            .put("memoryUsedOfMaxPercentage", printPercentage(memoryUsedOfMaxPercentage))));
+        };
+    }
+
+    private static String printPercentage(double percentage) {
+        return String.format("%.2f%%", percentage);
+    }
+}

--- a/src/main/java/io/neonbee/health/internal/HealthCheck.java
+++ b/src/main/java/io/neonbee/health/internal/HealthCheck.java
@@ -1,0 +1,39 @@
+package io.neonbee.health.internal;
+
+import io.neonbee.health.HealthCheckRegistry;
+import io.vertx.core.Future;
+import io.vertx.ext.healthchecks.CheckResult;
+
+public interface HealthCheck {
+    /**
+     * Provides the name of the health check.
+     *
+     * @return the name of the {@link HealthCheck}
+     */
+    String getId();
+
+    /**
+     * Provides the retention time of a health check, which is defined as the duration between two consecutive health
+     * checks, in which a cached result will be returned before a new health check will be requested again.
+     *
+     * @return the time (in seconds) how long the health check result should be returned from the cache.
+     */
+    long getRetentionTime();
+
+    /**
+     * Indicates whether the health check is a globally scoped health check, or a node-specific health check. A node
+     * specific health check should be used for parameters that can be different on every node in a cluster like RAM or
+     * CPU, for instance.
+     *
+     * @return true if the {@link HealthCheck} is a global health check, false otherwise.
+     */
+    boolean isGlobal();
+
+    /**
+     * The result of a health check. Will throw an exception if the health check was not yet registered to a
+     * {@link HealthCheckRegistry registry}.
+     *
+     * @return a Future with the result of the health check.
+     */
+    Future<CheckResult> result();
+}

--- a/src/main/java/io/neonbee/health/internal/MemoryStats.java
+++ b/src/main/java/io/neonbee/health/internal/MemoryStats.java
@@ -1,0 +1,56 @@
+package io.neonbee.health.internal;
+
+import static com.hazelcast.internal.memory.MemoryStatsSupport.freePhysicalMemory;
+
+public class MemoryStats {
+    private final Runtime runtime = Runtime.getRuntime();
+
+    /**
+     * Returns the maximum amount of memory that the JVM will attempt to use.
+     *
+     * @return the maximum memory in bytes
+     * @see Runtime#maxMemory()
+     */
+    public long getMaxHeap() {
+        return runtime.maxMemory();
+    }
+
+    /**
+     * Returns the amount of memory that is committed for.
+     *
+     * @return the committed memory in bytes
+     * @see Runtime#totalMemory()
+     */
+    public long getCommittedHeap() {
+        return runtime.totalMemory();
+    }
+
+    /**
+     * Returns the amount of used memory in the JVM.
+     *
+     * @return the used memory in bytes
+     */
+    public long getUsedHeap() {
+        return runtime.totalMemory() - runtime.freeMemory();
+    }
+
+    /**
+     * Returns the amount of free memory in the JVM in bytes.
+     *
+     * @return the free memory in bytes
+     * @see Runtime#freeMemory()
+     */
+    public long getFreeHeap() {
+        return runtime.freeMemory();
+    }
+
+    /**
+     * Returns the free physical memory available in OS.
+     *
+     * @return the free physical memory in bytes.
+     * @see com.hazelcast.internal.memory.MemoryStatsSupport#freePhysicalMemory()
+     */
+    public long getFreePhysical() {
+        return freePhysicalMemory();
+    }
+}

--- a/src/test/java/io/neonbee/NeonBeeMockHelper.java
+++ b/src/test/java/io/neonbee/NeonBeeMockHelper.java
@@ -30,6 +30,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.file.FileSystem;
+import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
 
 public final class NeonBeeMockHelper {
     /**
@@ -243,7 +244,7 @@ public final class NeonBeeMockHelper {
      */
     public static NeonBee registerNeonBeeMock(Vertx vertx, NeonBeeOptions options, NeonBeeConfig config) {
         createLogger(); // the logger is only created internally, create one manually if required
-        return new NeonBee(vertx, options, config, new CompositeMeterRegistry());
+        return new NeonBee(vertx, options, config, new CompositeMeterRegistry(), new HazelcastClusterManager());
     }
 
     @SuppressWarnings({ "CatchAndPrintStackTrace", "PMD.AvoidPrintStackTrace" })

--- a/src/test/java/io/neonbee/NeonBeeTest.java
+++ b/src/test/java/io/neonbee/NeonBeeTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -198,6 +199,12 @@ class NeonBeeTest extends NeonBeeTestBase {
         assertThat(getNeonBee().isLocalConsumerAvailable(address)).isTrue();
         getNeonBee().unregisterLocalConsumer(address);
         assertThat(getNeonBee().isLocalConsumerAvailable(address)).isFalse();
+    }
+
+    @Test
+    @DisplayName("NeonBee should have a (unique) node id")
+    void testGetNodeId() {
+        assertThat(getNeonBee().getNodeId()).matches(Pattern.compile("[0-9a-zA-Z\\-]+"));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/io/neonbee/config/NeonBeeConfigTest.java
+++ b/src/test/java/io/neonbee/config/NeonBeeConfigTest.java
@@ -173,6 +173,30 @@ class NeonBeeConfigTest extends NeonBeeTestBase {
     }
 
     @Test
+    @DisplayName("should read the health config correctly")
+    void testReadMetricsConfig() {
+        JsonObject settings = new JsonObject();
+        Function<Boolean, JsonObject> buildConfig =
+                enabled -> settings.put("health", new JsonObject().put("enabled", enabled));
+
+        NeonBeeConfig neonBeeConfig = new NeonBeeConfig(buildConfig.apply(true));
+        assertThat(neonBeeConfig.getHealthConfig().isEnabled()).isTrue();
+
+        neonBeeConfig = new NeonBeeConfig(buildConfig.apply(false));
+        assertThat(neonBeeConfig.getHealthConfig().isEnabled()).isFalse();
+    }
+
+    @Test
+    @DisplayName("should create the metrics config correctly")
+    void testHealthConfigToJson() {
+        NeonBeeConfig config = new NeonBeeConfig();
+        config.getHealthConfig().setEnabled(false);
+        JsonObject actual = config.toJson();
+
+        assertThat(actual.getJsonObject("health")).isEqualTo(new JsonObject().put("enabled", false).put("timeout", 1));
+    }
+
+    @Test
     @DisplayName("should have the correct default values")
     void testDefaultValues() {
         NeonBeeConfig defaultConfig = new NeonBeeConfig();
@@ -182,6 +206,8 @@ class NeonBeeConfigTest extends NeonBeeTestBase {
         assertThat(defaultConfig.getEventBusCodecs()).isEmpty();
         assertThat(defaultConfig.getPlatformClasses()).containsExactly("io.vertx.*", "io.neonbee.*", "org.slf4j.*",
                 "org.apache.olingo.*");
+        assertThat(defaultConfig.getHealthConfig().isEnabled()).isTrue();
+        assertThat(defaultConfig.getHealthConfig().getTimeout()).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/io/neonbee/health/AbstractHealthCheckTest.java
+++ b/src/test/java/io/neonbee/health/AbstractHealthCheckTest.java
@@ -1,0 +1,105 @@
+package io.neonbee.health;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.neonbee.health.AbstractHealthCheck.DEFAULT_RETENTION_TIME;
+import static io.neonbee.test.helper.OptionsHelper.defaultOptions;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.neonbee.NeonBee;
+import io.neonbee.NeonBeeMockHelper;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.healthchecks.Status;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class AbstractHealthCheckTest {
+    private static final String DUMMY_ID = "dummy/check-0";
+
+    private static Vertx vertxMock;
+
+    private AbstractHealthCheck hc;
+
+    @BeforeEach
+    void setUp() {
+        vertxMock = NeonBeeMockHelper.defaultVertxMock();
+        NeonBeeMockHelper.registerNeonBeeMock(vertxMock, defaultOptions());
+        hc = createDummyHealthCheck(true, true, null);
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("cannot get a health check result if health check was not registered to registry")
+    void testResultFails(VertxTestContext testContext) {
+        hc.result().onComplete(testContext.failing(t -> testContext.verify(() -> {
+            assertThat(t.getMessage()).contains("must be registered");
+            testContext.completeNow();
+        })));
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("can register global checks")
+    void testRegisterGlobalCheck(VertxTestContext testContext) throws HealthCheckException {
+        HealthCheckRegistry registry = mock(HealthCheckRegistry.class);
+        when(registry.registerGlobalCheck(anyString(), anyLong(), any(), any())).thenReturn(hc);
+
+        hc.register(registry).onComplete(testContext.succeeding(check -> testContext.verify(() -> {
+            assertThat(check.isGlobal()).isTrue();
+            verify(registry).registerGlobalCheck(eq(DUMMY_ID), eq(DEFAULT_RETENTION_TIME), any(), eq(new JsonObject()));
+            testContext.completeNow();
+        })));
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("can register node-specific checks")
+    void testRegisterNodeCheck(VertxTestContext testContext) throws HealthCheckException {
+        HealthCheckRegistry registry = mock(HealthCheckRegistry.class);
+        hc = createDummyHealthCheck(false, true, null);
+        when(registry.registerNodeCheck(anyString(), anyLong(), any(), any())).thenReturn(hc);
+
+        hc.register(registry).onComplete(testContext.succeeding(check -> testContext.verify(() -> {
+            assertThat(check.isGlobal()).isFalse();
+            verify(registry).registerNodeCheck(eq(DUMMY_ID), eq(DEFAULT_RETENTION_TIME), any(), eq(new JsonObject()));
+            testContext.completeNow();
+        })));
+    }
+
+    private static AbstractHealthCheck createDummyHealthCheck(boolean global, boolean ok, JsonObject data) {
+        return new AbstractHealthCheck(NeonBee.get(vertxMock)) {
+            @Override
+            Function<NeonBee, Handler<Promise<Status>>> createProcedure() {
+                return nb -> p -> p.complete(new Status().setOk(ok).setData(data));
+            }
+
+            @Override
+            public String getId() {
+                return DUMMY_ID;
+            }
+
+            @Override
+            public boolean isGlobal() {
+                return global;
+            }
+        };
+    }
+}

--- a/src/test/java/io/neonbee/health/HazelcastClusterHealthCheckTest.java
+++ b/src/test/java/io/neonbee/health/HazelcastClusterHealthCheckTest.java
@@ -1,0 +1,128 @@
+package io.neonbee.health;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.neonbee.health.HazelcastClusterHealthCheck.EXPECTED_CLUSTER_SIZE_KEY;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.hazelcast.cluster.Cluster;
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.cluster.impl.MemberImpl;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.LifecycleService;
+import com.hazelcast.partition.PartitionService;
+
+import io.neonbee.NeonBee;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.healthchecks.HealthChecks;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
+
+@ExtendWith(VertxExtension.class)
+class HazelcastClusterHealthCheckTest {
+    private NeonBee neonBee;
+
+    private HealthChecks checks;
+
+    private HazelcastClusterManager mockedManager;
+
+    private HazelcastClusterHealthCheck clusterHealthCheck;
+
+    PartitionService mockedPartitionService;
+
+    HazelcastInstance mockedHazelcast;
+
+    LifecycleService mockedLifecycleService;
+
+    Cluster mockedCluster;
+
+    @BeforeEach
+    void setUp(Vertx vertx) {
+        checks = HealthChecks.create(vertx);
+        mockedManager = mock(HazelcastClusterManager.class);
+        clusterHealthCheck = new HazelcastClusterHealthCheck(NeonBee.get(vertx), mockedManager);
+        neonBee = mock(NeonBee.class);
+        mockedPartitionService = mock(PartitionService.class);
+        mockedHazelcast = mock(HazelcastInstance.class);
+        mockedLifecycleService = mock(LifecycleService.class);
+        mockedCluster = mock(Cluster.class);
+
+        when(neonBee.getVertx()).thenReturn(vertx);
+        when(mockedPartitionService.isClusterSafe()).thenReturn(true);
+        when(mockedHazelcast.getPartitionService()).thenReturn(mockedPartitionService);
+        when(mockedLifecycleService.isRunning()).thenReturn(true);
+        when(mockedHazelcast.getLifecycleService()).thenReturn(mockedLifecycleService);
+        when(mockedManager.getHazelcastInstance()).thenReturn(mockedHazelcast);
+        when(mockedCluster.getClusterState()).thenReturn(ClusterState.ACTIVE);
+        when(mockedCluster.getMembers()).thenReturn(Set.of(new MemberImpl()));
+        when(mockedHazelcast.getCluster()).thenReturn(mockedCluster);
+
+        assertThat(clusterHealthCheck.isGlobal()).isTrue();
+        assertThat(clusterHealthCheck.getId()).startsWith("cluster/");
+    }
+
+    private static Stream<Arguments> provideStatus() {
+        return Stream.of(Arguments.of(true, true), Arguments.of(true, false), Arguments.of(false, true),
+                Arguments.of(false, false));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideStatus")
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("should set health status only to UP, when cluster state is healthy")
+    void testCreateProcedure(boolean clusterUp, boolean serviceUp, Vertx vertx, VertxTestContext testContext) {
+        when(mockedPartitionService.isClusterSafe()).thenReturn(clusterUp);
+        when(mockedHazelcast.getPartitionService()).thenReturn(mockedPartitionService);
+        when(mockedLifecycleService.isRunning()).thenReturn(serviceUp);
+        when(mockedHazelcast.getLifecycleService()).thenReturn(mockedLifecycleService);
+        when(mockedManager.getHazelcastInstance()).thenReturn(mockedHazelcast);
+        when(mockedCluster.getClusterState()).thenReturn(clusterUp ? ClusterState.ACTIVE : ClusterState.IN_TRANSITION);
+        when(mockedHazelcast.getCluster()).thenReturn(mockedCluster);
+
+        clusterHealthCheck.config = new JsonObject().put(EXPECTED_CLUSTER_SIZE_KEY, 1);
+
+        checks.register(HazelcastClusterHealthCheck.NAME, clusterHealthCheck.createProcedure().apply(neonBee));
+        checks.checkStatus(HazelcastClusterHealthCheck.NAME)
+                .onComplete(testContext.succeeding(result -> testContext.verify(() -> {
+                    assertThat(result.getUp()).isEqualTo(clusterUp && serviceUp);
+                    assertThat(result.getData().size()).isEqualTo(3);
+
+                    assertThat(result.getData().getInteger("clusterSize")).isEqualTo(1);
+                    assertThat(result.getData().getString("clusterState"))
+                            .isEqualTo(clusterUp ? "ACTIVE" : "IN_TRANSITION");
+                    assertThat(result.getData().getString("lifecycleServiceState"))
+                            .isEqualTo(serviceUp ? "ACTIVE" : "INACTIVE");
+                    testContext.completeNow();
+                })));
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("should set health status to DOWN if cluster size does not match the expected from config")
+    void testClusterSizeBelowExpected(Vertx vertx, VertxTestContext testContext) {
+        clusterHealthCheck.config = new JsonObject().put(EXPECTED_CLUSTER_SIZE_KEY, 3);
+
+        checks.register(HazelcastClusterHealthCheck.NAME, clusterHealthCheck.createProcedure().apply(neonBee));
+        checks.checkStatus(HazelcastClusterHealthCheck.NAME)
+                .onComplete(testContext.succeeding(result -> testContext.verify(() -> {
+                    assertThat(result.getUp()).isFalse();
+                    assertThat(result.getData().getInteger("clusterSize")).isEqualTo(1);
+                    testContext.completeNow();
+                })));
+    }
+}

--- a/src/test/java/io/neonbee/health/HealthCheckRegistryTest.java
+++ b/src/test/java/io/neonbee/health/HealthCheckRegistryTest.java
@@ -1,0 +1,245 @@
+package io.neonbee.health;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.neonbee.test.helper.OptionsHelper.defaultOptions;
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.endsWith;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+
+import io.neonbee.NeonBee;
+import io.neonbee.NeonBeeMockHelper;
+import io.neonbee.NeonBeeOptions;
+import io.neonbee.config.HealthConfig;
+import io.neonbee.config.NeonBeeConfig;
+import io.neonbee.health.internal.HealthCheck;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.file.FileSystem;
+import io.vertx.core.file.FileSystemException;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.healthchecks.HealthChecks;
+import io.vertx.ext.healthchecks.Status;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class HealthCheckRegistryTest {
+
+    private static final String DUMMY_ID = "dummy-group/check-0";
+
+    private static final String NODE_ID = "this-is-a-fake-uuid";
+
+    private static final long RETENTION_TIME = 12L;
+
+    private Vertx vertxMock;
+
+    private AbstractHealthCheck dummyCheck;
+
+    @BeforeEach
+    void setUp() {
+        vertxMock = NeonBeeMockHelper.defaultVertxMock();
+        NeonBee neonBee = NeonBeeMockHelper.registerNeonBeeMock(vertxMock, defaultOptions(),
+                new NeonBeeConfig().setHealthConfig(new HealthConfig().setEnabled(true).setTimeout(2)));
+        dummyCheck = new AbstractHealthCheck(neonBee) {
+            @Override
+            Function<NeonBee, Handler<Promise<Status>>> createProcedure() {
+                return nb -> p -> p.complete(new Status().setOK());
+            }
+
+            @Override
+            public String getId() {
+                return DUMMY_ID;
+            }
+
+            @Override
+            public boolean isGlobal() {
+                return true;
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("it can list all health checks")
+    void getHealthChecks() {
+        HealthCheckRegistry registry = new HealthCheckRegistry(vertxMock);
+
+        assertThat(registry.getHealthChecks()).isEmpty();
+        registry.checks.put("check-1", mock(HealthCheck.class));
+        assertThat(registry.getHealthChecks().size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("it can register global checks")
+    void registerGlobalCheck() throws HealthCheckException {
+        NeonBee neonBeeMock = mock(NeonBee.class);
+        when(neonBeeMock.getNodeId()).thenReturn(NODE_ID);
+        when(neonBeeMock.getConfig()).thenReturn(new NeonBeeConfig().setHealthConfig(new HealthConfig()));
+
+        try (MockedStatic<NeonBee> mocked = mockStatic(NeonBee.class)) {
+            mocked.when(() -> NeonBee.get(any(Vertx.class))).thenReturn(neonBeeMock);
+
+            HealthCheckRegistry registry = new HealthCheckRegistry(vertxMock);
+            HealthCheck healthCheck = registry.registerGlobalCheck(DUMMY_ID, RETENTION_TIME,
+                    nb -> p -> p.complete(new Status()), new JsonObject());
+
+            assertThat(healthCheck.getId()).contains(DUMMY_ID);
+            assertThat(healthCheck.getRetentionTime()).isEqualTo(RETENTION_TIME);
+            assertThat(registry.getHealthChecks().size()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    @DisplayName("it can register node checks")
+    void registerNodeCheck() throws HealthCheckException {
+        NeonBee neonBeeMock = mock(NeonBee.class);
+        when(neonBeeMock.getNodeId()).thenReturn(NODE_ID);
+        when(neonBeeMock.getConfig()).thenReturn(new NeonBeeConfig().setHealthConfig(new HealthConfig()));
+
+        try (MockedStatic<NeonBee> mocked = mockStatic(NeonBee.class)) {
+            mocked.when(() -> NeonBee.get(any(Vertx.class))).thenReturn(neonBeeMock);
+
+            HealthCheckRegistry registry = new HealthCheckRegistry(vertxMock);
+            HealthCheck healthCheck = registry.registerNodeCheck(DUMMY_ID, RETENTION_TIME,
+                    nb -> p -> p.complete(new Status()), new JsonObject());
+
+            assertThat(healthCheck.getId()).matches(Pattern.compile("node/" + NODE_ID + "/" + DUMMY_ID));
+            assertThat(healthCheck.getRetentionTime()).isEqualTo(RETENTION_TIME);
+            assertThat(registry.getHealthChecks().size()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    @DisplayName("it can only register health checks with unique names")
+    void register(VertxTestContext testContext) {
+        Checkpoint cp = testContext.checkpoint(3);
+
+        HealthCheckRegistry registry = new HealthCheckRegistry(vertxMock);
+        registry.register(dummyCheck).onComplete(testContext.succeeding(hc -> testContext.verify(() -> {
+            assertThat(registry.checks.size()).isEqualTo(1);
+            assertThat(registry.checks.get(DUMMY_ID).getId()).isEqualTo(DUMMY_ID);
+            cp.flag();
+
+            registry.register(dummyCheck).onComplete(testContext.failing(t -> testContext.verify(() -> {
+                assertThat(t.getMessage()).isEqualTo("HealthCheck '" + DUMMY_ID + "' already registered.");
+                assertThat(t).isInstanceOf(HealthCheckException.class);
+                assertThat(registry.checks.size()).isEqualTo(1);
+                cp.flag();
+
+                AbstractHealthCheck otherCheck = new AbstractHealthCheck(NeonBee.get(vertxMock)) {
+                    @Override
+                    Function<NeonBee, Handler<Promise<Status>>> createProcedure() {
+                        return neonBee -> p -> p.complete(new Status().setOK());
+                    }
+
+                    @Override
+                    public String getId() {
+                        return "other-dummy";
+                    }
+
+                    @Override
+                    public boolean isGlobal() {
+                        return true;
+                    }
+                };
+
+                registry.register(otherCheck).onComplete(testContext.succeeding(v -> testContext.verify(() -> {
+                    assertThat(registry.checks.size()).isEqualTo(2);
+                    cp.flag();
+                })));
+            })));
+        })));
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("should prefer disabling of health checks from health check config of config folder")
+    void testCustomConfigEnabled(VertxTestContext testContext) {
+        FileSystem fileSystemMock = vertxMock.fileSystem();
+        NeonBeeMockHelper.registerNeonBeeMock(vertxMock, new NeonBeeOptions.Mutable().setWorkingDirectory(Path.of("")),
+                new NeonBeeConfig().setHealthConfig(new HealthConfig().setEnabled(true)));
+        HealthCheckRegistry registry = new HealthCheckRegistry(vertxMock);
+
+        when(fileSystemMock.readFile(any()))
+                .thenReturn(failedFuture(new FileSystemException(new NoSuchFileException("file"))));
+        when(fileSystemMock.readFile(endsWith(".yml")))
+                .thenReturn(succeededFuture(Buffer.buffer("---\nenabled: false")));
+
+        dummyCheck.register(registry).onComplete(testContext.succeeding(check -> testContext.verify(() -> {
+            assertThat(check).isNull();
+            testContext.completeNow();
+        })));
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("should prefer enablement of health checks and timeout from health check config of config folder")
+    void testCustomConfigDisabled(VertxTestContext testContext) {
+        FileSystem fileSystemMock = vertxMock.fileSystem();
+        NeonBeeMockHelper.registerNeonBeeMock(vertxMock, new NeonBeeOptions.Mutable().setWorkingDirectory(Path.of("")),
+                new NeonBeeConfig().setHealthConfig(new HealthConfig().setEnabled(false).setTimeout(2)));
+        HealthCheckRegistry registry = new HealthCheckRegistry(vertxMock);
+        HealthChecks mockedChecks = mock(HealthChecks.class);
+
+        when(mockedChecks.register(anyString(), anyLong(), any())).thenReturn(mockedChecks);
+        registry.healthChecks = mockedChecks;
+        when(fileSystemMock.readFile(any()))
+                .thenReturn(failedFuture(new FileSystemException(new NoSuchFileException("file"))));
+        when(fileSystemMock.readFile(endsWith(".yml")))
+                .thenReturn(succeededFuture(Buffer.buffer("---\nenabled: true\ntimeout: 3")));
+
+        dummyCheck.register(registry).onComplete(testContext.succeeding(check -> testContext.verify(() -> {
+            assertThat(registry.checks.size()).isEqualTo(1);
+            verify(registry.healthChecks).register(eq(DUMMY_ID), eq(3000L), any());
+            testContext.completeNow();
+        })));
+    }
+
+    @Test
+    @DisplayName("it can unregister health checks by health object and id")
+    void testUnregister() {
+        HealthCheckRegistry registry = new HealthCheckRegistry(vertxMock);
+        HealthChecks mockedChecks = mock(HealthChecks.class);
+        when(mockedChecks.register(anyString(), anyLong(), any())).thenReturn(mockedChecks);
+        registry.healthChecks = mockedChecks;
+
+        registry.register(dummyCheck);
+        assertThat(registry.checks.size()).isEqualTo(1);
+
+        registry.unregister(dummyCheck);
+        assertThat(registry.checks.size()).isEqualTo(0);
+
+        registry.register(dummyCheck);
+        assertThat(registry.checks.size()).isEqualTo(1);
+
+        registry.unregister(DUMMY_ID);
+        assertThat(registry.checks.size()).isEqualTo(0);
+
+        verify(mockedChecks, times(2)).register(eq(DUMMY_ID), eq(2000L), any());
+        verify(mockedChecks, times(2)).unregister(eq(DUMMY_ID));
+    }
+}

--- a/src/test/java/io/neonbee/health/MemoryHealthCheckTest.java
+++ b/src/test/java/io/neonbee/health/MemoryHealthCheckTest.java
@@ -1,0 +1,102 @@
+package io.neonbee.health;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.neonbee.health.MemoryHealthCheck.CRITICAL_THRESHOLD_PERCENTAGE_KEY;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.neonbee.NeonBee;
+import io.neonbee.config.HealthConfig;
+import io.neonbee.config.NeonBeeConfig;
+import io.neonbee.health.internal.MemoryStats;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.healthchecks.HealthChecks;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class MemoryHealthCheckTest {
+    private NeonBee neonBee;
+
+    private MemoryHealthCheck memoryHealthCheck;
+
+    private HealthChecks checks;
+
+    @BeforeEach
+    void setUp(Vertx vertx) {
+        checks = HealthChecks.create(vertx);
+        memoryHealthCheck = new MemoryHealthCheck(NeonBee.get(vertx));
+        memoryHealthCheck.memoryStats = new MemoryStats() {
+            @Override
+            public long getMaxHeap() {
+                return 512_000_000;
+            }
+
+            @Override
+            public long getCommittedHeap() {
+                return 256_000_000;
+            }
+
+            @Override
+            public long getFreeHeap() {
+                return 128_000_000;
+            }
+
+            @Override
+            public long getUsedHeap() {
+                return this.getCommittedHeap() - this.getFreeHeap();
+            }
+        };
+        neonBee = mock(NeonBee.class);
+
+        when(neonBee.getConfig()).thenReturn(new NeonBeeConfig().setHealthConfig(new HealthConfig()));
+
+        assertThat(memoryHealthCheck.isGlobal()).isTrue();
+        assertThat(memoryHealthCheck.getId()).startsWith("os/");
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("should set health check to up if used memory is below configured threshold of health config")
+    void testCreateProcedureHealthy(VertxTestContext testContext) {
+        memoryHealthCheck.config = new JsonObject().put(CRITICAL_THRESHOLD_PERCENTAGE_KEY, 26);
+
+        checks.register(MemoryHealthCheck.NAME, memoryHealthCheck.createProcedure().apply(neonBee));
+        checks.checkStatus(MemoryHealthCheck.NAME)
+                .onComplete(testContext.succeeding(result -> testContext.verify(() -> {
+                    assertThat(result.getData().size()).isEqualTo(4);
+                    assertThat(result.getData().getString("freeHeapMemory")).isEqualTo("122 MB");
+                    assertThat(result.getData().getString("memoryUsedOfTotalPercentage")).matches("50[,.]{1}00%");
+                    assertThat(result.getData().getString("memoryUsedOfMaxPercentage")).matches("25[,.]{1}00%");
+                    assertThat(result.getUp()).isTrue();
+                    testContext.completeNow();
+                })));
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("should set health check to down if used memory is above configured threshold of health config")
+    void testCreateProcedureUnhealthy(VertxTestContext testContext) {
+        memoryHealthCheck.config = new JsonObject().put(CRITICAL_THRESHOLD_PERCENTAGE_KEY, 24);
+
+        checks.register(MemoryHealthCheck.NAME, memoryHealthCheck.createProcedure().apply(neonBee));
+        checks.checkStatus(MemoryHealthCheck.NAME)
+                .onComplete(testContext.succeeding(result -> testContext.verify(() -> {
+                    assertThat(result.getData().size()).isEqualTo(4);
+                    assertThat(result.getData().getString("freeHeapMemory")).isEqualTo("122 MB");
+                    assertThat(result.getData().getString("memoryUsedOfTotalPercentage")).matches("50[,.]{1}00%");
+                    assertThat(result.getData().getString("memoryUsedOfMaxPercentage")).matches("25[,.]{1}00%");
+                    assertThat(result.getUp()).isFalse();
+                    testContext.completeNow();
+                })));
+    }
+}


### PR DESCRIPTION
In order to provide a generic and extendable way of creating health
checks in NeonBee, a central registry is needed where health checks can
be provided. To achieve this, a `HealthCheckRegistry` is added to
NeonBee which will keep track of all default health checks of NeonBee
and custom health checks provided by the NeonBee user.

Vert.x already comes with a health check plugin which will be used for
the health check objects that can be registered on to the registry.
However, as the plugin does not prevent overriding of already existing
health check procedures, a wrapper is necessary to provide this
functionality. In addition, a caching mechanism is implemented which can
be controlled via the retention time. The retention time is the time
from the last health check until a new health check procedure is
triggered. If the next health check is inside this retention window, the
cached result of the previous health check will be returned.

The health checks can be be globally enabled / disabled and a timeout
for the checks can be set via the NeonBeeConfig.

Resolves #117