### PR TITLE
feat: Make ServerVerticle handler configurable.

### DIFF
--- a/docs/ServerVerticle.md
+++ b/docs/ServerVerticle.md
@@ -1,0 +1,25 @@
+# ServerVerticle configuration
+
+## Configuration
+
+### Handler factories
+
+Handler factories are used to register routing handlers on the root router in the ServerVerticle. A handler factory must
+implement the `io.neonbee.internal.handler.factories.RoutingHandlerFactory` interface and must be configured in the
+handlerFactories section of the ServerVerticle configuration. The configured handlerFactories are loaded and added in
+the configured order.
+The order of handler factories has to take the priority of the returned handlers into account.
+See `io.vertx.ext.web.impl.RouteState.weight` If the order is violated, an Exception is thrown.
+
+#### Default configuration
+
+```yaml
+handlerFactories:
+- io.neonbee.internal.handler.factories.LoggerHandlerFactory
+- io.neonbee.internal.handler.factories.InstanceInfoHandlerFactory
+- io.neonbee.internal.handler.factories.CorrelationIdHandlerFactory
+- io.neonbee.internal.handler.factories.TimeoutHandlerFactory
+- io.neonbee.internal.handler.factories.SessionHandlerFactory
+- io.neonbee.internal.handler.factories.CacheControlHandlerFactory
+- io.neonbee.internal.handler.factories.DisallowingFileUploadBodyHandlerFactory
+```

--- a/resources/config/io.neonbee.internal.verticle.ServerVerticle.example.yaml
+++ b/resources/config/io.neonbee.internal.verticle.ServerVerticle.example.yaml
@@ -91,3 +91,13 @@ config:
             # the authentication provider to be set for this handler# any of: HTDIGEST, HTPASSWD, JDBC, JWT, MONGO, OAUTH2, mandatory attribute
             type: string
             # ... more authentication provider options (see the specific provider implementations)
+
+    #  default handler factories. The order of handler factories has to take the priority of the returned handlers into account.
+    handlerFactories:
+    - io.neonbee.internal.handler.factories.LoggerHandlerFactory
+    - io.neonbee.internal.handler.factories.InstanceInfoHandlerFactory
+    - io.neonbee.internal.handler.factories.CorrelationIdHandlerFactory
+    - io.neonbee.internal.handler.factories.TimeoutHandlerFactory
+    - io.neonbee.internal.handler.factories.SessionHandlerFactory
+    - io.neonbee.internal.handler.factories.CacheControlHandlerFactory
+    - io.neonbee.internal.handler.factories.DisallowingFileUploadBodyHandlerFactory

--- a/src/generated/java/io/neonbee/config/ServerConfigConverter.java
+++ b/src/generated/java/io/neonbee/config/ServerConfigConverter.java
@@ -55,6 +55,16 @@ public class ServerConfigConverter {
                     obj.setErrorHandlerTemplate((String) member.getValue());
                 }
                 break;
+            case "handlerFactoriesClassNames":
+                if (member.getValue() instanceof JsonArray) {
+                    java.util.ArrayList<java.lang.String> list = new java.util.ArrayList<>();
+                    ((Iterable<Object>) member.getValue()).forEach(item -> {
+                        if (item instanceof String)
+                            list.add((String) item);
+                    });
+                    obj.setHandlerFactoriesClassNames(list);
+                }
+                break;
             case "sessionCookieName":
                 if (member.getValue() instanceof String) {
                     obj.setSessionCookieName((String) member.getValue());
@@ -103,6 +113,11 @@ public class ServerConfigConverter {
         }
         if (obj.getErrorHandlerTemplate() != null) {
             json.put("errorHandlerTemplate", obj.getErrorHandlerTemplate());
+        }
+        if (obj.getHandlerFactoriesClassNames() != null) {
+            JsonArray array = new JsonArray();
+            obj.getHandlerFactoriesClassNames().forEach(item -> array.add(item));
+            json.put("handlerFactoriesClassNames", array);
         }
         if (obj.getSessionCookieName() != null) {
             json.put("sessionCookieName", obj.getSessionCookieName());

--- a/src/main/java/io/neonbee/internal/handler/factories/CacheControlHandlerFactory.java
+++ b/src/main/java/io/neonbee/internal/handler/factories/CacheControlHandlerFactory.java
@@ -1,0 +1,19 @@
+package io.neonbee.internal.handler.factories;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import io.neonbee.internal.handler.CacheControlHandler;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Create the {@link CacheControlHandler}.
+ */
+public class CacheControlHandlerFactory implements RoutingHandlerFactory {
+
+    @Override
+    public Future<Handler<RoutingContext>> createHandler() {
+        return succeededFuture(new CacheControlHandler());
+    }
+}

--- a/src/main/java/io/neonbee/internal/handler/factories/CorrelationIdHandlerFactory.java
+++ b/src/main/java/io/neonbee/internal/handler/factories/CorrelationIdHandlerFactory.java
@@ -1,0 +1,22 @@
+package io.neonbee.internal.handler.factories;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import io.neonbee.NeonBee;
+import io.neonbee.config.ServerConfig;
+import io.neonbee.internal.handler.CorrelationIdHandler;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Create the {@link CorrelationIdHandler}.
+ */
+public class CorrelationIdHandlerFactory implements RoutingHandlerFactory {
+
+    @Override
+    public Future<Handler<RoutingContext>> createHandler() {
+        ServerConfig serverConfig = NeonBee.get().getServerConfig();
+        return succeededFuture(new CorrelationIdHandler(serverConfig.getCorrelationStrategy()));
+    }
+}

--- a/src/main/java/io/neonbee/internal/handler/factories/DisallowingFileUploadBodyHandlerFactory.java
+++ b/src/main/java/io/neonbee/internal/handler/factories/DisallowingFileUploadBodyHandlerFactory.java
@@ -1,0 +1,19 @@
+package io.neonbee.internal.handler.factories;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
+
+/**
+ * Create A {@link BodyHandler} that disallows file uploads.
+ */
+public class DisallowingFileUploadBodyHandlerFactory implements RoutingHandlerFactory {
+
+    @Override
+    public Future<Handler<RoutingContext>> createHandler() {
+        return succeededFuture(BodyHandler.create(false /* do not handle file uploads */));
+    }
+}

--- a/src/main/java/io/neonbee/internal/handler/factories/InstanceInfoHandlerFactory.java
+++ b/src/main/java/io/neonbee/internal/handler/factories/InstanceInfoHandlerFactory.java
@@ -1,0 +1,19 @@
+package io.neonbee.internal.handler.factories;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import io.neonbee.internal.handler.InstanceInfoHandler;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Create the {@link InstanceInfoHandler}.
+ */
+public class InstanceInfoHandlerFactory implements RoutingHandlerFactory {
+
+    @Override
+    public Future<Handler<RoutingContext>> createHandler() {
+        return succeededFuture(new InstanceInfoHandler());
+    }
+}

--- a/src/main/java/io/neonbee/internal/handler/factories/LoggerHandlerFactory.java
+++ b/src/main/java/io/neonbee/internal/handler/factories/LoggerHandlerFactory.java
@@ -1,0 +1,19 @@
+package io.neonbee.internal.handler.factories;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import io.neonbee.internal.handler.LoggerHandler;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Create the {@link LoggerHandler}.
+ */
+public class LoggerHandlerFactory implements RoutingHandlerFactory {
+
+    @Override
+    public Future<Handler<RoutingContext>> createHandler() {
+        return succeededFuture(new LoggerHandler());
+    }
+}

--- a/src/main/java/io/neonbee/internal/handler/factories/RoutingHandlerFactory.java
+++ b/src/main/java/io/neonbee/internal/handler/factories/RoutingHandlerFactory.java
@@ -1,0 +1,22 @@
+package io.neonbee.internal.handler.factories;
+
+import io.neonbee.internal.verticle.ServerVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Factory interface for creating routing handlers.
+ *
+ * This interface is evaluated when {@link ServerVerticle} is started. The returned handlers will be added to the root
+ * route.
+ */
+public interface RoutingHandlerFactory {
+
+    /**
+     * Returns an instance of the {@link Handler} object to add to the main route.
+     *
+     * @return the {@link Handler} object
+     */
+    Future<Handler<RoutingContext>> createHandler();
+}

--- a/src/main/java/io/neonbee/internal/handler/factories/SessionHandlerFactory.java
+++ b/src/main/java/io/neonbee/internal/handler/factories/SessionHandlerFactory.java
@@ -1,0 +1,69 @@
+package io.neonbee.internal.handler.factories;
+
+import java.util.Optional;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import io.neonbee.NeonBee;
+import io.neonbee.config.ServerConfig;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.PlatformHandler;
+import io.vertx.ext.web.handler.SessionHandler;
+import io.vertx.ext.web.sstore.ClusteredSessionStore;
+import io.vertx.ext.web.sstore.LocalSessionStore;
+import io.vertx.ext.web.sstore.SessionStore;
+
+/**
+ * Creates a SessionHandler.
+ *
+ * If ServerConfig.SessionHandling is set to NONE a no-operation handler is returned, which does not perform any session
+ * handling.
+ */
+public class SessionHandlerFactory implements RoutingHandlerFactory {
+
+    @VisibleForTesting
+    static final class NoOpHandler implements PlatformHandler {
+        @Override
+        public void handle(RoutingContext routingContext) {
+            routingContext.next();
+        }
+    }
+
+    @Override
+    public Future<Handler<RoutingContext>> createHandler() {
+        ServerConfig config = NeonBee.get().getServerConfig();
+        Handler<RoutingContext> sh =
+                createSessionStore(NeonBee.get().getVertx(), config.getSessionHandling()).map(SessionHandler::create)
+                        .map(sessionHandler -> sessionHandler.setSessionCookieName(config.getSessionCookieName()))
+                        .map(sessionHandler -> (Handler<RoutingContext>) sessionHandler).orElseGet(NoOpHandler::new);
+        return Future.succeededFuture(sh);
+    }
+
+    /**
+     * Creates a {@linkplain SessionStore} based on the given {@linkplain ServerConfig} to use either local or clustered
+     * session handling. If no session handling should be used, an empty optional is returned.
+     *
+     * @param vertx           the Vert.x instance to create the {@linkplain SessionStore} for
+     * @param sessionHandling the session handling type
+     * @return an optional session store, suitable for the given Vert.x instance and based on the provided config value
+     *         (none/local/clustered). In case the session handling is set to clustered, but Vert.x does not run in
+     *         clustered mode, fallback to the local session handling.
+     */
+    @VisibleForTesting
+    static Optional<SessionStore> createSessionStore(Vertx vertx, ServerConfig.SessionHandling sessionHandling) {
+        switch (sessionHandling) {
+        case LOCAL:
+            return Optional.of(LocalSessionStore.create(vertx));
+        case CLUSTERED:
+            if (!vertx.isClustered()) { // Behaves like clustered in case that instance isn't clustered
+                return Optional.of(LocalSessionStore.create(vertx));
+            }
+            return Optional.of(ClusteredSessionStore.create(vertx));
+        default: /* nothing to do here, no session handling, so neither add a cookie, nor a session handler */
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/io/neonbee/internal/handler/factories/TimeoutHandlerFactory.java
+++ b/src/main/java/io/neonbee/internal/handler/factories/TimeoutHandlerFactory.java
@@ -1,0 +1,25 @@
+package io.neonbee.internal.handler.factories;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import java.util.concurrent.TimeUnit;
+
+import io.neonbee.NeonBee;
+import io.neonbee.config.ServerConfig;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.TimeoutHandler;
+
+/**
+ * Create the {@link TimeoutHandler}.
+ */
+public class TimeoutHandlerFactory implements RoutingHandlerFactory {
+
+    @Override
+    public Future<Handler<RoutingContext>> createHandler() {
+        ServerConfig serverConfig = NeonBee.get().getServerConfig();
+        return succeededFuture(TimeoutHandler.create(TimeUnit.SECONDS.toMillis(serverConfig.getTimeout()),
+                serverConfig.getTimeoutStatusCode()));
+    }
+}

--- a/src/test/java/io/neonbee/internal/handler/factories/CacheControlHandlerFactoryTest.java
+++ b/src/test/java/io/neonbee/internal/handler/factories/CacheControlHandlerFactoryTest.java
@@ -1,0 +1,23 @@
+package io.neonbee.internal.handler.factories;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.neonbee.internal.handler.CacheControlHandler;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class CacheControlHandlerFactoryTest {
+
+    @Test
+    void testCreateHandler(VertxTestContext testContext) {
+        new CacheControlHandlerFactory().createHandler()
+                .onComplete(testContext.succeeding(instance -> testContext.verify(() -> {
+                    assertThat(instance).isInstanceOf(CacheControlHandler.class);
+                    testContext.completeNow();
+                })));
+    }
+}

--- a/src/test/java/io/neonbee/internal/handler/factories/CorrelationIdHandlerFactoryTest.java
+++ b/src/test/java/io/neonbee/internal/handler/factories/CorrelationIdHandlerFactoryTest.java
@@ -1,0 +1,37 @@
+package io.neonbee.internal.handler.factories;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+
+import io.neonbee.NeonBee;
+import io.neonbee.config.ServerConfig;
+import io.neonbee.internal.handler.CorrelationIdHandler;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class CorrelationIdHandlerFactoryTest {
+
+    @Test
+    void testCreateHandler(VertxTestContext testContext) {
+
+        try (MockedStatic<NeonBee> staticNeonBeeMock = mockStatic(NeonBee.class)) {
+            NeonBee neonBeeMock = mock(NeonBee.class);
+            when(neonBeeMock.getServerConfig()).thenReturn(new ServerConfig());
+            staticNeonBeeMock.when(() -> NeonBee.get()).thenReturn(neonBeeMock);
+
+            new CorrelationIdHandlerFactory().createHandler()
+                    .onComplete(testContext.succeeding(instance -> testContext.verify(() -> {
+                        assertThat(instance).isInstanceOf(CorrelationIdHandler.class);
+                        testContext.completeNow();
+                    })));
+        }
+
+    }
+}

--- a/src/test/java/io/neonbee/internal/handler/factories/DisallowingFileUploadBodyHandlerFactoryTest.java
+++ b/src/test/java/io/neonbee/internal/handler/factories/DisallowingFileUploadBodyHandlerFactoryTest.java
@@ -1,0 +1,22 @@
+package io.neonbee.internal.handler.factories;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vertx.ext.web.handler.BodyHandler;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class DisallowingFileUploadBodyHandlerFactoryTest {
+    @Test
+    void testCreateHandler(VertxTestContext testContext) {
+        new DisallowingFileUploadBodyHandlerFactory().createHandler()
+                .onComplete(testContext.succeeding(instance -> testContext.verify(() -> {
+                    assertThat(instance).isInstanceOf(BodyHandler.class);
+                    testContext.completeNow();
+                })));
+    }
+}

--- a/src/test/java/io/neonbee/internal/handler/factories/InstanceInfoHandlerFactoryTest.java
+++ b/src/test/java/io/neonbee/internal/handler/factories/InstanceInfoHandlerFactoryTest.java
@@ -1,0 +1,22 @@
+package io.neonbee.internal.handler.factories;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.neonbee.internal.handler.InstanceInfoHandler;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class InstanceInfoHandlerFactoryTest {
+    @Test
+    void testCreateHandler(VertxTestContext testContext) {
+        new InstanceInfoHandlerFactory().createHandler()
+                .onComplete(testContext.succeeding(instance -> testContext.verify(() -> {
+                    assertThat(instance).isInstanceOf(InstanceInfoHandler.class);
+                    testContext.completeNow();
+                })));
+    }
+}

--- a/src/test/java/io/neonbee/internal/handler/factories/LoggerHandlerFactoryTest.java
+++ b/src/test/java/io/neonbee/internal/handler/factories/LoggerHandlerFactoryTest.java
@@ -1,0 +1,22 @@
+package io.neonbee.internal.handler.factories;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.neonbee.internal.handler.LoggerHandler;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class LoggerHandlerFactoryTest {
+    @Test
+    void testCreateHandler(VertxTestContext testContext) {
+        new LoggerHandlerFactory().createHandler()
+                .onComplete(testContext.succeeding(instance -> testContext.verify(() -> {
+                    assertThat(instance).isInstanceOf(LoggerHandler.class);
+                    testContext.completeNow();
+                })));
+    }
+}

--- a/src/test/java/io/neonbee/internal/handler/factories/SessionHandlerFactoryTest.java
+++ b/src/test/java/io/neonbee/internal/handler/factories/SessionHandlerFactoryTest.java
@@ -1,0 +1,111 @@
+package io.neonbee.internal.handler.factories;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.neonbee.internal.handler.factories.SessionHandlerFactory.createSessionStore;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+
+import io.neonbee.NeonBee;
+import io.neonbee.config.ServerConfig;
+import io.neonbee.config.ServerConfig.SessionHandling;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.shareddata.SharedData;
+import io.vertx.ext.web.handler.SessionHandler;
+import io.vertx.ext.web.sstore.ClusteredSessionStore;
+import io.vertx.ext.web.sstore.LocalSessionStore;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class SessionHandlerFactoryTest {
+
+    @Test
+    void testCreateHandlerNone(Vertx vertx, VertxTestContext testContext) {
+        try (MockedStatic<NeonBee> staticNeonBeeMock = mockStatic(NeonBee.class)) {
+            NeonBee neonBeeMock = mock(NeonBee.class);
+            ServerConfig serverConfig = new ServerConfig();
+            serverConfig.setSessionHandling(SessionHandling.NONE);
+            when(neonBeeMock.getServerConfig()).thenReturn(serverConfig);
+            when(neonBeeMock.getVertx()).thenReturn(vertx);
+            staticNeonBeeMock.when(() -> NeonBee.get()).thenReturn(neonBeeMock);
+
+            new SessionHandlerFactory().createHandler()
+                    .onComplete(testContext.succeeding(instance -> testContext.verify(() -> {
+                        assertThat(instance).isInstanceOf(SessionHandlerFactory.NoOpHandler.class);
+                        testContext.completeNow();
+                    })));
+        }
+    }
+
+    @Test
+    void testCreateHandlerLocal(Vertx vertx, VertxTestContext testContext) {
+        try (MockedStatic<NeonBee> staticNeonBeeMock = mockStatic(NeonBee.class)) {
+            NeonBee neonBeeMock = mock(NeonBee.class);
+            ServerConfig serverConfig = new ServerConfig();
+            serverConfig.setSessionHandling(ServerConfig.SessionHandling.LOCAL);
+            when(neonBeeMock.getServerConfig()).thenReturn(serverConfig);
+            when(neonBeeMock.getVertx()).thenReturn(vertx);
+            staticNeonBeeMock.when(() -> NeonBee.get()).thenReturn(neonBeeMock);
+
+            new SessionHandlerFactory().createHandler()
+                    .onComplete(testContext.succeeding(instance -> testContext.verify(() -> {
+                        assertThat(instance).isInstanceOf(SessionHandler.class);
+                        testContext.completeNow();
+                    })));
+        }
+    }
+
+    @Test
+    void testCreateHandlerClustered(Vertx vertx, VertxTestContext testContext) {
+        try (MockedStatic<NeonBee> staticNeonBeeMock = mockStatic(NeonBee.class)) {
+            NeonBee neonBeeMock = mock(NeonBee.class);
+            ServerConfig serverConfig = new ServerConfig();
+            serverConfig.setSessionHandling(ServerConfig.SessionHandling.CLUSTERED);
+            when(neonBeeMock.getServerConfig()).thenReturn(serverConfig);
+            when(neonBeeMock.getVertx()).thenReturn(vertx);
+            staticNeonBeeMock.when(() -> NeonBee.get()).thenReturn(neonBeeMock);
+
+            new SessionHandlerFactory().createHandler()
+                    .onComplete(testContext.succeeding(instance -> testContext.verify(() -> {
+                        assertThat(instance).isInstanceOf(SessionHandler.class);
+                        testContext.completeNow();
+                    })));
+        }
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    void testCreateSessionStore() {
+        Vertx mockedVertx = mock(VertxInternal.class);
+        when(mockedVertx.isClustered()).thenReturn(false);
+        when(mockedVertx.sharedData()).thenReturn(mock(SharedData.class));
+
+        assertThat(createSessionStore(mockedVertx, SessionHandling.NONE).isEmpty()).isTrue();
+        assertThat(createSessionStore(mockedVertx, SessionHandling.LOCAL).get()).isInstanceOf(LocalSessionStore.class);
+        assertThat(createSessionStore(mockedVertx, SessionHandling.CLUSTERED).get())
+                .isInstanceOf(LocalSessionStore.class);
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    void testCreateSessionStoreClustered() {
+        Vertx mockedVertx = mock(VertxInternal.class);
+        when(mockedVertx.isClustered()).thenReturn(true);
+        when(mockedVertx.sharedData()).thenReturn(mock(SharedData.class));
+
+        assertThat(createSessionStore(mockedVertx, SessionHandling.NONE).isEmpty()).isTrue();
+        assertThat(createSessionStore(mockedVertx, SessionHandling.LOCAL).get()).isInstanceOf(LocalSessionStore.class);
+        assertThat(createSessionStore(mockedVertx, SessionHandling.CLUSTERED).get())
+                .isInstanceOf(ClusteredSessionStore.class);
+    }
+
+}

--- a/src/test/java/io/neonbee/internal/handler/factories/TimeoutHandlerFactoryTest.java
+++ b/src/test/java/io/neonbee/internal/handler/factories/TimeoutHandlerFactoryTest.java
@@ -1,0 +1,36 @@
+package io.neonbee.internal.handler.factories;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+
+import io.neonbee.NeonBee;
+import io.neonbee.config.ServerConfig;
+import io.vertx.ext.web.handler.TimeoutHandler;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class TimeoutHandlerFactoryTest {
+    @Test
+    void testCreateHandler(VertxTestContext testContext) {
+
+        try (MockedStatic<NeonBee> staticNeonBeeMock = mockStatic(NeonBee.class)) {
+            NeonBee neonBeeMock = mock(NeonBee.class);
+            when(neonBeeMock.getServerConfig()).thenReturn(new ServerConfig());
+            staticNeonBeeMock.when(() -> NeonBee.get()).thenReturn(neonBeeMock);
+
+            new TimeoutHandlerFactory().createHandler()
+                    .onComplete(testContext.succeeding(instance -> testContext.verify(() -> {
+                        assertThat(instance).isInstanceOf(TimeoutHandler.class);
+                        testContext.completeNow();
+                    })));
+        }
+
+    }
+}


### PR DESCRIPTION
The `ServerVerticle` attaches request handlers to the route. The request handlers attached to the route cannot be changed at the moment. This change makes the request handlers that the `ServerVerticle` attaches to the route configurable.

A `RoutingHandlerFactory` is used to create an instance of the `Handler<RoutingContext>` class. In the `ServerConfig`, a list of `RoutingHandlerFactory` class names is used to specify the `RoutingHandlerFactory`. The handler created by the `RoutingHandlerFactory` is then added to the root route. The request handlers are added in the order specified in the `ServerConfig` list.