### PR TITLE
ci: fix tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,8 +201,7 @@ test {
     // Is required for ReflectionsHelper
     jvmArgs += ['--add-opens', 'java.base/java.lang.reflect=ALL-UNNAMED']
 
-    // deactivate parallel execution of tests temporary until parallel execution works again
-    if (false && !org.gradle.nativeplatform.platform.internal.DefaultNativePlatform.getCurrentOperatingSystem().isMacOsX()) {
+    if (!org.gradle.nativeplatform.platform.internal.DefaultNativePlatform.getCurrentOperatingSystem().isMacOsX()) {
         systemProperties = [
             'junit.jupiter.execution.parallel.enabled' : 'true',
             'junit.jupiter.execution.parallel.mode.default' : 'concurrent',

--- a/src/main/java/io/neonbee/NeonBee.java
+++ b/src/main/java/io/neonbee/NeonBee.java
@@ -256,13 +256,8 @@ public class NeonBee {
         vertxOptions.setMetricsOptions(new MicrometerMetricsOptions().setRegistryName(options.getMetricsRegistryName())
                 .setMicrometerRegistry(compositeMeterRegistry).setEnabled(true));
 
-        Future<VertxOptions> loadClusterManager = Future.future(p -> {
-            if (options.isClustered()) {
-                p.handle(clusterManagerFactory.create(options).map(vertxOptions::setClusterManager));
-            } else {
-                p.complete(vertxOptions);
-            }
-        });
+        Future<VertxOptions> loadClusterManager = !options.isClustered() ? succeededFuture(vertxOptions)
+                : clusterManagerFactory.create(options).map(vertxOptions::setClusterManager);
 
         // create a Vert.x instance (clustered or unclustered)
         return loadClusterManager.compose(vertxFactory).compose(vertx -> {
@@ -284,16 +279,17 @@ public class NeonBee {
             };
 
             try {
-                Future<NeonBeeConfig> neonBeeConfigFuture;
+                Future<NeonBeeConfig> configFuture;
                 if (config == null) {
-                    neonBeeConfigFuture = loadConfig(vertx, options.getConfigDirectory());
+                    configFuture = loadConfig(vertx, options.getConfigDirectory());
                 } else {
-                    neonBeeConfigFuture = succeededFuture(config);
+                    configFuture = succeededFuture(config);
                 }
 
-                Future<NeonBee> neonBeeFuture = neonBeeConfigFuture
-                        // create a NeonBee instance, hook registry and close handler
-                        .map(c -> new NeonBee(vertx, options, c, compositeMeterRegistry));
+                // create a NeonBee instance, hook registry and close handler
+                Future<NeonBee> neonBeeFuture = configFuture.map(loadedConfig -> {
+                    return new NeonBee(vertx, options, loadedConfig, compositeMeterRegistry);
+                });
                 // boot NeonBee, on failure close Vert.x
                 return neonBeeFuture.compose(NeonBee::boot).recover(closeVertx).compose(unused -> neonBeeFuture);
             } catch (Throwable t) {

--- a/src/test/java/io/neonbee/NeonBeeExtensionBasedTest.java
+++ b/src/test/java/io/neonbee/NeonBeeExtensionBasedTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import io.neonbee.data.DataContext;
 import io.neonbee.data.DataMap;
@@ -28,6 +29,7 @@ import io.vertx.junit5.VertxTestContext;
 import io.vertx.test.fakecluster.FakeClusterManager;
 
 @ExtendWith(NeonBeeExtension.class)
+@Isolated("Some of the methods in this test class run clustered and use the FakeClusterManager for it. The FakeClusterManager uses a static state and can therefore not be run with other clustered tests.")
 class NeonBeeExtensionBasedTest {
     @Test
     @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)

--- a/src/test/java/io/neonbee/cluster/ClusterManagerFactoryTest.java
+++ b/src/test/java/io/neonbee/cluster/ClusterManagerFactoryTest.java
@@ -4,9 +4,11 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.neonbee.cluster.ClusterManagerFactory.HAZELCAST_FACTORY;
 import static io.neonbee.cluster.ClusterManagerFactory.INFINISPAN_FACTORY;
 
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import org.infinispan.manager.DefaultCacheManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +19,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import io.neonbee.NeonBeeOptions;
 import io.neonbee.NeonBeeOptions.Mutable;
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.ext.cluster.infinispan.InfinispanClusterManager;
 import io.vertx.junit5.Timeout;
@@ -63,13 +66,21 @@ class ClusterManagerFactoryTest {
     @ParameterizedTest(name = "{index}: for {2}")
     @MethodSource("withClusterManagers")
     @DisplayName("Test ClusterManagerFactory")
-    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
-    void testDefaultFactories(ClusterManagerFactory cmf, String defaultConfig, Class clusterManagerImpl,
+    @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+    void testDefaultFactories(ClusterManagerFactory cmf, String defaultConfig, Class clusterManagerImpl, Vertx vertx,
             VertxTestContext testContext) {
         assertThat(cmf.getDefaultConfig()).isEqualTo(defaultConfig);
 
         cmf.create(new Mutable()).onComplete(testContext.succeeding(cm -> {
             testContext.verify(() -> assertThat(cm).isInstanceOf(clusterManagerImpl));
+            // the INFINISPAN_FACTORY creates a DefaultCacheManager, which creates Threads that we have to stop!
+            if (cm instanceof InfinispanClusterManager) {
+                try {
+                    ((DefaultCacheManager) ((InfinispanClusterManager) cm).getCacheContainer()).close();
+                } catch (IOException e) {
+                    testContext.failNow(e);
+                }
+            }
             testContext.completeNow();
         }));
     }

--- a/src/test/java/io/neonbee/cluster/DataExceptionRequestTest.java
+++ b/src/test/java/io/neonbee/cluster/DataExceptionRequestTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import io.neonbee.NeonBee;
 import io.neonbee.NeonBeeExtension;
@@ -29,6 +30,7 @@ import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(NeonBeeExtension.class)
+@Isolated("Some of the methods in this test class run clustered and use the FakeClusterManager for it. The FakeClusterManager uses a static state and can therefore not be run with other clustered tests.")
 class DataExceptionRequestTest {
     private static final JsonObject FAILURE_OBJECT = new JsonObject().put("code", new JsonArray()
             .add(new JsonObject().put("message", "This is a bad response")).add(new JsonObject().put("lang", "en")));
@@ -72,7 +74,7 @@ class DataExceptionRequestTest {
     };
 
     @Test
-    @Timeout(value = 10, timeUnit = TimeUnit.HOURS)
+    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Test that DataException can be returned via the event bus")
     void testDataExceptionRequest(@NeonBeeInstanceConfiguration(clustered = true, activeProfiles = {}) NeonBee source,
             @NeonBeeInstanceConfiguration(clustered = true, activeProfiles = {}) NeonBee target,

--- a/src/test/java/io/neonbee/cluster/LocalPreferredClusterTest.java
+++ b/src/test/java/io/neonbee/cluster/LocalPreferredClusterTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import com.google.common.collect.Range;
 
@@ -33,6 +34,7 @@ import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(NeonBeeExtension.class)
+@Isolated("Some of the methods in this test class run clustered and use the FakeClusterManager for it. The FakeClusterManager uses a static state and can therefore not be run with other clustered tests.")
 class LocalPreferredClusterTest {
     private static final String LOCAL = "local";
 

--- a/src/test/java/io/neonbee/cluster/LocalRequestClusterTest.java
+++ b/src/test/java/io/neonbee/cluster/LocalRequestClusterTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import io.neonbee.NeonBee;
 import io.neonbee.NeonBeeExtension;
@@ -26,6 +27,7 @@ import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(NeonBeeExtension.class)
+@Isolated("Some of the methods in this test class run clustered and use the FakeClusterManager for it. The FakeClusterManager uses a static state and can therefore not be run with other clustered tests.")
 class LocalRequestClusterTest {
     private static final DataVerticle<JsonObject> LOCAL_TARGET_VERTICLE = new DataVerticle<>() {
         @Override

--- a/src/test/java/io/neonbee/cluster/TrackingInterceptorClusterTest.java
+++ b/src/test/java/io/neonbee/cluster/TrackingInterceptorClusterTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -34,6 +35,7 @@ import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith({ NeonBeeExtension.class, MockitoExtension.class })
+@Isolated("Some of the methods in this test class run clustered and use the FakeClusterManager for it. The FakeClusterManager uses a static state and can therefore not be run with other clustered tests.")
 class TrackingInterceptorClusterTest {
 
     @Mock

--- a/src/test/java/io/neonbee/health/HealthCheckRegistryTest.java
+++ b/src/test/java/io/neonbee/health/HealthCheckRegistryTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import io.neonbee.NeonBee;
 import io.neonbee.NeonBeeMockHelper;
@@ -47,6 +48,7 @@ import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(VertxExtension.class)
+@Isolated("Some of the methods in this test class run clustered and use the FakeClusterManager for it. The FakeClusterManager uses a static state and can therefore not be run with other clustered tests.")
 class HealthCheckRegistryTest {
     private static final long RETENTION_TIME = 12L;
 

--- a/src/test/java/io/neonbee/internal/logging/LoggerManagerVerticleClusterTest.java
+++ b/src/test/java/io/neonbee/internal/logging/LoggerManagerVerticleClusterTest.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import ch.qos.logback.classic.Level;
 import io.neonbee.NeonBee;
@@ -35,6 +36,7 @@ import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
 @ExtendWith(NeonBeeExtension.class)
+@Isolated("Some of the methods in this test class run clustered and use the FakeClusterManager for it. The FakeClusterManager uses a static state and can therefore not be run with other clustered tests.")
 class LoggerManagerVerticleClusterTest {
 
     private final DataContext dataContext = new DataContextImpl();

--- a/src/test/java/io/neonbee/internal/verticle/HealthCheckVerticleTest.java
+++ b/src/test/java/io/neonbee/internal/verticle/HealthCheckVerticleTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import io.neonbee.NeonBee;
 import io.neonbee.NeonBeeOptions;
@@ -25,6 +26,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
+@Isolated("Some of the methods in this test class run clustered and use the FakeClusterManager for it. The FakeClusterManager uses a static state and can therefore not be run with other clustered tests.")
 class HealthCheckVerticleTest extends DataVerticleTestBase {
     @Override
     protected void adaptOptions(TestInfo testInfo, NeonBeeOptions.Mutable options) {

--- a/src/test/java/io/neonbee/test/base/NeonBeeTestBase.java
+++ b/src/test/java/io/neonbee/test/base/NeonBeeTestBase.java
@@ -79,6 +79,8 @@ import io.vertx.micrometer.backends.BackendRegistries;
 
 @ExtendWith(VertxExtension.class)
 public class NeonBeeTestBase {
+    public static final String DOESNT_REQUIRE_NEONBEE = "NO_NEONBEE";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(NeonBeeTestBase.class);
 
     // create a dummy JsonObject indicating that the provideUserPrincipal method was not overridden. depending on the
@@ -102,6 +104,14 @@ public class NeonBeeTestBase {
         // associate the Vert.x instance to the current test (unfortunately the only "identifier" that is shared between
         // TestInfo and TestIdentifier is the display name)
         StaleVertxChecker.VERTX_TEST_MAP.put(vertx, testInfo.getDisplayName());
+
+        // for some tests, even in a NeonBeeTestBase you might not want to have a NeonBee instance created. use a @Tag
+        // to disable creation of a NeonBee instance for the specific test only
+        if (testInfo.getTags().contains(DOESNT_REQUIRE_NEONBEE)) {
+            neonBee = null; // NOPMD
+            testContext.completeNow();
+            return;
+        }
 
         // build working directory
         workingDirPath = FileSystemHelper.createTempDirectory();
@@ -194,7 +204,12 @@ public class NeonBeeTestBase {
 
     @AfterEach
     @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
-    void tearDown(Vertx vertx, VertxTestContext testContext) throws IOException {
+    void tearDown(Vertx vertx, VertxTestContext testContext, TestInfo testInfo) throws IOException {
+        if (testInfo.getTags().contains(DOESNT_REQUIRE_NEONBEE)) {
+            testContext.completeNow();
+            return;
+        }
+
         // if the metrics registry is still the same random id generated in this test run and was not changed by the
         // adaptOptions method, stop the metrics registry that was (likely) started by NeonBee
         if (randomMetricsRegistryName.equals(neonBee.getOptions().getMetricsRegistryName())) {


### PR DESCRIPTION
- Re-enable parallel test execution (old issues are fixed)
- Better to reset the FakeClusterManager more often than not
- The Infinispan cluster manager must be stopped after tests
- A test with a timeout of over a hour is not good
- Tests that create own Vert.x instances or NeonBee(s) must take care to also shut them down properly, which can be very tricky. Generally it is recommended to use existing test bases or extensios, as they take care to properly shut down the instance(s).
- Tests that use the FakeClusterManager must run isolated
- Test methods that are in a NeonBeeTestBase, but not require NeonBee, can now be tagged with a @tag(DOESNT_REQUIRE_NEONBEE)
- Improve StaleThreadChecker to locate all tests creating stale threads (set VERBOSE = true, disable parallel execution and enable showStandardStreams in build.gradle to run analysis)