### PR TITLE
feat: make test cluster manager configurable.

### DIFF
--- a/src/test/java/io/neonbee/NeonBeeInstanceConfiguration.java
+++ b/src/test/java/io/neonbee/NeonBeeInstanceConfiguration.java
@@ -8,6 +8,9 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.function.Function;
+
+import io.vertx.test.fakecluster.FakeClusterManager;
 
 /**
  * An annotation to pass NeonBee configuration to the NeonBee instance required for testing.
@@ -39,4 +42,27 @@ public @interface NeonBeeInstanceConfiguration {
     boolean disableJobScheduling() default true;
 
     NeonBeeProfile[] activeProfiles() default { ALL };
+
+    ClusterManager clusterManager() default ClusterManager.FAKE;
+
+    enum ClusterManager {
+        FAKE {
+            @Override
+            Function<NeonBeeOptions, io.vertx.core.spi.cluster.ClusterManager> factory() {
+                return (opts) -> new FakeClusterManager();
+            }
+        },
+
+        HAZELCAST {
+            @Override
+            Function<NeonBeeOptions, io.vertx.core.spi.cluster.ClusterManager> factory() {
+                return NeonBee.HAZELCAST_FACTORY;
+            }
+        };
+
+        /**
+         * @return factory for creating the {@link io.vertx.core.spi.cluster.ClusterManager}
+         */
+        abstract Function<NeonBeeOptions, io.vertx.core.spi.cluster.ClusterManager> factory();
+    }
 }


### PR DESCRIPTION
This change allows to choose the ClusterManager that will be used for the test execution. The default is the vert.x FakeClusterManager. You can choose other ClusterManagers by setting the testClusterManager value in the NeonBeeInstanceConfiguration annotation.