### PR TITLE
feat: use Vert.x FakeClusterManager in NeonBeeExtension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ dependencies {
     annotationProcessor group: 'io.vertx', name: 'vertx-codegen', classifier: 'processor', version: vertx_version
 
     // Framework test dependencies
+    testImplementation group: 'io.vertx', name: 'vertx-core', classifier: 'tests', version: vertx_version
     testImplementation group: 'io.vertx', name: 'vertx-junit5', version: vertx_version
 
     def truth_version = '1.1.3'
@@ -108,6 +109,9 @@ dependencies {
     // Gradle plugin dependencies
     errorprone group: 'com.google.errorprone', name: 'error_prone_core', version: '2.10.0'
     checkstyle group: 'com.puppycrawl.tools', name: 'checkstyle', version: '9.2'
+
+    // Without this the IDE can't find the test source files which are needed for debugging
+    testCompileOnly group: 'io.vertx', name: 'vertx-core', classifier: 'test-sources', version: vertx_version
 }
 
 // we need to define the generated source set first, because it is needed by staticCodeCheck

--- a/src/main/java/io/neonbee/NeonBeeOptions.java
+++ b/src/main/java/io/neonbee/NeonBeeOptions.java
@@ -17,8 +17,6 @@ import java.util.stream.Collectors;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import com.hazelcast.config.ClasspathXmlConfig;
-import com.hazelcast.config.Config;
 
 import io.neonbee.internal.helper.FileSystemHelper;
 import io.neonbee.internal.verticle.WatchVerticle;
@@ -155,7 +153,7 @@ public interface NeonBeeOptions {
      *
      * @return Hazelcast cluster configuration
      */
-    Config getClusterConfig();
+    String getClusterConfig();
 
     /**
      * Get the port number of the server verticle. If not set, the port number will be retrieved from the server
@@ -205,7 +203,7 @@ public interface NeonBeeOptions {
 
         private boolean clustered;
 
-        private Config clusterConfig;
+        private String clusterConfig = DEFAULT_CLUSTER_CONFIG;
 
         private String instanceName;
 
@@ -412,34 +410,21 @@ public interface NeonBeeOptions {
         }
 
         @Override
-        public Config getClusterConfig() {
-            if (clusterConfig == null) {
-                setClusterConfigResource(DEFAULT_CLUSTER_CONFIG);
-            }
+        public String getClusterConfig() {
             return clusterConfig;
-        }
-
-        /**
-         * Set the cluster config.
-         *
-         * @param config the cluster config
-         * @return this instance for chaining
-         */
-        public Mutable setClusterConfig(Config config) {
-            this.clusterConfig = config;
-            return this;
         }
 
         /**
          * Set a cluster config by loading a resource from the class path (blocking).
          *
-         * @param resource the resource, an XML configuration file from the class path
+         * @param clusterConfig the resource, an XML configuration file from the class path
          * @return this instance for chaining
          */
         @Option(longName = "cluster-config", shortName = "cc")
-        @Description("Set the cluster/Hazelast configuration file path")
-        public Mutable setClusterConfigResource(String resource) {
-            return setClusterConfig(new ClasspathXmlConfig(resource));
+        @Description("Set the cluster configuration file path")
+        public Mutable setClusterConfig(String clusterConfig) {
+            this.clusterConfig = clusterConfig;
+            return this;
         }
 
         @Override

--- a/src/test/java/io/neonbee/LauncherTest.java
+++ b/src/test/java/io/neonbee/LauncherTest.java
@@ -28,8 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 import org.mockito.MockedStatic;
 
-import com.hazelcast.config.ClasspathXmlConfig;
-
 import io.neonbee.Launcher.EnvironmentAwareCommandLine;
 import io.neonbee.config.NeonBeeConfig;
 import io.neonbee.test.helper.FileSystemHelper;
@@ -228,10 +226,7 @@ class LauncherTest {
         NeonBeeOptions neonBeeOptions = parseArgs();
         assertThat(neonBeeOptions.getClusterPort()).isEqualTo(10000);
         assertThat(neonBeeOptions.isClustered()).isTrue();
-        assertThat(neonBeeOptions.getClusterConfig()).isInstanceOf(ClasspathXmlConfig.class);
-
-        ClasspathXmlConfig xmlConfig = (ClasspathXmlConfig) neonBeeOptions.getClusterConfig();
-        assertThat(xmlConfig.getNetworkConfig().getPort()).isEqualTo(20000);
+        assertThat(neonBeeOptions.getClusterConfig()).isEqualTo("hazelcast-local.xml");
     }
 
     private NeonBeeOptions parseArgs() {

--- a/src/test/java/io/neonbee/NeonBeeExtensionBasedTest.java
+++ b/src/test/java/io/neonbee/NeonBeeExtensionBasedTest.java
@@ -7,24 +7,25 @@ import static io.neonbee.NeonBeeProfile.STABLE;
 import static io.neonbee.NeonBeeProfile.WEB;
 import static io.vertx.core.Future.succeededFuture;
 
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.hazelcast.core.Hazelcast;
-
 import io.neonbee.data.DataContext;
 import io.neonbee.data.DataMap;
 import io.neonbee.data.DataQuery;
 import io.neonbee.data.DataVerticle;
 import io.neonbee.test.helper.DeploymentHelper;
+import io.neonbee.test.helper.ReflectionHelper;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
+import io.vertx.test.fakecluster.FakeClusterManager;
 
 @ExtendWith(NeonBeeExtension.class)
 class NeonBeeExtensionBasedTest {
@@ -80,7 +81,8 @@ class NeonBeeExtensionBasedTest {
     @DisplayName("3 NeonBee instances with WEB, CORE and STABLE profiles should be started and join one cluster.")
     void testNeonBeeWithClusters(@NeonBeeInstanceConfiguration(activeProfiles = WEB, clustered = true) NeonBee web,
             @NeonBeeInstanceConfiguration(activeProfiles = CORE, clustered = true) NeonBee core,
-            @NeonBeeInstanceConfiguration(activeProfiles = STABLE, clustered = true) NeonBee stable) {
+            @NeonBeeInstanceConfiguration(activeProfiles = STABLE, clustered = true) NeonBee stable)
+            throws NoSuchFieldException, IllegalAccessException {
         assertThat(web).isNotNull();
         assertThat(web.getOptions().getActiveProfiles()).contains(WEB);
         assertThat(web.getVertx().isClustered()).isTrue();
@@ -96,7 +98,8 @@ class NeonBeeExtensionBasedTest {
         assertThat(stable.getVertx().isClustered()).isTrue();
         assertThat(isClustered(stable)).isTrue();
 
-        assertThat(Hazelcast.getAllHazelcastInstances().size()).isAtLeast(3);
+        Map<?, ?> nodes = ReflectionHelper.getValueOfPrivateStaticField(FakeClusterManager.class, "nodes");
+        assertThat(nodes.size()).isEqualTo(3);
     }
 
     @NeonBeeDeployable(profile = CORE)

--- a/src/test/java/io/neonbee/NeonBeeMockHelper.java
+++ b/src/test/java/io/neonbee/NeonBeeMockHelper.java
@@ -33,7 +33,7 @@ import io.vertx.core.file.FileSystem;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.micrometer.impl.VertxMetricsFactoryImpl;
-import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
+import io.vertx.test.fakecluster.FakeClusterManager;
 
 public final class NeonBeeMockHelper {
     /**
@@ -193,7 +193,7 @@ public final class NeonBeeMockHelper {
                 new VertxMetricsFactoryImpl().metrics(vertxOptions);
             }
             return succeededFuture(vertx);
-        }, options, null);
+        }, opts -> new FakeClusterManager(), options, null);
     }
 
     /**
@@ -259,6 +259,6 @@ public final class NeonBeeMockHelper {
         } catch (IllegalStateException ignored) {
             // Fall through
         }
-        return new NeonBee(vertx, options, config, new CompositeMeterRegistry(), new HazelcastClusterManager());
+        return new NeonBee(vertx, options, config, new CompositeMeterRegistry());
     }
 }

--- a/src/test/java/io/neonbee/NeonBeeOptionsTest.java
+++ b/src/test/java/io/neonbee/NeonBeeOptionsTest.java
@@ -1,6 +1,7 @@
 package io.neonbee;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.neonbee.NeonBeeOptions.Mutable.DEFAULT_CLUSTER_CONFIG;
 import static io.neonbee.NeonBeeProfile.ALL;
 import static io.neonbee.NeonBeeProfile.CORE;
 import static io.neonbee.NeonBeeProfile.WEB;
@@ -16,8 +17,6 @@ import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import com.hazelcast.config.Config;
 
 import io.neonbee.NeonBeeOptions.Mutable;
 import io.neonbee.test.helper.FileSystemHelper;
@@ -170,15 +169,13 @@ class NeonBeeOptionsTest {
     @DisplayName("Test clusterConfig getter and setter")
     void testClusterConfig() {
         Mutable mutable = new NeonBeeOptions.Mutable();
-        Config defaultConfig = mutable.getClusterConfig();
-        assertThat(defaultConfig.getNetworkConfig().getPort()).isEqualTo(50000);
+        assertThat(mutable.getClusterConfig()).isEqualTo(DEFAULT_CLUSTER_CONFIG);
 
-        mutable.setClusterConfigResource("hazelcast-local.xml");
-        Config localConfig = mutable.getClusterConfig();
-        assertThat(localConfig.getNetworkConfig().getPort()).isEqualTo(20000);
+        mutable.setClusterConfig("hazelcast-local.xml");
+        assertThat(mutable.getClusterConfig()).isEqualTo("hazelcast-local.xml");
 
-        mutable = new NeonBeeOptions.Mutable().setClusterConfig(localConfig);
-        assertThat(mutable.getClusterConfig().getNetworkConfig().getPort()).isEqualTo(20000);
+        mutable = new NeonBeeOptions.Mutable().setClusterConfig("hazelcast-local.xml");
+        assertThat(mutable.getClusterConfig()).isEqualTo("hazelcast-local.xml");
     }
 
     @Test

--- a/src/test/java/io/neonbee/test/helper/OptionsHelper.java
+++ b/src/test/java/io/neonbee/test/helper/OptionsHelper.java
@@ -53,7 +53,7 @@ public final class OptionsHelper {
         NeonBeeOptions.Mutable options = new NeonBeeOptions.Mutable();
 
         options.setActiveProfiles(Arrays.<NeonBeeProfile>asList(config.activeProfiles()))
-                .setClusterConfigResource(config.clusterConfigFile()).setClustered(config.clustered())
+                .setClusterConfig(config.clusterConfigFile()).setClustered(config.clustered())
                 .setClusterPort(config.clusterPort()).setDisableJobScheduling(config.disableJobScheduling())
                 .setDoNotWatchFiles(config.doNotWatchFiles()).setEventLoopPoolSize(config.eventLoopPoolSize())
                 .setIgnoreClassPath(config.ignoreClassPath()).setServerPort(port)


### PR DESCRIPTION
Tests based on NeonBeeExtension are very slow, because NeonBeeExtension always constructs a real
Hazelcast cluster. With this change NeonBeeExtension will use the Vert.x FakeClusterManager which
speed up these tests dramatically.