### PR TITLE
feat: SFMBBB-305 entity model manager controls shared model definition

### DIFF
--- a/docs/shared-entity-model-manager-deployable.puml
+++ b/docs/shared-entity-model-manager-deployable.puml
@@ -1,0 +1,99 @@
+@startuml
+'https://plantuml.com/class-diagram
+
+package vertx {
+    interface EventBus {
+        publish( address, message)
+    }
+    interface SharedData {
+        getAsyncMap()
+
+        putInAsyncMap()
+    }
+    interface MessageCodec
+}
+
+package neonbee {
+
+    class DeployerVerticle extends WatchVerticle {
+        triggerDeployment
+    }
+
+    class Deployables
+
+    class DeployableModule extends Deployables {
+        fromJar()
+    }
+
+    class DeployableModels extends Deployables {
+        scanClassPath()
+        Map<String, byte[]> readModelPayloads()
+        deploy()
+    }
+
+    class EntityModelManager {
+        Map<String, EntityModel> reloadModels()
+    }
+
+    class EntityModel {
+        CdsModel csnModel;
+        Map<String, ServiceMetadata> edmxMap;
+    }
+
+    class EntityModelLoader {
+        Map<String, EntityModel>> load()
+
+        scanDir(Path path)
+
+        loadModelFromBuffer(): new method
+    }
+
+    class EntityWrapperMessageCodec implements MessageCodec {
+    }
+}
+
+package neonbee.changes {
+    class SharedEntityModelManager extends EntityModelManager {
+
+        reloadRemoteModels()
+
+        mergeRemoteModels(Map<String, EntityModel> newModels)
+    }
+    class Timer {
+        every5Minutes()
+    }
+
+    class DistributedFileSystem {
+        pushChanges()
+
+        /**
+        contains relative path and
+        content of distributed files
+        */
+        Map<String, byte[]> files
+
+        obtainChanges()
+    }
+}
+
+
+
+DeployerVerticle::observedCreateOrModify ..> DeployableModule::fromJar: 1
+DeployableModule::fromJar ..> DeployableModels::scanClassPath: 2
+DeployableModels::scanClassPath ..> DeployableModels::readModelPayloads: 3
+DeployerVerticle::observedCreateOrModify ..> DeployableModels::deploy: 4
+DeployableModels::deploy ..> EntityModelManager::registerModels: 5
+EntityModelManager::registerModels ..> DistributedFileSystem::pushChanges: 6
+DistributedFileSystem::pushChanges ..> SharedData::putInAsyncMap: 7
+EntityModelManager::reloadModels ..> EventBus::publish: 6  EVENT_BUS_MODELS_LOADED_ADDRESS, local only
+
+Timer::every5Minutes .right.> SharedEntityModelManager::reloadRemoteModels: 1
+SharedEntityModelManager::reloadRemoteModels ..> DistributedFileSystem::obtainChanges: 2
+DistributedFileSystem::obtainChanges ..> SharedData::getAsyncMap: 3
+SharedEntityModelManager::reloadRemoteModels .right.> EntityModelLoader::loadModelFromBuffer: 4
+SharedEntityModelManager::reloadRemoteModels ..> SharedEntityModelManager::mergeRemoteModels: 5
+EntityWrapperMessageCodec ..> EntityModelManager
+
+
+
+@enduml

--- a/docs/shared-entity-model-manager-model-refresh.puml
+++ b/docs/shared-entity-model-manager-model-refresh.puml
@@ -1,0 +1,81 @@
+@startuml
+'https://plantuml.com/class-diagram
+
+package vertx {
+    interface EventBus {
+        publish( address, message)
+    }
+    interface SharedData {
+        getAsyncMap()
+
+        putInAsyncMap()
+    }
+    interface MessageCodec
+}
+
+package neonbee {
+    class ModelRefreshVerticle extends WatchVerticle {
+        observedCreateOrModify()
+    }
+    class EntityModelManager {
+        Map<String, EntityModel> reloadModels()
+    }
+
+    class EntityModel {
+        CdsModel csnModel;
+        Map<String, ServiceMetadata> edmxMap;
+    }
+
+    class EntityModelLoader {
+        Map<String, EntityModel>> load()
+
+        scanDir(Path path)
+
+        loadModelFromBuffer(): new method
+    }
+
+    class EntityWrapperMessageCodec implements MessageCodec {
+    }
+}
+
+package neonbee.changes {
+    class SharedEntityModelManager extends EntityModelManager {
+
+        reloadRemoteModels()
+
+        mergeRemoteModels(Map<String, EntityModel> newModels)
+    }
+    class Timer {
+        every5Minutes()
+    }
+
+    class DistributedFileSystem {
+        pushChanges()
+
+        /**
+        contains relative path and
+        content of distributed files
+        */
+        Map<String, byte[]> files
+
+        obtainChanges()
+    }
+}
+
+
+
+ModelRefreshVerticle::observedCreateOrModify ..> EntityModelManager::reloadModels: 1
+EntityModelManager::reloadModels ..> EntityModelLoader::load: 2
+EntityModelLoader::load ..> EntityModelLoader::scanDir: 3
+EntityModelLoader::load ..> DistributedFileSystem::pushChanges: 4
+DistributedFileSystem::pushChanges ..> SharedData::putInAsyncMap: 5
+EntityModelManager::reloadModels ..> EventBus::publish: 6  EVENT_BUS_MODELS_LOADED_ADDRESS, local only
+
+Timer::every5Minutes ..> SharedEntityModelManager::reloadRemoteModels: 1
+SharedEntityModelManager::reloadRemoteModels ..> DistributedFileSystem::obtainChanges: 2
+DistributedFileSystem::obtainChanges ..> SharedData::getAsyncMap: 3
+SharedEntityModelManager::reloadRemoteModels ..> EntityModelLoader::loadModelFromBuffer: 4
+SharedEntityModelManager::reloadRemoteModels ..> SharedEntityModelManager::mergeRemoteModels: 5
+EntityWrapperMessageCodec ..> EntityModelManager
+
+@enduml

--- a/src/main/java/io/neonbee/NeonBee.java
+++ b/src/main/java/io/neonbee/NeonBee.java
@@ -77,6 +77,7 @@ import io.neonbee.internal.tracking.MessageDirection;
 import io.neonbee.internal.tracking.TrackingDataHandlingStrategy;
 import io.neonbee.internal.tracking.TrackingDataLoggingStrategy;
 import io.neonbee.internal.tracking.TrackingInterceptor;
+import io.neonbee.internal.verticle.ClusterEntityModelReloadVerticle;
 import io.neonbee.internal.verticle.ConsolidationVerticle;
 import io.neonbee.internal.verticle.DeployerVerticle;
 import io.neonbee.internal.verticle.HealthCheckVerticle;
@@ -498,6 +499,7 @@ public class NeonBee {
         List<Future<? extends Deployable>> requiredVerticles = new ArrayList<>();
         requiredVerticles.add(fromClass(vertx, ConsolidationVerticle.class, new JsonObject().put("instances", 1)));
         requiredVerticles.add(fromClass(vertx, LoggerManagerVerticle.class));
+        requiredVerticles.add(fromClass(vertx, ClusterEntityModelReloadVerticle.class));
 
         List<Future<Optional<? extends Deployable>>> optionalVerticles = new ArrayList<>();
         if (Optional.ofNullable(config.getHealthConfig()).map(HealthConfig::isEnabled).orElse(true)) {

--- a/src/main/java/io/neonbee/entity/EntityModelDefinition.java
+++ b/src/main/java/io/neonbee/entity/EntityModelDefinition.java
@@ -2,15 +2,25 @@ package io.neonbee.entity;
 
 import static java.util.Objects.requireNonNull;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.google.common.annotations.VisibleForTesting;
 import com.sap.cds.reflect.CdsModel;
 import com.sap.cds.reflect.CdsService;
 
-public final class EntityModelDefinition {
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.shareddata.ClusterSerializable;
+
+public final class EntityModelDefinition implements ClusterSerializable {
     /**
      * File extension for CSN model definition files.
      */
@@ -21,22 +31,24 @@ public final class EntityModelDefinition {
      */
     public static final String EDMX = ".edmx";
 
-    private final Map<String, byte[]> csnModelDefinitions;
+    private Map<String, byte[]> csData;
 
-    private final Map<String, byte[]> associatedModelDefinitions;
+    private Map<String, byte[]> associatedData;
 
     /**
      * Creates a new {@link EntityModelDefinition} based on a CSN and any number of associated model definitions like
      * EDMX files.
      *
-     * @param csnModelDefinitions        any number of CSN model definitions
-     * @param associatedModelDefinitions any number of associated model definition files such as EDMX
+     * @param csData         any number of CSN model definitions
+     * @param associatedData any number of associated model definition files such as EDMX
      */
-    public EntityModelDefinition(Map<String, byte[]> csnModelDefinitions,
-            Map<String, byte[]> associatedModelDefinitions) {
-        this.csnModelDefinitions = requireNonNull(csnModelDefinitions);
-        this.associatedModelDefinitions = requireNonNull(associatedModelDefinitions);
+    public EntityModelDefinition(Map<String, byte[]> csData, Map<String, byte[]> associatedData) {
+        this.csData = requireNonNull(csData);
+        this.associatedData = requireNonNull(associatedData);
     }
+
+    @VisibleForTesting
+    public EntityModelDefinition() {}
 
     /**
      * Get all CSN model definitions of this {@link EntityModelDefinition}.
@@ -44,7 +56,7 @@ public final class EntityModelDefinition {
      * @return a map of CSN models
      */
     public Map<String, byte[]> getCSNModelDefinitions() {
-        return csnModelDefinitions;
+        return csData;
     }
 
     /**
@@ -52,14 +64,14 @@ public final class EntityModelDefinition {
      *
      * @return a map of associated models
      */
-    public Map<String, byte[]> getAssociatedModelDefinitions() {
-        return associatedModelDefinitions;
+    public Map<String, byte[]> getAssociatedData() {
+        return associatedData;
     }
 
     @Override
     public String toString() {
-        return String.join(",", csnModelDefinitions.keySet()) + "$"
-                + String.join(",", associatedModelDefinitions.keySet());
+        return String.join(",", csData.keySet().stream().sorted().collect(Collectors.toList())) + "$"
+                + String.join(",", associatedData.keySet().stream().sorted().collect(Collectors.toList()));
     }
 
     /**
@@ -100,5 +112,72 @@ public final class EntityModelDefinition {
             String edmxFileName = qualifiedName + EDMX;
             return csnPath.getParent().resolve(edmxFileName);
         }).collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return toString().equals(o.toString());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(csData.keySet(), associatedData.keySet());
+    }
+
+    public Buffer toBuffer() {
+        Buffer buffer = Buffer.buffer();
+        writeToBuffer(buffer);
+        return buffer;
+    }
+
+    public static EntityModelDefinition fromBuffer(Buffer buffer) {
+        EntityModelDefinition definition = new EntityModelDefinition();
+        definition.readFromBuffer(0, buffer);
+        return definition;
+    }
+
+    @Override
+    public void writeToBuffer(Buffer buffer) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            byte[] csn = mapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(csData);
+            byte[] associated = mapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(associatedData);
+
+            buffer.appendInt(csn.length);
+            buffer.appendBytes(csn);
+            buffer.appendInt(associated.length);
+            buffer.appendBytes(associated);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    @Override
+    public int readFromBuffer(int pos, Buffer buffer) {
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            ObjectReader reader = mapper.readerFor(new TypeReference<Map<String, byte[]>>() {});
+
+            int len = buffer.getInt(pos);
+            pos += 4;
+            csData = reader.readValue(buffer.getBytes(), pos, pos + len);
+            pos += len;
+
+            len = buffer.getInt(pos);
+            pos += 4;
+            associatedData = reader.readValue(buffer.getBytes(), pos, pos + len);
+            pos += len;
+            return pos;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/io/neonbee/internal/handler/InstanceInfoHandler.java
+++ b/src/main/java/io/neonbee/internal/handler/InstanceInfoHandler.java
@@ -17,9 +17,14 @@ public class InstanceInfoHandler implements PlatformHandler {
             }
 
             // Sets the NeonBee instance name as default
-            String instanceName = NeonBee.get(routingContext.vertx()).getOptions().getInstanceName();
-            if (instanceName != null && !instanceName.isBlank()) {
-                headers.set(X_INSTANCE_INFO_HEADER, instanceName);
+            String instanceName = null;
+            NeonBee neonbee = NeonBee.get(routingContext.vertx());
+            if (neonbee != null) {
+                instanceName = NeonBee.get(routingContext.vertx()).getOptions().getInstanceName();
+
+                if (instanceName != null && !instanceName.isBlank()) {
+                    headers.set(X_INSTANCE_INFO_HEADER, instanceName);
+                }
             }
         });
         routingContext.next();

--- a/src/main/java/io/neonbee/internal/handler/LoggerHandler.java
+++ b/src/main/java/io/neonbee/internal/handler/LoggerHandler.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 import io.neonbee.logging.LoggingFacade;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.impl.VertxImpl;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.PlatformHandler;
@@ -47,7 +48,10 @@ public class LoggerHandler implements PlatformHandler {
         }
 
         int statusCode = request.response().getStatusCode();
-        String message = String.format("%s - %s %s %s %d %d - %d ms",
+        StringBuilder nodeId = new StringBuilder();
+        Optional.ofNullable(routingContext.vertx())
+                .ifPresent(v -> nodeId.append(((VertxImpl) v).getClusterManager().getNodeId()));
+        String message = String.format("%s - %s - %s %s %s %d %d - %d ms", nodeId,
                 Optional.ofNullable(request.remoteAddress()).map(SocketAddress::host).orElse(null), request.method(),
                 request.uri(), version, statusCode, request.response().bytesWritten(),
                 System.currentTimeMillis() - timestamp);

--- a/src/main/java/io/neonbee/internal/verticle/ClusterEntityModelReloadVerticle.java
+++ b/src/main/java/io/neonbee/internal/verticle/ClusterEntityModelReloadVerticle.java
@@ -1,0 +1,24 @@
+package io.neonbee.internal.verticle;
+
+import java.util.concurrent.TimeUnit;
+
+import io.neonbee.NeonBee;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+
+public class ClusterEntityModelReloadVerticle extends AbstractVerticle {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterEntityModelReloadVerticle.class);
+
+    public static final Long REMOTE_MODEL_RELOAD_DELAY = TimeUnit.MINUTES.toMillis(2);
+
+    @Override
+    public void start() {
+        long reloadPeriod = config().getLong("REMOTE_MODEL_RELOAD_DELAY", REMOTE_MODEL_RELOAD_DELAY);
+        vertx.setPeriodic(reloadPeriod, t -> {
+            NeonBee.get(vertx).getModelManager().reloadRemoteModels(getVertx())
+                    .onSuccess(map -> LOGGER.info("obtainedChanges: " + map));
+        });
+    }
+}

--- a/src/main/java/io/neonbee/internal/verticle/ModelRefreshVerticle.java
+++ b/src/main/java/io/neonbee/internal/verticle/ModelRefreshVerticle.java
@@ -49,6 +49,7 @@ public class ModelRefreshVerticle extends WatchVerticle {
     }
 
     private void triggerRefresh(Promise<Void> finishPromise) {
+        LOGGER.debug("in trigger refresh");
         NeonBee.get(vertx).getModelManager().reloadModels().map((Void) null).onComplete(asyncResult -> {
             LOGGER.debug("Models have been refreshed.");
             finishPromise.handle(asyncResult);

--- a/src/main/java/io/neonbee/internal/verticle/WatchVerticle.java
+++ b/src/main/java/io/neonbee/internal/verticle/WatchVerticle.java
@@ -165,6 +165,7 @@ public class WatchVerticle extends AbstractVerticle {
 
         try {
             watcher = watchPath.getFileSystem().newWatchService();
+            LOGGER.debug("observing folder " + watchPath.toFile().getAbsolutePath());
         } catch (IOException e) {
             startPromise.fail(e);
             return;

--- a/src/test/java/io/neonbee/NeonBeeTest.java
+++ b/src/test/java/io/neonbee/NeonBeeTest.java
@@ -66,6 +66,7 @@ import io.neonbee.internal.NeonBeeModuleJar;
 import io.neonbee.internal.tracking.MessageDirection;
 import io.neonbee.internal.tracking.TrackingDataLoggingStrategy;
 import io.neonbee.internal.tracking.TrackingInterceptor;
+import io.neonbee.internal.verticle.ClusterEntityModelReloadVerticle;
 import io.neonbee.internal.verticle.ConsolidationVerticle;
 import io.neonbee.internal.verticle.HealthCheckVerticle;
 import io.neonbee.internal.verticle.LoggerManagerVerticle;
@@ -146,7 +147,7 @@ class NeonBeeTest extends NeonBeeTestBase {
     @DisplayName("NeonBee should deploy all none optional system verticles")
     void testDeployNoneOptionalSystemVerticles(Vertx vertx) {
         assertThat(getDeployedVerticles(vertx)).containsExactly(ConsolidationVerticle.class,
-                LoggerManagerVerticle.class);
+                LoggerManagerVerticle.class, ClusterEntityModelReloadVerticle.class);
     }
 
     @Test
@@ -154,7 +155,7 @@ class NeonBeeTest extends NeonBeeTestBase {
     @DisplayName("NeonBee should deploy all none optional system verticles plus HealthCheckVerticle")
     void testDeployNoneOptionalSystemVerticlesPlusHealthCheckVerticle(Vertx vertx) {
         assertThat(getDeployedVerticles(vertx)).containsExactly(ConsolidationVerticle.class,
-                LoggerManagerVerticle.class, HealthCheckVerticle.class);
+                LoggerManagerVerticle.class, ClusterEntityModelReloadVerticle.class, HealthCheckVerticle.class);
     }
 
     @Test

--- a/src/test/java/io/neonbee/cluster/LocalPreferredClusterTest.java
+++ b/src/test/java/io/neonbee/cluster/LocalPreferredClusterTest.java
@@ -28,6 +28,8 @@ import io.neonbee.data.DataVerticle;
 import io.neonbee.data.internal.DataContextImpl;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
@@ -65,7 +67,7 @@ class LocalPreferredClusterTest extends NeonBeeExtension.TestBase {
     }
 
     @Test
-    @Timeout(value = 20, timeUnit = TimeUnit.SECONDS)
+    @Timeout(value = 200, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Test that localPreferred requests are dispatched to remote consumers when no local consumer is available")
     void testLocalPreferredRequestWithoutLocalConsumer(VertxTestContext testContext) {
         // Create a localPreferred request
@@ -123,6 +125,8 @@ class LocalPreferredClusterTest extends NeonBeeExtension.TestBase {
     private static class ConsumerVerticle extends DataVerticle<String> {
         public static final String NAME = "Consumer";
 
+        private static final Logger LOGGER = LoggerFactory.getLogger(ConsumerVerticle.class);
+
         private final String node;
 
         ConsumerVerticle(String node) {
@@ -137,6 +141,7 @@ class LocalPreferredClusterTest extends NeonBeeExtension.TestBase {
 
         @Override
         public Future<String> retrieveData(DataQuery query, DataMap require, DataContext context) {
+            LOGGER.info("in retrieveData");
             return succeededFuture(node);
         }
     }

--- a/src/test/java/io/neonbee/cluster/MultipleInstancesTest.java
+++ b/src/test/java/io/neonbee/cluster/MultipleInstancesTest.java
@@ -1,0 +1,48 @@
+package io.neonbee.cluster;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Isolated;
+
+/**
+ * Tests behavior of neon bee in cluster. Multiple instances of neon bee will be created to maintain cluster. Two nodes
+ * will deploy some verticle providing data. Third vnode will deploy verticle using the data of provider verticle. Test
+ * scenarios contain cases with stop and restart of nodes with provider verticles during the access to consumer verticle
+ * over http in the loop to provoke error situation. Also heartbeat and failure detection features of cluster manager
+ * can be then tested.
+ */
+@Isolated("")
+class MultipleInstancesTest {
+
+    private NeonbeeClusterRunner clusterRunner;
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        NeonbeeClusterRunner.init();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        NeonbeeClusterRunner.cleanUp();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        clusterRunner = new NeonbeeClusterRunner();
+    }
+
+    @Test
+    void runInstances() throws IOException, InterruptedException {
+        for (int i = 0; i < 3; i++) {
+            clusterRunner.startProcess(i);
+        }
+
+        Thread.sleep(50000);
+    }
+
+    @AfterEach
+    void afterEach() {
+        clusterRunner.clean();
+    }
+}

--- a/src/test/java/io/neonbee/cluster/NeonbeeClusterRunner.java
+++ b/src/test/java/io/neonbee/cluster/NeonbeeClusterRunner.java
@@ -1,0 +1,90 @@
+package io.neonbee.cluster;
+
+import static io.neonbee.test.helper.FileSystemHelper.createTempDirectory;
+import static io.neonbee.test.helper.FileSystemHelper.deleteRecursiveBlocking;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.*;
+
+import org.apache.commons.io.FileUtils;
+
+import com.sap.cds.impl.util.Pair;
+
+import io.neonbee.test.helper.WorkingDirectoryBuilder;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+
+public class NeonbeeClusterRunner {
+    private final Map<Process, StringBuilder> processes = new HashMap<>();
+
+    private static Path workDirPath;
+
+    private static String workDir;
+
+    static String[] args;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NeonbeeClusterRunner.class);
+
+    static final int STARTING_PORT = 8081;
+
+    private static final int CLUSTER_STARTING_PORT = 10000;
+
+    static void init() throws IOException {
+        workDirPath = createTempDirectory();
+        workDir = workDirPath.toAbsolutePath().toString();
+        args = new String[] { "-no-cp", "-cl", "-cc", "hazelcast-localtcp.xml" };
+    }
+
+    static void cleanUp() {
+        deleteRecursiveBlocking(workDirPath);
+    }
+
+    void clean() {
+        processes.forEach((k, v) -> LOGGER.info("output from process " + k.pid() + " " + v.toString()));
+        processes.keySet().forEach(Process::destroy);
+    }
+
+    Pair<Process, StringBuilder> startProcess(int instanceNumber) throws IOException {
+        String classPath = System.getProperty("java.class.path");
+        var sb = new StringBuilder();
+        String[] params = { "java", "-cp", classPath, "io.neonbee.Launcher" };
+        var paramsList = new ArrayList<>(List.of(params));
+        var tmpFolder = workDir + '/' + instanceNumber;
+        var moduleDir = tmpFolder + '/' + WorkingDirectoryBuilder.MODULES_DIR;
+        FileUtils.forceMkdir(new File(moduleDir));
+
+        paramsList.addAll(List.of("-port", Integer.toString(STARTING_PORT + instanceNumber), "-clp",
+                Integer.toString(CLUSTER_STARTING_PORT + instanceNumber), "-cwd", tmpFolder));
+        paramsList.addAll(List.of(args));
+        var processBuilder = new ProcessBuilder(paramsList);
+        processBuilder.redirectErrorStream(true);
+        Process process = processBuilder.start();
+        LOGGER.info("started process " + process.pid());
+        new Thread(() -> {
+            try {
+                try (BufferedReader output =
+                        new BufferedReader(new InputStreamReader(process.getInputStream(), UTF_8))) {
+
+                    processes.put(process, sb);
+                    while (process.isAlive()) {
+                        sb.append((char) output.read());
+                    }
+                    sb.append("exit code ").append(process.exitValue());
+                }
+            } catch (IOException e) {
+                LOGGER.error(e);
+            }
+        }).start();
+
+        return Pair.of(process, sb);
+    }
+
+    public static Path getWorkDirPath(int instanceNumber) {
+        return Path.of(workDir + '/' + instanceNumber);
+    }
+}

--- a/src/test/java/io/neonbee/cluster/SharedEntityModelManagerTest.java
+++ b/src/test/java/io/neonbee/cluster/SharedEntityModelManagerTest.java
@@ -1,0 +1,94 @@
+package io.neonbee.cluster;
+
+import static io.neonbee.internal.verticle.DeployerVerticleTest.MODEL_FOLDER;
+import static io.neonbee.internal.verticle.DeployerVerticleTest.getModelsToDeploy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import com.sap.cds.impl.util.Pair;
+
+import io.neonbee.internal.verticle.DeployerVerticleTest;
+import io.neonbee.logging.LoggingFacade;
+import io.neonbee.test.helper.WorkingDirectoryBuilder;
+
+/**
+ * creates 2 neonbee nodes in cluster, deploys one module with dummy verticle and 2 entity models
+ */
+@Isolated("")
+public class SharedEntityModelManagerTest {
+
+    private static final LoggingFacade LOGGER = LoggingFacade.create();
+
+    private NeonbeeClusterRunner clusterRunner;
+
+    private Class<?> verticleCls = SharedEntityModelVerticle.class;
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        NeonbeeClusterRunner.init();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        NeonbeeClusterRunner.cleanUp();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        clusterRunner = new NeonbeeClusterRunner();
+    }
+
+    @Test
+    void run() throws IOException, InterruptedException {
+        List<Pair<Process, StringBuilder>> processInfos = new ArrayList<>(3);
+        for (int i = 0; i < 2; i++) {
+            processInfos.add(clusterRunner.startProcess(i));
+        }
+
+        Thread.sleep(30 * 1000);
+        /**
+         * assert that every instance of neonbee hasn't obtained the model
+         */
+        for (Pair<Process, StringBuilder> processInfo : processInfos) {
+            assertFalse(Arrays.stream(processInfo.right.toString().split("\n"))
+                    .anyMatch(s -> s.contains("obtainedChanges: ") && s.contains("io.neonbee.test2")));
+        }
+
+        // deploy test verticle with model to the first neonbee instance
+        String fileSimpleName = verticleCls.getSimpleName() + ".jar";
+        Path workDir = NeonbeeClusterRunner.getWorkDirPath(0);
+        Path module = workDir.resolve(WorkingDirectoryBuilder.MODULES_DIR);
+        File moduleDir = module.toFile();
+        moduleDir.mkdirs();
+        FileUtils.copyFile(DeployerVerticleTest.createJarFile(verticleCls, getModelsToDeploy(MODEL_FOLDER)),
+                new File(moduleDir + "/" + fileSimpleName));
+
+        Thread.sleep(150_000);
+
+        processInfos.forEach(pi -> LOGGER.info("process output " + pi.left.pid() + "\n" + pi.right));
+        /**
+         * assert that every instance of neonbee obtained the model
+         */
+        for (Pair<Process, StringBuilder> processInfo : processInfos) {
+            assertTrue(Arrays.stream(processInfo.right.toString().split("\n"))
+                    .anyMatch(s -> s.contains("obtainedChanges: ") && s.contains("io.neonbee.test2")));
+        }
+
+    }
+
+    @AfterEach
+    void afterEach() {
+        clusterRunner.clean();
+    }
+}

--- a/src/test/java/io/neonbee/cluster/SharedEntityModelVerticle.java
+++ b/src/test/java/io/neonbee/cluster/SharedEntityModelVerticle.java
@@ -1,0 +1,42 @@
+package io.neonbee.cluster;
+
+import static io.neonbee.cluster.NeonbeeClusterRunner.STARTING_PORT;
+
+import java.util.Map;
+
+import io.neonbee.NeonBee;
+import io.neonbee.entity.EntityModel;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+
+/**
+ * verticle that can be used to do something special on one of the instances of neonbee cluster. As for now no
+ * functionality implemented here.
+ */
+public class SharedEntityModelVerticle extends AbstractVerticle {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SharedEntityModelVerticle.class);
+
+    @Override
+    public void start() {
+        LOGGER.info("starting verticle on the instance with port " + NeonBee.get().getOptions().getServerPort());
+        if (isFirstInstance()) {
+            vertx.setTimer(1000, id -> {
+                Map<String, EntityModel> models = NeonBee.get(vertx).getModelManager().getBufferedModels();
+                LOGGER.info("buffered models: " + models);
+            });
+        } else {
+            vertx.setTimer(4 * 60000, id -> {
+                LOGGER.info("from not first instance");
+            });
+        }
+
+    }
+
+    boolean isFirstInstance() {
+        Integer port = NeonBee.get().getOptions().getServerPort();
+        return STARTING_PORT == port || port > STARTING_PORT + 10;
+    }
+
+}

--- a/src/test/java/io/neonbee/internal/deploy/DeployableModelsTest.java
+++ b/src/test/java/io/neonbee/internal/deploy/DeployableModelsTest.java
@@ -123,7 +123,7 @@ class DeployableModelsTest {
 
         EntityModelDefinition definition = deployable.result().modelDefinition;
         assertThat(definition.getCSNModelDefinitions().keySet()).containsExactly("entry");
-        assertThat(definition.getAssociatedModelDefinitions().keySet()).containsExactly("entry");
+        assertThat(definition.getAssociatedData().keySet()).containsExactly("entry");
     }
 
     @Test
@@ -135,7 +135,7 @@ class DeployableModelsTest {
         assertThat(deployable.result().modelDefinition.getCSNModelDefinitions())
                 .comparingValuesUsing(Correspondence.<byte[], byte[]>from(Arrays::equals, "is not equal to"))
                 .containsExactlyEntriesIn(NeonBeeModuleJar.DUMMY_MODELS);
-        assertThat(deployable.result().modelDefinition.getAssociatedModelDefinitions())
+        assertThat(deployable.result().modelDefinition.getAssociatedData())
                 .comparingValuesUsing(Correspondence.<byte[], byte[]>from(Arrays::equals, "is not equal to"))
                 .containsExactlyEntriesIn(NeonBeeModuleJar.DUMMY_EXTENSION_MODELS);
     }

--- a/src/test/java/io/neonbee/internal/deploy/DeployableModuleTest.java
+++ b/src/test/java/io/neonbee/internal/deploy/DeployableModuleTest.java
@@ -108,7 +108,7 @@ class DeployableModuleTest {
         assertThat(deployableModels.get(0).modelDefinition.getCSNModelDefinitions())
                 .comparingValuesUsing(Correspondence.<byte[], byte[]>from(Arrays::equals, "is not equal to"))
                 .containsExactlyEntriesIn(NeonBeeModuleJar.DUMMY_MODELS);
-        assertThat(deployableModels.get(0).modelDefinition.getAssociatedModelDefinitions())
+        assertThat(deployableModels.get(0).modelDefinition.getAssociatedData())
                 .comparingValuesUsing(Correspondence.<byte[], byte[]>from(Arrays::equals, "is not equal to"))
                 .containsExactlyEntriesIn(NeonBeeModuleJar.DUMMY_EXTENSION_MODELS);
         assertThat(deployables.stream().filter(DeployableVerticle.class::isInstance).map(DeployableVerticle.class::cast)
@@ -141,7 +141,7 @@ class DeployableModuleTest {
         assertThat(deployableModels.get(0).modelDefinition.getCSNModelDefinitions())
                 .comparingValuesUsing(Correspondence.<byte[], byte[]>from(Arrays::equals, "is not equal to"))
                 .containsExactlyEntriesIn(NeonBeeModuleJar.DUMMY_MODELS);
-        assertThat(deployableModels.get(0).modelDefinition.getAssociatedModelDefinitions())
+        assertThat(deployableModels.get(0).modelDefinition.getAssociatedData())
                 .comparingValuesUsing(Correspondence.<byte[], byte[]>from(Arrays::equals, "is not equal to"))
                 .containsExactlyEntriesIn(NeonBeeModuleJar.DUMMY_EXTENSION_MODELS);
         assertThat(deployables.stream().filter(DeployableVerticle.class::isInstance)).isEmpty();

--- a/src/test/java/io/neonbee/internal/verticle/DeployerVerticleTest.java
+++ b/src/test/java/io/neonbee/internal/verticle/DeployerVerticleTest.java
@@ -1,6 +1,41 @@
 package io.neonbee.internal.verticle;
 
-public class DeployerVerticleTest {
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import io.neonbee.NeonBee;
+import io.neonbee.NeonBeeOptions;
+import io.neonbee.cluster.SharedEntityModelVerticle;
+import io.neonbee.entity.EntityModel;
+import io.neonbee.test.base.NeonBeeTestBase;
+import io.neonbee.test.helper.WorkingDirectoryBuilder;
+import io.vertx.core.impl.VertxImpl;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+
+public class DeployerVerticleTest extends NeonBeeTestBase {
 
     // 1. Override DeployerVerticle to be able to catch events and futures
     // 2. Create NeonBeeModule and copy it into verticle folder
@@ -12,4 +47,127 @@ public class DeployerVerticleTest {
     // 5. Delete the NeonBeeModule from verticle directory
     // 6. check if modelsTempDir is deleted
     // 7. check if verticle are undeployed.
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeployerVerticleTest.class);
+
+    private final Class<?> verticleCls = SharedEntityModelVerticle.class;
+
+    public static final String RESOURCES_FOLDER = "build/resources/test/";
+
+    public static final String MODEL_SOURCES_PATH = "io/neonbee/entity";
+
+    public static final String MODEL_FOLDER = RESOURCES_FOLDER + MODEL_SOURCES_PATH;
+
+    @Override
+    protected void adaptOptions(TestInfo testInfo, NeonBeeOptions.Mutable options) {
+        options.setDoNotWatchFiles(false);
+    }
+
+    @BeforeEach
+    @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+    @SuppressWarnings("ReferenceEquality")
+    public void beforeEach(VertxTestContext testContext) throws Exception {
+
+        String fileSimpleName = verticleCls.getSimpleName() + ".jar";
+        Path workDir = getNeonBee().getOptions().getWorkingDirectory();
+        Path module = workDir.resolve(WorkingDirectoryBuilder.MODULES_DIR);
+        File moduleDir = module.toFile();
+        moduleDir.mkdirs();
+        FileUtils.copyFile(createJarFile(verticleCls, getModelsToDeploy(MODEL_FOLDER)),
+                new File(moduleDir + "/" + fileSimpleName));
+
+        testContext.completeNow();
+    }
+
+    @Test
+    @Timeout(value = 50, timeUnit = TimeUnit.SECONDS)
+    void deploy(VertxTestContext testContext) {
+        final long start = System.currentTimeMillis();
+        var vertx = (VertxImpl) getNeonBee().getVertx();
+        vertx.setPeriodic(3000, timerId -> {
+
+            Set<String> verticles = new HashSet<>();
+
+            vertx.deploymentIDs().forEach(id -> {
+                var verticleClsNames = vertx.getDeployment(id).getVerticles().stream()
+                        .map(v -> v.getClass().getSimpleName()).collect(Collectors.toSet());
+                LOGGER.info("deployed verticles " + verticleClsNames);
+                verticles.addAll(verticleClsNames);
+
+            });
+
+            Map<String, EntityModel> models = NeonBee.get().getModelManager().getBufferedModels();
+            if (models != null) {
+                LOGGER.info("entity models: "
+                        + models.entrySet().stream().map(e -> e.getKey()).collect(Collectors.joining(", ")));
+            }
+
+            if (verticles.contains(verticleCls.getSimpleName()) && models.containsKey("io.neonbee.test1")) {
+                vertx.cancelTimer(timerId);
+                testContext.completeNow();
+            } else if (System.currentTimeMillis() - start > 30000) {
+                testContext.failNow("verticle " + verticleCls.getSimpleName() + " or model were not deployed ");
+                vertx.cancelTimer(timerId);
+            }
+
+        });
+    }
+
+    public static File createJarFile(Class<?> verticleCls, List<File> models) throws IOException {
+
+        String fileSimpleName = verticleCls.getSimpleName() + ".jar";
+        File jarFile = new File(("build/" + fileSimpleName));
+        jarFile.delete();
+        var manifest = new Manifest();
+        manifest.getMainAttributes().put(new Attributes.Name("NeonBee-Module"), verticleCls.getSimpleName());
+        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        manifest.getMainAttributes().put(new Attributes.Name("NeonBee-Deployables"), verticleCls.getName());
+        StringBuilder modelsAttributeValue = new StringBuilder();
+        StringBuilder modelsExtensionsAttributeValue = new StringBuilder();
+        models.forEach(model -> {
+            if (model.getName().endsWith("csn") || model.getName().endsWith("cds")) {
+                if (modelsAttributeValue.length() > 0) {
+                    modelsAttributeValue.append(';');
+                }
+                modelsAttributeValue.append(model.getPath().substring(RESOURCES_FOLDER.length()));
+            } else if (model.getName().endsWith("edmx")) {
+                if (modelsExtensionsAttributeValue.length() > 0) {
+                    modelsExtensionsAttributeValue.append(';');
+                }
+                modelsExtensionsAttributeValue.append(model.getPath().substring(RESOURCES_FOLDER.length()));
+            }
+        });
+
+        manifest.getMainAttributes().put(new Attributes.Name("NeonBee-Models"), modelsAttributeValue.toString());
+        manifest.getMainAttributes().put(new Attributes.Name("NeonBee-Model-Extensions"),
+                modelsExtensionsAttributeValue.toString());
+
+        JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarFile), manifest);
+
+        JarEntry clsEntry = new JarEntry(verticleCls.getName() + ".class");
+        jos.putNextEntry(clsEntry);
+        jos.write(FileUtils.readFileToByteArray(
+                new File("build/classes/java/test/" + verticleCls.getName().replace('.', '/') + ".class")));
+        models.forEach(model -> {
+            try {
+                jos.putNextEntry(new JarEntry(model.getPath().substring(RESOURCES_FOLDER.length())));
+                jos.write(FileUtils.readFileToByteArray(model));
+            } catch (IOException e) {
+                LOGGER.error(e);
+            }
+        });
+        jos.closeEntry();
+        jos.finish();
+        jos.flush();
+        jos.close();
+        return jarFile;
+    }
+
+    public static List<File> getModelsToDeploy(String folder) {
+        List<String> extensions = List.of("edmx", "csn");
+        File folderAsFile = new File(folder);
+        return Arrays.asList(Objects.requireNonNull(
+                folderAsFile.listFiles(file -> extensions.contains(FilenameUtils.getExtension(file.getName())))));
+    }
+
 }


### PR DESCRIPTION
Every node pushes its entity model definitions in shared memory and is able to reload them from shared memory. 