### PR TITLE
build(deps): upgrade org.ow2.asm to version 9.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
 
     implementation group: 'com.sap.cds', name: 'cds4j-core', version: '1.25.0'
     implementation group: 'io.micrometer', name: 'micrometer-registry-prometheus', version: '1.8.1'
-    implementation group: 'org.ow2.asm', name: 'asm', version: '7.2'
+    implementation group: 'org.ow2.asm', name: 'asm', version: '9.3'
 
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.32'
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.9'


### PR DESCRIPTION
Upgrading asm to version 9.3 is required, otherwise NeonBee ClasspathScanner is
no longer able to scan class files compiled with java 12 or higher.