### PR TITLE
feat: extend DataException and return DataException via eventbus

### DIFF
--- a/src/main/java/io/neonbee/NeonBee.java
+++ b/src/main/java/io/neonbee/NeonBee.java
@@ -42,6 +42,7 @@ import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.neonbee.config.HealthConfig;
 import io.neonbee.config.NeonBeeConfig;
 import io.neonbee.config.ServerConfig;
+import io.neonbee.data.DataException;
 import io.neonbee.data.DataQuery;
 import io.neonbee.entity.EntityModelManager;
 import io.neonbee.entity.EntityWrapper;
@@ -55,6 +56,7 @@ import io.neonbee.hook.HookType;
 import io.neonbee.hook.internal.DefaultHookRegistry;
 import io.neonbee.internal.SharedDataAccessor;
 import io.neonbee.internal.buffer.ImmutableBuffer;
+import io.neonbee.internal.codec.DataExceptionMessageCodec;
 import io.neonbee.internal.codec.DataQueryMessageCodec;
 import io.neonbee.internal.codec.EntityWrapperMessageCodec;
 import io.neonbee.internal.codec.ImmutableBufferMessageCodec;
@@ -410,7 +412,8 @@ public class NeonBee {
                     .registerDefaultCodec(EntityWrapper.class, new EntityWrapperMessageCodec(vertx))
                     .registerDefaultCodec(ImmutableBuffer.class, new ImmutableBufferMessageCodec())
                     .registerDefaultCodec(ImmutableJsonArray.class, new ImmutableJsonArrayMessageCodec())
-                    .registerDefaultCodec(ImmutableJsonObject.class, new ImmutableJsonObjectMessageCodec());
+                    .registerDefaultCodec(ImmutableJsonObject.class, new ImmutableJsonObjectMessageCodec())
+                    .registerDefaultCodec(DataException.class, new DataExceptionMessageCodec());
 
             // add any additional default codecs configured in NeonBeeConfig
             config.getEventBusCodecs().forEach(this::registerCodec);

--- a/src/main/java/io/neonbee/internal/codec/DataExceptionMessageCodec.java
+++ b/src/main/java/io/neonbee/internal/codec/DataExceptionMessageCodec.java
@@ -1,0 +1,70 @@
+package io.neonbee.internal.codec;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import io.neonbee.data.DataException;
+import io.netty.util.CharsetUtil;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.MessageCodec;
+import io.vertx.core.json.JsonObject;
+
+public class DataExceptionMessageCodec implements MessageCodec<DataException, DataException> {
+
+    @Override
+    public void encodeToWire(Buffer buffer, DataException exception) {
+        buffer.appendInt(exception.failureCode());
+
+        String msgEncoded = exception.getMessage();
+        if (msgEncoded != null) {
+            byte[] msgBytes = msgEncoded.getBytes(CharsetUtil.UTF_8);
+            buffer.appendInt(msgBytes.length);
+            buffer.appendBytes(msgBytes);
+        } else {
+            buffer.appendInt(-1);
+        }
+
+        Buffer failureDetailEncoded = new JsonObject(exception.failureDetail()).toBuffer();
+        buffer.appendInt(failureDetailEncoded.length());
+        buffer.appendBuffer(failureDetailEncoded);
+    }
+
+    @Override
+    public DataException decodeFromWire(int pos, Buffer buffer) {
+        int tmpPos = pos;
+        int failureCode = buffer.getInt(tmpPos);
+        tmpPos += Integer.BYTES;
+
+        int msgLength = buffer.getInt(tmpPos);
+        tmpPos += Integer.BYTES;
+        String message =
+                msgLength != -1 ? new String(buffer.getBytes(tmpPos, tmpPos + msgLength), CharsetUtil.UTF_8) : null;
+        tmpPos += msgLength != -1 ? msgLength : 0;
+
+        int failureDetailLength = buffer.getInt(tmpPos);
+        tmpPos += Integer.BYTES;
+
+        Buffer buff = buffer.getBuffer(tmpPos, tmpPos + failureDetailLength);
+        Map<String, Object> failureDetail =
+                buff.toJsonObject().stream().collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+        return new DataException(failureCode, message, failureDetail);
+    }
+
+    @Override
+    public DataException transform(DataException exception) {
+        return exception;
+    }
+
+    @Override
+    public String name() {
+        return "dataexception";
+    }
+
+    @Override
+    public byte systemCodecID() {
+        return -1;
+    }
+
+}

--- a/src/test/java/io/neonbee/cluster/DataExceptionRequestTest.java
+++ b/src/test/java/io/neonbee/cluster/DataExceptionRequestTest.java
@@ -1,0 +1,134 @@
+package io.neonbee.cluster;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.neonbee.test.helper.DeploymentHelper.deployVerticle;
+import static io.vertx.core.Future.failedFuture;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.neonbee.NeonBee;
+import io.neonbee.NeonBeeExtension;
+import io.neonbee.NeonBeeInstanceConfiguration;
+import io.neonbee.data.DataContext;
+import io.neonbee.data.DataException;
+import io.neonbee.data.DataMap;
+import io.neonbee.data.DataQuery;
+import io.neonbee.data.DataRequest;
+import io.neonbee.data.DataVerticle;
+import io.neonbee.data.internal.DataContextImpl;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(NeonBeeExtension.class)
+class DataExceptionRequestTest {
+    private static final JsonObject FAILURE_OBJECT = new JsonObject().put("code", new JsonArray()
+            .add(new JsonObject().put("message", "This is a bad response")).add(new JsonObject().put("lang", "en")));
+
+    private static final Map<String, Object> FAILURE_DETAIL = Map.of("error", FAILURE_OBJECT);
+
+    private static final DataVerticle<Buffer> DATA_EXCEPTION_VERTICLE = new DataVerticle<>() {
+        @Override
+        public String getName() {
+            return "DataException";
+        }
+
+        @Override
+        public Future<Buffer> retrieveData(DataQuery query, DataMap dataMap, DataContext context) {
+            return failedFuture(new DataException(400, "Bad Response", FAILURE_DETAIL));
+        }
+    };
+
+    private static final DataVerticle<Buffer> DATA_EXCEPTION_VERTICLE_ONLY_FAILURE_CODE = new DataVerticle<>() {
+        @Override
+        public String getName() {
+            return "DataExceptionFailureCodeOnly";
+        }
+
+        @Override
+        public Future<Buffer> retrieveData(DataQuery query, DataMap dataMap, DataContext context) {
+            return failedFuture(new DataException(400));
+        }
+    };
+
+    private static final DataVerticle<Buffer> DATA_EXCEPTION_VERTICLE_FAILURE_CODE_AND_MESSAGE = new DataVerticle<>() {
+        @Override
+        public String getName() {
+            return "DataExceptionFailureCodeAndMessage";
+        }
+
+        @Override
+        public Future<Buffer> retrieveData(DataQuery query, DataMap dataMap, DataContext context) {
+            return failedFuture(new DataException(400, "Bad response"));
+        }
+    };
+
+    @Test
+    @Timeout(value = 10, timeUnit = TimeUnit.HOURS)
+    @DisplayName("Test that DataException can be returned via the event bus")
+    void testDataExceptionRequest(@NeonBeeInstanceConfiguration(clustered = true, activeProfiles = {}) NeonBee source,
+            @NeonBeeInstanceConfiguration(clustered = true, activeProfiles = {}) NeonBee target,
+            VertxTestContext testContext) {
+        deployVerticle(target.getVertx(), DATA_EXCEPTION_VERTICLE).compose(s -> {
+            DataRequest request = new DataRequest(DATA_EXCEPTION_VERTICLE.getName());
+            return DataVerticle.<JsonObject>requestData(source.getVertx(), request, new DataContextImpl());
+        }).onComplete(testContext.failing(response -> {
+            testContext.verify(() -> {
+                assertThat(response).isInstanceOf(DataException.class);
+                assertThat(((DataException) response).failureCode()).isEqualTo(400);
+                assertThat(response.getMessage()).isEqualTo("Bad Response");
+                assertThat(((DataException) response).failureDetail().get("error")).isEqualTo(FAILURE_OBJECT);
+            });
+            testContext.completeNow();
+        }));
+    }
+
+    @Test
+    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("Test that DataException with failure code and message be returned via the event bus")
+    void testDataExceptionRequestFailureCodeAndMessage(
+            @NeonBeeInstanceConfiguration(clustered = true, activeProfiles = {}) NeonBee source,
+            @NeonBeeInstanceConfiguration(clustered = true, activeProfiles = {}) NeonBee target,
+            VertxTestContext testContext) {
+        deployVerticle(target.getVertx(), DATA_EXCEPTION_VERTICLE_FAILURE_CODE_AND_MESSAGE).compose(s -> {
+            DataRequest request = new DataRequest(DATA_EXCEPTION_VERTICLE_FAILURE_CODE_AND_MESSAGE.getName());
+            return DataVerticle.<JsonObject>requestData(source.getVertx(), request, new DataContextImpl());
+        }).onComplete(testContext.failing(response -> {
+            testContext.verify(() -> {
+                assertThat(response).isInstanceOf(DataException.class);
+                assertThat(((DataException) response).failureCode()).isEqualTo(400);
+                assertThat(response.getMessage()).isEqualTo("Bad response");
+            });
+            testContext.completeNow();
+        }));
+    }
+
+    @Test
+    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("Test that DataException with failure code be returned via the event bus")
+    void testDataExceptionRequestFailureCodeOnly(
+            @NeonBeeInstanceConfiguration(clustered = true, activeProfiles = {}) NeonBee source,
+            @NeonBeeInstanceConfiguration(clustered = true, activeProfiles = {}) NeonBee target,
+            VertxTestContext testContext) {
+        deployVerticle(target.getVertx(), DATA_EXCEPTION_VERTICLE_ONLY_FAILURE_CODE).compose(s -> {
+            DataRequest request = new DataRequest(DATA_EXCEPTION_VERTICLE_ONLY_FAILURE_CODE.getName());
+            return DataVerticle.<JsonObject>requestData(source.getVertx(), request, new DataContextImpl());
+        }).onComplete(testContext.failing(response -> {
+            testContext.verify(() -> {
+                assertThat(response).isInstanceOf(DataException.class);
+                assertThat(((DataException) response).failureCode()).isEqualTo(400);
+                assertThat(response.getMessage()).isEqualTo(null);
+                assertThat(((DataException) response).failureDetail()).isEqualTo(Map.of());
+            });
+            testContext.completeNow();
+        }));
+    }
+}

--- a/src/test/java/io/neonbee/data/DataExceptionTest.java
+++ b/src/test/java/io/neonbee/data/DataExceptionTest.java
@@ -1,0 +1,90 @@
+package io.neonbee.data;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+class DataExceptionTest {
+
+    private final DataException exception0 = new DataException(400);
+
+    private final DataException exception1 = new DataException("Bad Response");
+
+    private final DataException exception2 = new DataException(400, "Bad Response");
+
+    private final DataException exception3 =
+            new DataException(400, "Bad Response", Map.of("error", "This is an error."));
+
+    private final JsonObject exceptionJsonObject = new JsonObject().put("message", "This is an error.");
+
+    private final DataException exception4 =
+            new DataException(400, "Bad Response", Map.of("error", exceptionJsonObject));
+
+    private final JsonArray exceptionJsonArray = new JsonArray()
+            .add(new JsonObject().put("message", "This is an error.")).add(new JsonObject().put("lang", "en"));
+
+    private final DataException exception5 =
+            new DataException(400, "Bad Response", Map.of("error", exceptionJsonArray));
+
+    @Test
+    @DisplayName("Test DataException getters")
+    void testGetters() {
+        assertThat(exception0.failureCode()).isEqualTo(400);
+        assertThat(exception0.getMessage()).isEqualTo(null);
+        assertThat(exception0.failureDetail()).isEqualTo(Map.of());
+
+        assertThat(exception1.failureCode()).isEqualTo(-1);
+        assertThat(exception1.getMessage()).isEqualTo("Bad Response");
+        assertThat(exception1.failureDetail()).isEqualTo(Map.of());
+
+        assertThat(exception2.failureCode()).isEqualTo(400);
+        assertThat(exception2.getMessage()).isEqualTo("Bad Response");
+        assertThat(exception2.failureDetail()).isEqualTo(Map.of());
+
+        assertThat(exception3.failureCode()).isEqualTo(400);
+        assertThat(exception3.getMessage()).isEqualTo("Bad Response");
+        assertThat(exception3.failureDetail()).isEqualTo(Map.of("error", "This is an error."));
+
+        assertThat(exception4.failureCode()).isEqualTo(400);
+        assertThat(exception4.getMessage()).isEqualTo("Bad Response");
+        assertThat(exception4.failureDetail()).isEqualTo(Map.of("error", exceptionJsonObject));
+
+        assertThat(exception5.failureCode()).isEqualTo(400);
+        assertThat(exception5.getMessage()).isEqualTo("Bad Response");
+        assertThat(exception5.failureDetail()).isEqualTo(Map.of("error", exceptionJsonArray));
+
+        assertThrows(NullPointerException.class, () -> new DataException(400, "Bad Response", null));
+    }
+
+    @Test
+    @DisplayName("Test toString method")
+    void testToString() {
+        assertThat(exception0.toString()).isEqualTo("(400)");
+        assertThat(exception1.toString()).isEqualTo("(-1) Bad Response");
+        assertThat(exception2.toString()).isEqualTo("(400) Bad Response");
+        assertThat(exception3.toString()).isEqualTo("(400) Bad Response");
+    }
+
+    @Test
+    @DisplayName("Test hashCode and equals")
+    void testHashCode() {
+        DataException exceptionClone = new DataException(400, "Bad Response", Map.of("error", "This is an error."));
+        DataException exceptionClone2 = new DataException(400, "Bad Response", Map.of());
+
+        // hashCode
+        assertThat(exception3.hashCode()).isEqualTo(exceptionClone.hashCode());
+        assertThat(exception3.hashCode()).isNotEqualTo(exceptionClone2.hashCode());
+
+        // equals
+        assertThat(exception3.equals(exceptionClone)).isTrue();
+        assertThat(exception3.equals(exceptionClone2)).isFalse();
+        assertThat(exception2.equals(exceptionClone2)).isTrue();
+    }
+}

--- a/src/test/java/io/neonbee/internal/codec/DataExceptionMessageCodecTest.java
+++ b/src/test/java/io/neonbee/internal/codec/DataExceptionMessageCodecTest.java
@@ -1,0 +1,96 @@
+package io.neonbee.internal.codec;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.neonbee.data.DataException;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+class DataExceptionMessageCodecTest {
+    private final DataExceptionMessageCodec codec = new DataExceptionMessageCodec();
+
+    private final DataException exception0 = new DataException(400, null);
+
+    private final DataException exception1 = new DataException(400, "Bad Response");
+
+    private final DataException exception2 =
+            new DataException(400, "Bad Response", Map.of("error", "This is a bad response."));
+
+    private static final JsonObject FAILURE_OBJECT = new JsonObject().put("code", new JsonArray()
+            .add(new JsonObject().put("message", "This is a bad response2")).add(new JsonObject().put("lang", "en")));
+
+    private final DataException exception3 = new DataException(400, "Bad Response", Map.of("error", FAILURE_OBJECT));
+
+    private static final JsonArray FAILURE_ARRAY =
+            new JsonArray().add(FAILURE_OBJECT).add(new JsonObject().put("key", "value"));
+
+    private final DataException exception4 = new DataException(400, "Bad Response", Map.of("error", FAILURE_ARRAY));
+
+    @Test
+    @DisplayName("enocde/decode for data exception with failure code")
+    void testEncodeDecodeDataExceptionWithFailureCode() {
+        Buffer buffer = Buffer.buffer();
+        codec.encodeToWire(buffer, exception0);
+        DataException decoded = codec.decodeFromWire(0, buffer);
+        assertThat(decoded).isEqualTo(exception0);
+    }
+
+    @Test
+    @DisplayName("enocde/decode for data exception with failure code and message")
+    void testEncodeDecodeDataExceptionWithFailureCodeAndMessage() {
+        Buffer buffer = Buffer.buffer();
+        codec.encodeToWire(buffer, exception1);
+        DataException decoded = codec.decodeFromWire(0, buffer);
+        assertThat(decoded).isEqualTo(exception1);
+    }
+
+    @Test
+    @DisplayName("enocde/decode for data exception: failureDetail as String")
+    void testEncodeDecodeWithStringFailureDetail() {
+        Buffer buffer = Buffer.buffer();
+        codec.encodeToWire(buffer, exception2);
+        DataException decoded = codec.decodeFromWire(0, buffer);
+        assertThat(decoded).isEqualTo(exception2);
+    }
+
+    @Test
+    @DisplayName("enocde/decode for data exception: failureDetail as JsonObject")
+    void testEncodeDecodeWithJsonObjectFailureDetail() {
+        Buffer buffer = Buffer.buffer();
+        codec.encodeToWire(buffer, exception3);
+        DataException decoded = codec.decodeFromWire(0, buffer);
+        assertThat(decoded).isEqualTo(exception3);
+    }
+
+    @Test
+    @DisplayName("enocde/decode for data exception: failureDetail as JsonArray")
+    void testEncodeDecodeWithJsonArrayFailureDetail() {
+        Buffer buffer = Buffer.buffer();
+        codec.encodeToWire(buffer, exception4);
+        DataException decoded = codec.decodeFromWire(0, buffer);
+        assertThat(decoded).isEqualTo(exception4);
+    }
+
+    @Test
+    void testTransform() {
+        assertThat(codec.transform(exception0)).isEqualTo(exception0);
+        assertThat(codec.transform(exception1)).isEqualTo(exception1);
+        assertThat(codec.transform(exception2)).isEqualTo(exception2);
+    }
+
+    @Test
+    void testName() {
+        assertThat(codec.name()).isEqualTo("dataexception");
+    }
+
+    @Test
+    void testSystemCodecID() {
+        assertThat(codec.systemCodecID()).isEqualTo(-1);
+    }
+}


### PR DESCRIPTION
Currently DataException only allows propagation of one error message. The intention is to add an failureDetail message to be able to propagate source error messages to the invoker, but should not be exposed to the consumer. A message codec for DataException is provided to allow serialization/deserialization of DataException objects via the event bus.