### PR TITLE
feat: unregister entities from shared map

### DIFF
--- a/src/main/java/io/neonbee/NeonBee.java
+++ b/src/main/java/io/neonbee/NeonBee.java
@@ -61,6 +61,7 @@ import io.neonbee.internal.SharedDataAccessor;
 import io.neonbee.internal.WriteSafeRegistry;
 import io.neonbee.internal.buffer.ImmutableBuffer;
 import io.neonbee.internal.cluster.ClusterHelper;
+import io.neonbee.internal.cluster.entity.ClusterEntityRegistry;
 import io.neonbee.internal.codec.DataExceptionMessageCodec;
 import io.neonbee.internal.codec.DataQueryMessageCodec;
 import io.neonbee.internal.codec.EntityWrapperMessageCodec;
@@ -592,7 +593,12 @@ public class NeonBee {
 
         this.healthRegistry = new HealthCheckRegistry(vertx);
         this.modelManager = new EntityModelManager(this);
-        this.entityRegistry = new WriteSafeRegistry<>(vertx, EntityVerticle.REGISTRY_NAME);
+        if (vertx.isClustered()) {
+            this.entityRegistry = new ClusterEntityRegistry(vertx, EntityVerticle.REGISTRY_NAME);
+        } else {
+            this.entityRegistry = new WriteSafeRegistry<>(vertx, EntityVerticle.REGISTRY_NAME);
+        }
+
         this.compositeMeterRegistry = compositeMeterRegistry;
 
         // to be able to retrieve the NeonBee instance from any point you have a Vert.x instance add it to a global map

--- a/src/main/java/io/neonbee/hook/HookType.java
+++ b/src/main/java/io/neonbee/hook/HookType.java
@@ -32,10 +32,33 @@ public enum HookType {
     /**
      * The shutdown hook is called before the associated Vert.x instance to a NeonBee object is closed / shut down.
      */
-    BEFORE_SHUTDOWN;
+    BEFORE_SHUTDOWN,
+
+    /**
+     * This hook is called when a node has been added to the cluster.
+     * <p>
+     * Available parameters in the {@linkplain HookContext}:
+     * <p>
+     * {@link #CLUSTER_NODE_ID}
+     */
+    NODE_ADDED,
+
+    /**
+     * This hook is called when a node has left the cluster.
+     * <p>
+     * Available parameters in the {@linkplain HookContext}:
+     * <p>
+     * {@link #CLUSTER_NODE_ID}
+     */
+    NODE_LEFT;
 
     /**
      * Name for the routing context parameter of HookType {@link #ONCE_PER_REQUEST}.
      */
     public static final String ROUTING_CONTEXT = "routingContext";
+
+    /**
+     * Name for the node ID parameter of the cluster node for {@link #NODE_LEFT} and {@link #NODE_ADDED}.
+     */
+    public static final String CLUSTER_NODE_ID = "nodeId";
 }

--- a/src/main/java/io/neonbee/internal/cluster/ClusterHelper.java
+++ b/src/main/java/io/neonbee/internal/cluster/ClusterHelper.java
@@ -1,0 +1,106 @@
+package io.neonbee.internal.cluster;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.infinispan.manager.EmbeddedCacheManager;
+
+import com.hazelcast.cluster.Member;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.ext.cluster.infinispan.InfinispanClusterManager;
+import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
+
+public class ClusterHelper {
+
+    /**
+     * Returns the {@link ClusterManager} if NeonBee is started in clustering mode, otherwise it returns null.
+     *
+     * @param vertx {@link Vertx} instance
+     * @return null or the {@link HazelcastClusterManager} instance
+     */
+    public static Optional<ClusterManager> getClusterManager(Vertx vertx) {
+        if (vertx instanceof VertxInternal) {
+            VertxInternal vertxInternal = (VertxInternal) vertx;
+            return Optional.ofNullable(vertxInternal.getClusterManager());
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Returns an optinal with {@link HazelcastClusterManager} if NeonBee was started in cluster mode and
+     * {@link HazelcastClusterManager} is used as {@link ClusterManager}, otherwise it returns an empty Optional.
+     *
+     * @param vertx {@link Vertx} instance
+     * @return null or the {@link HazelcastClusterManager} instance
+     */
+    public static Optional<HazelcastClusterManager> getHazelcastClusterManager(Vertx vertx) {
+        return getSpecificClusterManager(vertx, HazelcastClusterManager.class);
+    }
+
+    /**
+     * Returns an optinal with {@link InfinispanClusterManager} if NeonBee was started in cluster mode and
+     * {@link InfinispanClusterManager} is used as {@link ClusterManager}, otherwise it returns an empty Optional.
+     *
+     * @param vertx {@link Vertx} instance
+     * @return null or the {@link InfinispanClusterManager} instance
+     */
+    public static Optional<InfinispanClusterManager> getInfinispanClusterManager(Vertx vertx) {
+        return getSpecificClusterManager(vertx, InfinispanClusterManager.class);
+    }
+
+    /**
+     * Returns an optinal with the provided {@link ClusterManager} class if NeonBee was started in cluster mode and the
+     * {@link ClusterManager} is used as {@link ClusterManager}, otherwise it returns an empty Optional.
+     *
+     * @param vertx {@link Vertx} instance
+     * @return null or the {@link InfinispanClusterManager} instance
+     */
+    private static <T extends ClusterManager> Optional<T> getSpecificClusterManager(Vertx vertx, Class<T> cmClass) {
+        return getClusterManager(vertx).map(cm -> cmClass.isInstance(cm) ? cmClass.cast(cm) : null);
+    }
+
+    /**
+     * Get the cluster node ID.
+     *
+     * @param vertx {@link Vertx} instance
+     * @return the cluster node ID
+     */
+    public static String getClusterNodeId(Vertx vertx) {
+        return getClusterManager(vertx).map(ClusterManager::getNodeId).orElseThrow(() -> new IllegalStateException(
+                "Can not retrieve the ClusterManager. Is vert.x running in a cluster?"));
+    }
+
+    /**
+     * Is this cluster node the leader?
+     *
+     * @param vertx {@link Vertx} instance
+     * @return true if this node is the leader, otherwise false
+     */
+    public static boolean isLeader(Vertx vertx) {
+        if (!vertx.isClustered()) {
+            return true;
+        }
+
+        return getHazelcastClusterManager(vertx).map(hcm -> isLeader(hcm))
+                .or(() -> getInfinispanClusterManager(vertx).map(icm -> isLeader(icm)))
+                .orElseThrow(() -> new IllegalStateException(
+                        "Can not find the cluster leader. Is vert.x running in a cluster?"));
+    }
+
+    private static Boolean isLeader(InfinispanClusterManager icm) {
+        EmbeddedCacheManager cacheContainer = (EmbeddedCacheManager) icm.getCacheContainer();
+        return cacheContainer.isCoordinator();
+    }
+
+    private static boolean isLeader(HazelcastClusterManager hcm) {
+        // getMembers() returns a set. The first element is the leader.
+        // The underlying set is a kind of linked hashset and In this case the order is kept.
+        // see https://github.com/hazelcast/hazelcast/issues/3760
+        Set<Member> members = hcm.getHazelcastInstance().getCluster().getMembers();
+        Member oldestMember = members.iterator().next();
+        return oldestMember.localMember();
+    }
+}

--- a/src/main/java/io/neonbee/internal/cluster/entity/ClusterEntityRegistry.java
+++ b/src/main/java/io/neonbee/internal/cluster/entity/ClusterEntityRegistry.java
@@ -1,0 +1,144 @@
+package io.neonbee.internal.cluster.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import io.neonbee.entity.EntityVerticle;
+import io.neonbee.internal.Registry;
+import io.neonbee.internal.WriteSafeRegistry;
+import io.neonbee.internal.cluster.ClusterHelper;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.shareddata.AsyncMap;
+
+/**
+ * A special registry implementation that stores cluster information's.
+ * <p>
+ * This implementation stores note specific entries for the registered {@link EntityVerticle}. The cluster information
+ * is stored in a JsonObject:
+ *
+ * <pre>
+ * {
+ *     "qualifiedName": "value",
+ *     "entityName": "key"
+ * }
+ * </pre>
+ */
+public class ClusterEntityRegistry implements Registry<String> {
+
+    private static final String QUALIFIED_NAME = "qualifiedName";
+
+    private static final String ENTITY_NAME = "entityName";
+
+    @VisibleForTesting
+    final WriteSafeRegistry<JsonObject> clusteringInformation;
+
+    private final Vertx vertx;
+
+    private final WriteSafeRegistry<Object> entityRegistry;
+
+    /**
+     * Create a new instance of {@link ClusterEntityRegistry}.
+     *
+     * @param vertx        the {@link Vertx} instance
+     * @param registryName the name of the map registry
+     */
+    public ClusterEntityRegistry(Vertx vertx, String registryName) {
+        this.entityRegistry = new WriteSafeRegistry<>(vertx, registryName);
+        this.clusteringInformation = new WriteSafeRegistry<>(vertx, registryName + "#ClusteringInformation");
+        this.vertx = vertx;
+    }
+
+    @VisibleForTesting
+    static JsonObject clusterRegistrationInformation(String sharedMapKey, String value) {
+        return JsonObject.of(QUALIFIED_NAME, value, ENTITY_NAME, sharedMapKey);
+    }
+
+    @Override
+    public Future<Void> register(String sharedMapKey, String value) {
+        return CompositeFuture.all(entityRegistry.register(sharedMapKey, value),
+                clusteringInformation.register(getClusterNodeId(), clusterRegistrationInformation(sharedMapKey, value)))
+                .mapEmpty();
+    }
+
+    @Override
+    public Future<Void> unregister(String sharedMapKey, String value) {
+        return CompositeFuture
+                .all(entityRegistry.unregister(sharedMapKey, value), clusteringInformation
+                        .unregister(getClusterNodeId(), clusterRegistrationInformation(sharedMapKey, value)))
+                .mapEmpty();
+    }
+
+    /**
+     * Get the cluster node ID.
+     *
+     * @return the ID of the cluster node
+     */
+    @VisibleForTesting
+    String getClusterNodeId() {
+        return ClusterHelper.getClusterNodeId(vertx);
+    }
+
+    @Override
+    public Future<JsonArray> get(String sharedMapKey) {
+        return entityRegistry.get(sharedMapKey);
+    }
+
+    /**
+     * Get the clustering information for the provided cluster ID from the registry.
+     *
+     * @param clusterNodeId the ID of the cluster node
+     * @return the future
+     */
+    Future<JsonArray> getClusteringInformation(String clusterNodeId) {
+        return clusteringInformation.get(clusterNodeId);
+    }
+
+    /**
+     * Remove the entry for a node ID.
+     *
+     * @param clusterNodeId the ID of the cluster node
+     * @return the future
+     */
+    Future<Void> removeClusteringInformation(String clusterNodeId) {
+        return clusteringInformation.getSharedMap().compose(map -> map.remove(clusterNodeId)).mapEmpty();
+    }
+
+    /**
+     * Unregister all registered entities for a node by ID.
+     *
+     * @param clusterNodeId the ID of the cluster node
+     * @return the future
+     */
+    public Future<Void> unregisterNode(String clusterNodeId) {
+        return clusteringInformation.getSharedMap().compose(AsyncMap::entries).compose(map -> {
+            JsonArray registeredEntities = ((JsonArray) map.remove(clusterNodeId)).copy();
+            List<Future> futureList = new ArrayList<>(registeredEntities.size());
+            for (Object o : registeredEntities) {
+                if (remove(map, o)) {
+                    JsonObject jo = (JsonObject) o;
+                    String entityName = jo.getString(ENTITY_NAME);
+                    String qualifiedName = jo.getString(QUALIFIED_NAME);
+                    futureList.add(unregister(entityName, qualifiedName));
+                }
+            }
+            return CompositeFuture.join(futureList).mapEmpty();
+        }).compose(cf -> removeClusteringInformation(clusterNodeId));
+    }
+
+    private boolean remove(Map<String, Object> map, Object o) {
+        for (Map.Entry<String, Object> node : map.entrySet()) {
+            JsonArray ja = (JsonArray) node.getValue();
+            if (ja.contains(o)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/io/neonbee/internal/cluster/entity/UnregisterEntityVerticlesHook.java
+++ b/src/main/java/io/neonbee/internal/cluster/entity/UnregisterEntityVerticlesHook.java
@@ -1,0 +1,92 @@
+package io.neonbee.internal.cluster.entity;
+
+import static io.neonbee.hook.HookType.CLUSTER_NODE_ID;
+import static io.vertx.core.Future.succeededFuture;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.neonbee.NeonBee;
+import io.neonbee.hook.Hook;
+import io.neonbee.hook.HookContext;
+import io.neonbee.hook.HookType;
+import io.neonbee.internal.Registry;
+import io.neonbee.internal.cluster.ClusterHelper;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
+/**
+ * Hooks for unregistering verticle models.
+ */
+public class UnregisterEntityVerticlesHook {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UnregisterEntityVerticlesHook.class);
+
+    /**
+     * This method is called when a NeonBee instance shutdown gracefully.
+     *
+     * @param neonBee     the {@link NeonBee} instance
+     * @param hookContext the {@link HookContext}
+     * @param promise     {@link Promise} to complete the function.
+     */
+    @Hook(HookType.BEFORE_SHUTDOWN)
+    public void unregisterOnShutdown(NeonBee neonBee, HookContext hookContext, Promise<Void> promise) {
+        LOGGER.info("Unregistering models on shutdown");
+        Vertx vertx = neonBee.getVertx();
+        String clusterNodeId = ClusterHelper.getClusterNodeId(vertx);
+        unregister(neonBee, clusterNodeId).onComplete(promise)
+                .onSuccess(unused -> LOGGER.info("Models unregistered successfully"))
+                .onFailure(ignoredCause -> LOGGER.error("Failed to unregister models on shutdown"));
+    }
+
+    /**
+     * Unregister the entity qualified names for the node by ID.
+     *
+     * @param neonBee       the {@link NeonBee} instance
+     * @param clusterNodeId the ID of the cluster node
+     * @return Future
+     */
+    public static Future<Void> unregister(NeonBee neonBee, String clusterNodeId) {
+        if (!neonBee.getVertx().isClustered()) {
+            return succeededFuture();
+        }
+
+        Registry<String> registry = neonBee.getEntityRegistry();
+        if (!(registry instanceof ClusterEntityRegistry)) {
+            LOGGER.warn("Running in clustered mode but not using the ClusterEntityRegistry.");
+            return succeededFuture();
+        }
+
+        ClusterEntityRegistry clusterEntityRegistry = (ClusterEntityRegistry) registry;
+
+        LOGGER.info("Unregistering entity verticle models for node ID {} ...", clusterNodeId);
+        Future<Void> unregisterFuture = clusterEntityRegistry.unregisterNode(clusterNodeId);
+
+        return unregisterFuture
+                .onSuccess(
+                        unused -> LOGGER.info("Unregistered entity verticle models for node ID {} ...", clusterNodeId))
+                .onFailure(cause -> LOGGER.error("Failed to unregistered entity verticle models for node ID {} ...",
+                        clusterNodeId, cause));
+    }
+
+    /**
+     * This method is called when a NeonBee node has left the cluster.
+     *
+     * @param neonBee     the {@link NeonBee} instance
+     * @param hookContext the {@link HookContext}
+     * @param promise     {@link Promise} to completed the function.
+     */
+    @Hook(HookType.NODE_LEFT)
+    public void cleanup(NeonBee neonBee, HookContext hookContext, Promise<Void> promise) {
+        String clusterNodeId = hookContext.get(CLUSTER_NODE_ID);
+        LOGGER.info("Cleanup qualified names for node {}", clusterNodeId);
+        if (ClusterHelper.isLeader(neonBee.getVertx())) {
+            LOGGER.info("Cleaning registered qualified names ...");
+            unregister(neonBee, clusterNodeId).onComplete(promise)
+                    .onSuccess(unused -> LOGGER.info("Qualified names successfully cleaned up"))
+                    .onFailure(ignoredCause -> LOGGER.error("Failed to cleanup qualified names"));
+        }
+    }
+
+}

--- a/src/test/java/io/neonbee/hook/internal/DefaultHookRegistryTest.java
+++ b/src/test/java/io/neonbee/hook/internal/DefaultHookRegistryTest.java
@@ -103,7 +103,7 @@ class DefaultHookRegistryTest {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Check that getHookRegistrations works correct")
-    void getHookRegistruationsTest(VertxTestContext testContext) {
+    void getHookRegistrationsTest(VertxTestContext testContext) {
         hookRegistry.registerHooks(classWithValidHook, CORRELATION_ID).compose(hookRegistrations -> {
             return hookRegistry.getHookRegistrations()
                     .onComplete(testContext.succeeding(allRegistrations -> testContext.verify(() -> {

--- a/src/test/java/io/neonbee/internal/cluster/entity/ClusterEntityRegistryTest.java
+++ b/src/test/java/io/neonbee/internal/cluster/entity/ClusterEntityRegistryTest.java
@@ -1,0 +1,172 @@
+package io.neonbee.internal.cluster.entity;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class ClusterEntityRegistryTest {
+
+    private static final String REGISTRY_NAME = "CLUSTER_REGISTRY_NAME";
+
+    private static final String KEY = "key";
+
+    private static final String VALUE = "value";
+
+    @Test
+    @DisplayName("register value in registry")
+    void register(Vertx vertx, VertxTestContext context) {
+        ClusterEntityRegistry registry = new TestClusterEntityRegistry(vertx, REGISTRY_NAME);
+        registry.register(KEY, VALUE).compose(unused -> registry.get(KEY)).onSuccess(mapValue -> context.verify(() -> {
+            assertThat(mapValue).isEqualTo(new JsonArray().add(VALUE));
+            context.completeNow();
+        })).onFailure(context::failNow);
+    }
+
+    @Test
+    @DisplayName("unregister value from registry")
+    void unregister(Vertx vertx, VertxTestContext context) {
+        ClusterEntityRegistry registry = new TestClusterEntityRegistry(vertx, REGISTRY_NAME);
+        registry.register(KEY, VALUE).compose(unused -> registry.unregister(KEY, "value2"))
+                .compose(unused -> registry.get(KEY)).onSuccess(mapValue -> context.verify(() -> {
+                    assertThat(mapValue).isEqualTo(new JsonArray().add(VALUE));
+                })).compose(unused -> registry.unregister(KEY, VALUE)).compose(unused -> registry.get(KEY))
+                .onSuccess(mapValue -> context.verify(() -> {
+                    assertThat(mapValue).isEqualTo(new JsonArray());
+                    context.completeNow();
+                })).onFailure(context::failNow);
+    }
+
+    @Test
+    @DisplayName("get value from registry")
+    void get(Vertx vertx, VertxTestContext context) {
+        ClusterEntityRegistry registry = new TestClusterEntityRegistry(vertx, REGISTRY_NAME);
+        registry.register(KEY, VALUE).compose(unused -> registry.get(KEY)).onSuccess(jsonArray -> context.verify(() -> {
+            assertThat(jsonArray).isNotNull();
+            assertThat(jsonArray.contains(VALUE)).isTrue();
+            context.completeNow();
+        })).onFailure(context::failNow);
+    }
+
+    @Test
+    @Timeout(value = 1, unit = TimeUnit.SECONDS)
+    @DisplayName("get the clustering information from the registry")
+    void getClusteringInformation(Vertx vertx, VertxTestContext context) {
+        ClusterEntityRegistry registry = new TestClusterEntityRegistry(vertx, REGISTRY_NAME);
+        registry.register(KEY, VALUE)
+                .compose(unused -> registry.getClusteringInformation(TestClusterEntityRegistry.CLUSTER_NODE_ID))
+                .onSuccess(mapValue -> context.verify(() -> {
+                    assertThat(mapValue)
+                            .isEqualTo(JsonArray.of(ClusterEntityRegistry.clusterRegistrationInformation(KEY, VALUE)));
+                    context.completeNow();
+                })).onFailure(context::failNow);
+    }
+
+    @Test
+    @DisplayName("unregister all key from registry")
+    void removeClusteringInformation(Vertx vertx, VertxTestContext context) {
+        Checkpoint checkpoint = context.checkpoint(2);
+        ClusterEntityRegistry registry = new TestClusterEntityRegistry(vertx, REGISTRY_NAME);
+        registry.register(KEY, VALUE)
+                .compose(unused -> registry.getClusteringInformation(TestClusterEntityRegistry.CLUSTER_NODE_ID))
+                .onSuccess(mapValue -> context.verify(() -> {
+                    assertThat(mapValue).isNotEmpty();
+                    checkpoint.flag();
+                })).compose(unused -> registry.removeClusteringInformation(TestClusterEntityRegistry.CLUSTER_NODE_ID))
+                .onSuccess(mapValue -> context.verify(() -> {
+                    assertThat(mapValue).isNull();
+                    checkpoint.flag();
+                })).onFailure(context::failNow);
+    }
+
+    @Test
+    @DisplayName("unregister node")
+    void unregisterNode1(Vertx vertx, VertxTestContext context) {
+        ClusterEntityRegistry registry = new TestClusterEntityRegistry(vertx, REGISTRY_NAME);
+        registry.register(KEY, VALUE)
+                .compose(unused -> registry.getClusteringInformation(TestClusterEntityRegistry.CLUSTER_NODE_ID))
+                .compose(unused -> registry.unregisterNode(TestClusterEntityRegistry.CLUSTER_NODE_ID))
+                .compose(unused -> registry.getClusteringInformation(TestClusterEntityRegistry.CLUSTER_NODE_ID))
+                .onSuccess(mapValue -> context.verify(() -> {
+                    assertThat(mapValue).isNull();
+                    context.completeNow();
+                })).onFailure(context::failNow);
+    }
+
+    @Test
+    @Timeout(value = 1, unit = TimeUnit.SECONDS)
+    @DisplayName("unregister node with two nodes with same entities")
+    void unregisterNode2(Vertx vertx, VertxTestContext context) {
+        Checkpoint checkpoint = context.checkpoint(5);
+        String clusterIdNode1 = "TEST_CLUSTER_ID_0000000000000001";
+        String clusterIdNode2 = "TEST_CLUSTER_ID_0000000000000002";
+        ClusterEntityRegistry registry1 = new TestClusterEntityRegistry(vertx, REGISTRY_NAME, clusterIdNode1);
+        ClusterEntityRegistry registry2 = new TestClusterEntityRegistry(vertx, REGISTRY_NAME, clusterIdNode2);
+
+        registry1.register(KEY, VALUE).compose(unused -> registry2.register(KEY, VALUE))
+                .compose(unused -> registry1.get(KEY)).onSuccess(ja -> context.verify(() -> {
+                    assertThat(ja).containsExactly(VALUE);
+                    checkpoint.flag();
+                })).compose(unused -> registry1.getClusteringInformation(clusterIdNode1))
+                .compose(unused -> registry1.unregisterNode(clusterIdNode1)).compose(unused -> registry2.get(KEY))
+                .onSuccess(ja -> context.verify(() -> {
+                    assertThat(ja).containsExactly(VALUE);
+                    checkpoint.flag();
+                })).compose(unused -> registry2.getClusteringInformation(clusterIdNode1))
+                .onSuccess(mapValue -> context.verify(() -> {
+                    assertThat(mapValue).isNull();
+                    checkpoint.flag();
+                })).compose(unused -> registry2.getClusteringInformation(clusterIdNode2))
+                .onSuccess(mapValue -> context.verify(() -> {
+                    assertThat(mapValue)
+                            .containsExactly(ClusterEntityRegistry.clusterRegistrationInformation("key", VALUE));
+                    checkpoint.flag();
+                })).compose(unused -> registry2.unregisterNode(clusterIdNode2)).compose(unused -> registry2.get(KEY))
+                .onSuccess(ja -> context.verify(() -> {
+                    assertThat(ja).isEmpty();
+                    checkpoint.flag();
+                })).onFailure(context::failNow);
+    }
+
+    @Test
+    @DisplayName("remove key from registry")
+    void remove(Vertx vertx, VertxTestContext context) {
+        ClusterEntityRegistry registry = new TestClusterEntityRegistry(vertx, REGISTRY_NAME);
+        registry.register(KEY, VALUE).compose(unused -> registry.removeClusteringInformation(KEY))
+                .onSuccess(jsonArray -> context.verify(() -> {
+                    assertThat(jsonArray).isNull();
+                    context.completeNow();
+                })).onFailure(context::failNow);
+    }
+
+    static class TestClusterEntityRegistry extends ClusterEntityRegistry {
+        static final String CLUSTER_NODE_ID = "TEST_CLUSTER_ID_0000000000000000";
+
+        final String clusterNodeId;
+
+        TestClusterEntityRegistry(Vertx vertx, String registryName) {
+            this(vertx, registryName, CLUSTER_NODE_ID);
+        }
+
+        TestClusterEntityRegistry(Vertx vertx, String registryName, String clusterNodeId) {
+            super(vertx, registryName);
+            this.clusterNodeId = clusterNodeId;
+        }
+
+        @Override
+        String getClusterNodeId() {
+            return clusterNodeId;
+        }
+    }
+}

--- a/src/test/java/io/neonbee/internal/cluster/entity/UnregisterEntitiesTest.java
+++ b/src/test/java/io/neonbee/internal/cluster/entity/UnregisterEntitiesTest.java
@@ -1,0 +1,127 @@
+package io.neonbee.internal.cluster.entity;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.neonbee.NeonBeeInstanceConfiguration.ClusterManager.HAZELCAST;
+import static io.neonbee.NeonBeeInstanceConfiguration.ClusterManager.INFINISPAN;
+import static io.neonbee.NeonBeeProfile.WEB;
+import static io.vertx.core.Future.succeededFuture;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.apache.olingo.commons.api.edm.FullQualifiedName;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.neonbee.NeonBee;
+import io.neonbee.NeonBeeExtension;
+import io.neonbee.NeonBeeInstanceConfiguration;
+import io.neonbee.entity.EntityVerticle;
+import io.neonbee.internal.cluster.ClusterHelper;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith({ NeonBeeExtension.class })
+class UnregisterEntitiesTest {
+
+    static final String SHARED_ENTITY_MAP_NAME = "entityVerticles[%s]";
+
+    @Test
+    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("test unregistering entity models (Infinispan cluster)) ")
+    void testInfinispanUnregisteringEntities(@NeonBeeInstanceConfiguration(activeProfiles = WEB, clustered = true,
+            clusterManager = INFINISPAN) NeonBee web, VertxTestContext testContext) {
+        testUnregisteringEntities(web, testContext);
+    }
+
+    @Test
+    @Timeout(value = 2000, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("test unregistering entity models (Hazelcast cluster)")
+    void testHazelcastUnregisteringEntities(@NeonBeeInstanceConfiguration(activeProfiles = WEB, clustered = true,
+            clusterManager = HAZELCAST) NeonBee web, VertxTestContext testContext) {
+        testUnregisteringEntities(web, testContext);
+    }
+
+    private void testUnregisteringEntities(NeonBee web, VertxTestContext testContext) {
+        assertThat(isClustered(web)).isTrue();
+
+        Vertx vertx = web.getVertx();
+        String clusterNodeId = ClusterHelper.getClusterNodeId(vertx);
+
+        ClusterEntityRegistry registry = (ClusterEntityRegistry) web.getEntityRegistry();
+        EntityVerticleUnregisterImpl entityVerticle = new EntityVerticleUnregisterImpl();
+        vertx.deployVerticle(entityVerticle)
+                .compose(unused -> registry.clusteringInformation.get(ClusterHelper.getClusterNodeId(web.getVertx())))
+                .onSuccess(jsonArray -> testContext.verify(() -> {
+                    assertThat(jsonArray).hasSize(2);
+
+                    List<JsonObject> jsonObjectList = jsonArray.stream().map(JsonObject.class::cast).sorted(
+                            (o1, o2) -> CharSequence.compare(o1.getString("entityName"), o2.getString("entityName")))
+                            .collect(Collectors.toList());
+
+                    assertThat(jsonObjectList.get(0))
+                            .isEqualTo(JsonObject.of("qualifiedName", entityVerticle.getQualifiedName(), "entityName",
+                                    sharedEntityMapName(EntityVerticleUnregisterImpl.FQN_ERP_CUSTOMERS)));
+
+                    assertThat(jsonObjectList.get(1))
+                            .isEqualTo(JsonObject.of("qualifiedName", entityVerticle.getQualifiedName(), "entityName",
+                                    sharedEntityMapName(EntityVerticleUnregisterImpl.FQN_SALES_ORDERS)));
+                }))
+                .compose(unused -> EntityVerticle.getVerticlesForEntityType(vertx,
+                        EntityVerticleUnregisterImpl.FQN_ERP_CUSTOMERS))
+                .compose(list -> EntityVerticle
+                        .getVerticlesForEntityType(vertx, EntityVerticleUnregisterImpl.FQN_SALES_ORDERS).map(list2 -> {
+                            list.addAll(list2);
+                            return list;
+                        }))
+                .onSuccess(list -> testContext.verify(() -> {
+                    assertThat(list).hasSize(2);
+                })).compose(unused -> UnregisterEntityVerticlesHook.unregister(web, clusterNodeId))
+                .compose(unused -> registry.get(sharedEntityMapName(EntityVerticleUnregisterImpl.FQN_ERP_CUSTOMERS)))
+                .onSuccess(jsonArray -> testContext.verify(() -> {
+                    assertThat(jsonArray).isEqualTo(new JsonArray());
+                })).compose(unused -> registry.clusteringInformation.get(clusterNodeId))
+                .onSuccess(object -> testContext.verify(() -> {
+                    assertThat(object).isNull();
+                    testContext.completeNow();
+                }))
+                .compose(unused -> EntityVerticle.getVerticlesForEntityType(vertx,
+                        EntityVerticleUnregisterImpl.FQN_ERP_CUSTOMERS))
+                .compose(list -> EntityVerticle
+                        .getVerticlesForEntityType(vertx, EntityVerticleUnregisterImpl.FQN_SALES_ORDERS).map(list2 -> {
+                            list.addAll(list2);
+                            return list;
+                        }))
+                .onSuccess(list -> testContext.verify(() -> {
+                    assertThat(list).isEmpty();
+                }))
+
+                .onFailure(testContext::failNow);
+    }
+
+    static String sharedEntityMapName(FullQualifiedName entityTypeName) {
+        return String.format(SHARED_ENTITY_MAP_NAME, entityTypeName.getFullQualifiedNameAsString());
+    }
+
+    private boolean isClustered(NeonBee neonBee) {
+        return ClusterHelper.getClusterManager(neonBee.getVertx()).isPresent();
+    }
+
+    public static class EntityVerticleUnregisterImpl extends EntityVerticle {
+        static final FullQualifiedName FQN_ERP_CUSTOMERS = new FullQualifiedName("ERP", "Customers");
+
+        static final FullQualifiedName FQN_SALES_ORDERS = new FullQualifiedName("Sales", "Orders");
+
+        @Override
+        public Future<Set<FullQualifiedName>> entityTypeNames() {
+            return succeededFuture(Set.of(FQN_ERP_CUSTOMERS, FQN_SALES_ORDERS));
+        }
+    }
+}


### PR DESCRIPTION
NeonBee uses the shared map to manage the registration fo entities to
EntityVerticles e.g:
("Products" -> "ProductsVerticle")
("OrderTypes" -> "C4SOrderTypesVerticle")
During the boot up of an EntityVerticle "announceEntityVerticle" is used to register:
"Entity Products" is handled by "me" (EntityProductsVerticle)
Currently no "stop()" method is implemented, and no fallback handling was implemented (so the map may contain entries of verticles that no longer exist)

This commit adds two methods to delete the registered entities from the shared map.
The `UnregisterEntityModelHook#unregisterOnShutdown` method is executed if a node shuts down gracefully.
The `UnregisterEntityModelHook#cleanup` method is executed when the cluster detects that a node has left