### PR TITLE
fix: speed up the test execution

### DIFF
--- a/src/test/java/io/neonbee/endpoint/metrics/NeonBeeMetricsTest.java
+++ b/src/test/java/io/neonbee/endpoint/metrics/NeonBeeMetricsTest.java
@@ -65,6 +65,7 @@ public class NeonBeeMetricsTest {
 
         NeonBeeOptions.Mutable mutable = new NeonBeeOptions.Mutable();
         mutable.setServerPort(PORT);
+        mutable.setIgnoreClassPath(true);
         mutable.setWorkingDirectory(Path.of("src", "test", "resources", "io", "neonbee", "endpoint", "metrics"));
 
         NeonBee.create(mutable).onComplete(context.succeeding(event -> httpGet(vertx, TEST_ENDPOINT_URI)


### PR DESCRIPTION
The test method NeonBeeMetricsTest#testCustomMetric occasionally takes more than a minute to execute. By setting setIgnoreClassPath to true, the test will execute in less than 15 seconds.