### PR TITLE
fix: vert.x worker threads included in StaleThreadChecker

### DIFF
--- a/src/test/java/io/neonbee/test/listeners/StaleThreadChecker.java
+++ b/src/test/java/io/neonbee/test/listeners/StaleThreadChecker.java
@@ -14,18 +14,13 @@ import org.junit.platform.launcher.TestPlan;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.SetMultimap;
-import io.vertx.core.Vertx;
-
 /**
  * The {@link StaleThreadChecker} checks for any stale threads after test execution. Generally after a test finishes to
  * execute it must clean up all resources. If not this listener will print an error to the logs.
  */
 public class StaleThreadChecker implements TestExecutionListener {
-    public static final SetMultimap<Vertx, String> VERTX_TEST_MAP = HashMultimap.create();
 
-    static final String VERTX_THREAD_NAME_PREFIX = "vert.x-";
+    static final String VERTX_EVENTLOOP_THREAD_NAME_PREFIX = "vert.x-eventloop";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StaleThreadChecker.class);
 
@@ -51,7 +46,7 @@ public class StaleThreadChecker implements TestExecutionListener {
     @Override
     public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
         if (!parallelExecution) {
-            checkForStaleThreads("Vert.x", VERTX_THREAD_NAME_PREFIX);
+            checkForStaleThreads("Vert.x", VERTX_EVENTLOOP_THREAD_NAME_PREFIX);
             checkForStaleThreads("Hazelcast", "hz.");
             checkForStaleThreads("WatchService", "FileSystemWatch");
         }

--- a/src/test/java/io/neonbee/test/listeners/StaleVertxChecker.java
+++ b/src/test/java/io/neonbee/test/listeners/StaleVertxChecker.java
@@ -88,8 +88,8 @@ public class StaleVertxChecker extends StaleThreadChecker {
         LOGGER.info("Checking for stale Vert.x instances");
 
         // first try to determine all Vert.x instances that are currently available (and running?)
-        Set<Vertx> vertxInstances = findStaleThreads(VERTX_THREAD_NAME_PREFIX).filter(VertxThread.class::isInstance)
-                .map(VertxThread.class::cast).map(thread -> {
+        Set<Vertx> vertxInstances = findStaleThreads(VERTX_EVENTLOOP_THREAD_NAME_PREFIX)
+                .filter(VertxThread.class::isInstance).map(VertxThread.class::cast).map(thread -> {
                     try {
                         Context context = (Context) CONTEXT_METHOD.invoke(thread);
                         if (context == null) {


### PR DESCRIPTION
The StaleThreadChecker currently checks for all vert.x threads. This also includes the worker threads. However, a worker thread may be blocked and should therefore not be included in this check.