### PR TITLE
fix: pass SystemClassLoader to cluster manager configuration

### DIFF
--- a/src/main/java/io/neonbee/cluster/ClusterManagerFactory.java
+++ b/src/main/java/io/neonbee/cluster/ClusterManagerFactory.java
@@ -31,7 +31,8 @@ public abstract class ClusterManagerFactory {
         @Override
         public Future<ClusterManager> create(NeonBeeOptions neonBeeOptions) {
             String effectiveConfig = getEffectiveConfig(neonBeeOptions);
-            return succeededFuture(new HazelcastClusterManager(new ClasspathXmlConfig(effectiveConfig)));
+            return succeededFuture(new HazelcastClusterManager(
+                    new ClasspathXmlConfig(getSystemClassLoader(), effectiveConfig, System.getProperties())));
         }
     };
 


### PR DESCRIPTION
When NeonBee is stated in clustered mode with Hazelcast as cluster manager, an IllegalArgumentException, "classLoader can't be null" is thrown.