### PR TITLE
fix: make SystemClassLoader available to Infinispan

### DIFF
--- a/src/main/java/io/neonbee/cluster/ClusterManagerFactory.java
+++ b/src/main/java/io/neonbee/cluster/ClusterManagerFactory.java
@@ -3,6 +3,7 @@ package io.neonbee.cluster;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
+import static java.lang.ClassLoader.getSystemClassLoader;
 
 import java.io.IOException;
 
@@ -48,6 +49,7 @@ public abstract class ClusterManagerFactory {
             String effectiveConfig = getEffectiveConfig(neonBeeOptions);
 
             try {
+                Thread.currentThread().setContextClassLoader(getSystemClassLoader());
                 return succeededFuture(new InfinispanClusterManager(new DefaultCacheManager(effectiveConfig, true)));
             } catch (IOException e) {
                 return failedFuture(e);


### PR DESCRIPTION
When Infinispan is initialized it is using the ContextClassLoader of the current Thread to resolve resources. The ContextClassLoader of a Vert.x event loop is initially null, which causes Infinispan to fail.