### PR TITLE
fix: odata query encoding

### DIFF
--- a/src/main/java/io/neonbee/endpoint/odatav4/ODataV4Endpoint.java
+++ b/src/main/java/io/neonbee/endpoint/odatav4/ODataV4Endpoint.java
@@ -10,8 +10,6 @@ import static io.neonbee.internal.helper.FunctionalHelper.entryFunction;
 import static io.neonbee.internal.helper.StringHelper.EMPTY;
 import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 import static io.vertx.core.Future.succeededFuture;
-import static java.net.URLDecoder.decode;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.Comparator;
 import java.util.List;
@@ -466,7 +464,7 @@ public class ODataV4Endpoint implements Endpoint {
             fullQualifiedName = entityName != null ? schemaNamespace + '.' + entityName : null;
 
             // construct the full request path and URI, the query is provided by the request
-            requestQuery = decode(nullToEmpty(request.query()), UTF_8);
+            requestQuery = nullToEmpty(request.query());
             requestUri = hostUri + (this.requestPath = basePath + schemaNamespace + resourcePath)
                     + (requestQuery.isEmpty() ? EMPTY : "?" + requestQuery);
         }

--- a/src/main/java/io/neonbee/endpoint/odatav4/internal/olingo/processor/ProcessorHelper.java
+++ b/src/main/java/io/neonbee/endpoint/odatav4/internal/olingo/processor/ProcessorHelper.java
@@ -1,6 +1,9 @@
 package io.neonbee.endpoint.odatav4.internal.olingo.processor;
 
+import static com.google.common.base.Strings.nullToEmpty;
 import static io.neonbee.entity.EntityVerticle.requestEntity;
+import static java.net.URLDecoder.decode;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.Optional;
 
@@ -53,7 +56,7 @@ public final class ProcessorHelper {
         // the uriPath without /odata root path and without query path
         String uriPath = "/" + request.getRawServiceResolutionUri() + request.getRawODataPath();
         // the raw query path
-        String rawQueryPath = request.getRawQueryPath();
+        String rawQueryPath = decode(nullToEmpty(request.getRawQueryPath()), UTF_8);
         return new DataQuery(action, uriPath, rawQueryPath, request.getAllHeaders(), body).addHeader("X-HTTP-Method",
                 request.getMethod().name());
     }

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataReadEntitiesTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataReadEntitiesTest.java
@@ -178,4 +178,13 @@ class ODataReadEntitiesTest extends ODataEndpointTestBase {
         assertOData(requestOData(new ODataRequest(looseFQN).setCount()), "6", testContext)
                 .onComplete(testContext.succeedingThenComplete());
     }
+
+    @Test
+    @Timeout(value = 3, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("test query encoding with special characters")
+    void testCountWithFilter(VertxTestContext testContext) {
+        ODataRequest oDataRequest = new ODataRequest(TEST_ENTITY_SET_FQN);
+        oDataRequest.setQuery(Map.of("$filter", "KeyPropertyString eq '你好ä'")).setCount();
+        assertOData(requestOData(oDataRequest), "0", testContext).onComplete(testContext.succeedingThenComplete());
+    }
 }


### PR DESCRIPTION
The OdataRequest RawQueryPath is expected to be in Percent-encoding, but it was decoded.