### PR TITLE
fix: odata query encoding and DataQuery setQuery

### DIFF
--- a/src/main/java/io/neonbee/data/DataQuery.java
+++ b/src/main/java/io/neonbee/data/DataQuery.java
@@ -6,6 +6,9 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toCollection;
 
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -121,9 +124,13 @@ public final class DataQuery { // NOPMD not a "god class"
     /**
      * DataQuery with a URI path and query.
      *
+     * @deprecated This constructor is deprecated because it cannot correctly process query strings that contain the
+     *             '&amp;' or '=' characters in the value. Eg. {@code filter=string eq '&'}
+     *
      * @param uriPath The URI path to request
      * @param query   The (URL decoded) query string
      */
+    @Deprecated
     public DataQuery(String uriPath, String query) {
         this(READ, uriPath, query);
     }
@@ -131,10 +138,14 @@ public final class DataQuery { // NOPMD not a "god class"
     /**
      * DataQuery with a URI path and query.
      *
+     * @deprecated This constructor is deprecated because it cannot correctly process query strings that contain the
+     *             '&amp;' or '=' characters in the value. Eg. {@code filter=string eq '&'}
+     *
      * @param action  The action to perform
      * @param uriPath The URI path to request
      * @param query   The (URL decoded) query string
      */
+    @Deprecated
     public DataQuery(DataAction action, String uriPath, String query) {
         this(action, uriPath, query, (Buffer) null);
     }
@@ -142,11 +153,15 @@ public final class DataQuery { // NOPMD not a "god class"
     /**
      * DataQuery with a URI path and query.
      *
+     * @deprecated This constructor is deprecated because it cannot correctly process query strings that contain the
+     *             '&amp;' or '=' characters in the value. Eg. {@code filter=string eq '&'}
+     *
      * @param action  The action to perform
      * @param uriPath The URI path to request
      * @param query   The (URL decoded) query string
      * @param body    The body of this query
      */
+    @Deprecated
     public DataQuery(DataAction action, String uriPath, String query, Buffer body) {
         this(action, uriPath, query, null, body);
     }
@@ -154,10 +169,14 @@ public final class DataQuery { // NOPMD not a "god class"
     /**
      * DataQuery with a URI path, query and headers.
      *
+     * @deprecated This constructor is deprecated because it cannot correctly process query strings that contain the
+     *             '&amp;' or '=' characters in the value. Eg. {@code filter=string eq '&'}
+     *
      * @param uriPath The URI path to request
      * @param query   The (URL decoded) query string
      * @param headers The headers of this query
      */
+    @Deprecated
     public DataQuery(String uriPath, String query, Map<String, List<String>> headers) {
         this(READ, uriPath, query, headers);
     }
@@ -165,11 +184,15 @@ public final class DataQuery { // NOPMD not a "god class"
     /**
      * DataQuery with a URI path, query and headers.
      *
+     * @deprecated This constructor is deprecated because it cannot correctly process query strings that contain the
+     *             '&amp;' or '=' characters in the value. Eg. {@code filter=string eq '&'}
+     *
      * @param action  The action to perform
      * @param uriPath The URI path to request
      * @param query   The (URL decoded) query string
      * @param headers The headers of this query
      */
+    @Deprecated
     public DataQuery(DataAction action, String uriPath, String query, Map<String, List<String>> headers) {
         this(action, uriPath, query, headers, null);
     }
@@ -177,17 +200,39 @@ public final class DataQuery { // NOPMD not a "god class"
     /**
      * DataQuery with a URI path, query and headers.
      *
+     * @deprecated This constructor is deprecated because it cannot correctly process query strings that contain the
+     *             '&amp;' or '=' characters in the value. Eg. {@code filter=string eq '&'}
+     *
      * @param action  The action to perform
      * @param uriPath The URI path to request
      * @param query   The (URL decoded) query string
      * @param headers The headers of this query
      * @param body    The body of this query
      */
+    @Deprecated
     public DataQuery(DataAction action, String uriPath, String query, Map<String, List<String>> headers, Buffer body) {
         this.action = action;
         this.setUriPath(uriPath); // Calling the setter here, because there is an additional check implemented.
         this.headers = CollectionHelper.mutableCopyOf(headers != null ? headers : Map.of());
         this.parameters = parseQueryString(query);
+        this.body = CollectionHelper.copyOf(body);
+    }
+
+    /**
+     * DataQuery with a URI path, query and headers.
+     *
+     * @param action          The action to perform
+     * @param uriPath         The URI path to request
+     * @param queryParameters The query parameters of this query
+     * @param headers         The headers of this query
+     * @param body            The body of this query
+     */
+    public DataQuery(DataAction action, String uriPath, Map<String, List<String>> queryParameters,
+            Map<String, List<String>> headers, Buffer body) {
+        this.action = action;
+        this.setUriPath(uriPath); // Calling the setter here, because there is an additional check implemented.
+        this.headers = CollectionHelper.mutableCopyOf(headers != null ? headers : Map.of());
+        this.parameters = CollectionHelper.mutableCopyOf(queryParameters != null ? queryParameters : Map.of());
         this.body = CollectionHelper.copyOf(body);
     }
 
@@ -236,13 +281,30 @@ public final class DataQuery { // NOPMD not a "god class"
     }
 
     /**
+     * Returns the parameters of this data query represented as a URL encoded string.
+     *
+     * @return the URL encoded query string
+     */
+    public String getRawQuery() {
+        return getQuery(s -> URLEncoder.encode(s, StandardCharsets.UTF_8).replace("+", "%20"));
+    }
+
+    /**
      * Returns the parameters of this data query represented as a string.
+     *
+     * @deprecated This method is deprecated because it can generate query strings that can no longer be parsed
+     *             correctly. See {@link DataQuery#setQuery}
      *
      * @return the query
      */
+    @Deprecated
     public String getQuery() {
-        Function<String, Stream<String>> paramBuilder =
-                name -> getParameterValues(name).stream().map(value -> String.format("%s=%s", name, value));
+        return getQuery(Function.identity());
+    }
+
+    private String getQuery(Function<String, String> encoder) {
+        Function<String, Stream<String>> paramBuilder = name -> getParameterValues(name).stream()
+                .map(value -> String.format("%s=%s", encoder.apply(name), encoder.apply(value)));
 
         return parameters.keySet().stream().flatMap(paramBuilder).collect(joining("&"));
     }
@@ -250,11 +312,28 @@ public final class DataQuery { // NOPMD not a "god class"
     /**
      * Set the query string. Please note that this will also remove all previously added parameters.
      *
+     * <b>This method is deprecated because it cannot correctly process query strings that contain the '&amp;' or '='
+     * characters in the value.</b><br>
+     * Eg. {@code filter=string eq '&'}
+     *
      * @param query the (URL decoded) query to set
      * @return the DataQuery for chaining
      */
+    @Deprecated
     public DataQuery setQuery(String query) {
         this.parameters = parseQueryString(query);
+        return this;
+    }
+
+    /**
+     * Set the query string. Please note that this will also remove all previously added parameters.
+     *
+     * @param encodedQuery the (URL encoded) query to set
+     * @return the DataQuery for chaining
+     * @throws IllegalArgumentException if the implementation encounters illegal characters
+     */
+    public DataQuery setRawQuery(String encodedQuery) {
+        this.parameters = parseEncodedQueryString(encodedQuery);
         return this;
     }
 
@@ -336,14 +415,40 @@ public final class DataQuery { // NOPMD not a "god class"
         return this;
     }
 
+    /**
+     * Pars the encoded query parameter string.
+     *
+     * @param encodedQuery the encoded query parameter string
+     * @return the query parameter map
+     * @throws IllegalArgumentException if the implementation encounters illegal characters
+     */
+    public static Map<String, List<String>> parseEncodedQueryString(String encodedQuery) {
+        return parseQueryString(encodedQuery, s -> URLDecoder.decode(s, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * This method is deprecated because it cannot correctly process query strings that contain the '&amp;' or '='
+     * characters in the value.<br>
+     * Eg. {@code filter=string eq '&'}
+     *
+     * @param query the decoded query string
+     * @return map with the query
+     */
     @VisibleForTesting
+    @Deprecated
     static Map<String, List<String>> parseQueryString(String query) {
-        if (Strings.isNullOrEmpty(query)) {
+        return parseQueryString(query, Function.identity());
+    }
+
+    private static Map<String, List<String>> parseQueryString(String encodedQuery, Function<String, String> decoder) {
+        if (Strings.isNullOrEmpty(encodedQuery)) {
             return new HashMap<>();
         }
 
-        return QUERY_SPLIT_PATTERN.splitAsStream(query).map(paramString -> PARAM_SPLIT_PATTERN.split(paramString, 2))
-                .map(paramArray -> Map.entry(paramArray[0], paramArray.length > 1 ? paramArray[1] : ""))
+        return QUERY_SPLIT_PATTERN.splitAsStream(encodedQuery)
+                .map(paramString -> PARAM_SPLIT_PATTERN.split(paramString, 2))
+                .map(paramArray -> Map.entry(decoder.apply(paramArray[0]),
+                        paramArray.length > 1 ? decoder.apply(paramArray[1]) : ""))
                 .collect(groupingBy(Map.Entry::getKey, HashMap::new,
                         mapping(Map.Entry::getValue, toCollection(ArrayList::new))));
     }
@@ -450,7 +555,7 @@ public final class DataQuery { // NOPMD not a "god class"
      * @return a copy of this DataQuery
      */
     public DataQuery copy() {
-        return new DataQuery(action, uriPath, getQuery(), headers, body);
+        return new DataQuery(action, uriPath, parameters, headers, body);
     }
 
     @Override

--- a/src/main/java/io/neonbee/data/DataVerticle.java
+++ b/src/main/java/io/neonbee/data/DataVerticle.java
@@ -494,10 +494,10 @@ public abstract class DataVerticle<T> extends AbstractVerticle implements DataAd
 
     private <U> void reportRequestDataMetrics(DataRequest request, Future<U> future) {
         List<Tag> tags;
-        if (request.getQuery() == null || request.getQuery().getQuery() == null) {
+        if (request.getQuery() == null) {
             tags = List.of();
         } else {
-            tags = List.of(new ImmutableTag("query", request.getQuery().getQuery()));
+            tags = List.of(new ImmutableTag("query", request.getQuery().getRawQuery()));
         }
         String qualifiedName = request.getQualifiedName();
 

--- a/src/main/java/io/neonbee/endpoint/odatav4/internal/olingo/processor/ProcessorHelper.java
+++ b/src/main/java/io/neonbee/endpoint/odatav4/internal/olingo/processor/ProcessorHelper.java
@@ -1,10 +1,9 @@
 package io.neonbee.endpoint.odatav4.internal.olingo.processor;
 
-import static com.google.common.base.Strings.nullToEmpty;
 import static io.neonbee.entity.EntityVerticle.requestEntity;
-import static java.net.URLDecoder.decode;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.olingo.commons.api.data.Entity;
@@ -56,8 +55,8 @@ public final class ProcessorHelper {
         // the uriPath without /odata root path and without query path
         String uriPath = "/" + request.getRawServiceResolutionUri() + request.getRawODataPath();
         // the raw query path
-        String rawQueryPath = decode(nullToEmpty(request.getRawQueryPath()), UTF_8);
-        return new DataQuery(action, uriPath, rawQueryPath, request.getAllHeaders(), body).addHeader("X-HTTP-Method",
+        Map<String, List<String>> stringListMap = DataQuery.parseEncodedQueryString(request.getRawQueryPath());
+        return new DataQuery(action, uriPath, stringListMap, request.getAllHeaders(), body).addHeader("X-HTTP-Method",
                 request.getMethod().name());
     }
 

--- a/src/main/java/io/neonbee/endpoint/raw/RawEndpoint.java
+++ b/src/main/java/io/neonbee/endpoint/raw/RawEndpoint.java
@@ -24,9 +24,9 @@ import static io.vertx.core.http.HttpMethod.PUT;
 import static io.vertx.ext.web.impl.Utils.pathOffset;
 import static java.lang.Character.isUpperCase;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -131,11 +131,9 @@ public class RawEndpoint implements Endpoint {
                 return;
             }
 
-            String decodedQueryPath = null;
+            Map<String, List<String>> queryParameterMap;
             try {
-                if (!Strings.isNullOrEmpty(request.query())) {
-                    decodedQueryPath = URLDecoder.decode(request.query(), StandardCharsets.UTF_8);
-                }
+                queryParameterMap = DataQuery.parseEncodedQueryString(request.query());
             } catch (IllegalArgumentException e) {
                 routingContext.fail(BAD_REQUEST.code(), new IllegalArgumentException("Invalid request query"));
                 return;
@@ -143,7 +141,7 @@ public class RawEndpoint implements Endpoint {
 
             DataQuery query = new DataQuery(action,
                     pathOffset(routingContext.normalizedPath(), routingContext).substring(qualifiedName.length() + 1),
-                    decodedQueryPath, multiMapToMap(request.headers()), routingContext.body().buffer())
+                    queryParameterMap, multiMapToMap(request.headers()), routingContext.body().buffer())
                             .addHeader("X-HTTP-Method", request.method().name());
 
             DataContextImpl context = new DataContextImpl(routingContext);

--- a/src/main/java/io/neonbee/entity/EntityVerticle.java
+++ b/src/main/java/io/neonbee/entity/EntityVerticle.java
@@ -178,7 +178,7 @@ public abstract class EntityVerticle extends DataVerticle<EntityWrapper> {
         return neonBee.getModelManager().getSharedModel(EntityModelDefinition.retrieveNamespace(serviceName))
                 .compose(entityModel -> AsyncHelper.executeBlocking(neonBee.getVertx(), () -> {
                     return new Parser(entityModel.getEdmxMetadata(serviceName).getEdm(), getBufferedOData())
-                            .parseUri(uriMatcher.group(ENTITY_PATH_GROUP), query.getQuery(), EMPTY, EMPTY);
+                            .parseUri(uriMatcher.group(ENTITY_PATH_GROUP), query.getRawQuery(), EMPTY, EMPTY);
                 }));
     }
 

--- a/src/test/java/io/neonbee/endpoint/raw/RawEndpointTest.java
+++ b/src/test/java/io/neonbee/endpoint/raw/RawEndpointTest.java
@@ -125,8 +125,8 @@ class RawEndpointTest extends DataVerticleTestBase {
         DataVerticle<String> dummy = createDummyDataVerticle(NEONBEE_NAMESPACE + '/' + verticleName)
                 .withDynamicResponse((query, context) -> {
                     testContext.verify(() -> {
-                        assertThat(query.getQuery()).contains("Hodor=Hodor");
-                        assertThat(query.getQuery()).contains("Foo=123");
+                        assertThat(query.getRawQuery()).contains("Hodor=Hodor");
+                        assertThat(query.getRawQuery()).contains("Foo=123");
                         assertThat(query.getUriPath()).isEqualTo(expectedUriPath);
                     });
                     testContext.completeNow();

--- a/src/test/java/io/neonbee/entity/EntityVerticleTest.java
+++ b/src/test/java/io/neonbee/entity/EntityVerticleTest.java
@@ -243,6 +243,21 @@ class EntityVerticleTest extends EntityVerticleTestBase {
             testVertx.eventBus().publish(EntityModelManager.EVENT_BUS_MODELS_LOADED_ADDRESS, null);
         }));
     }
+
+    @Test
+    @Timeout(value = 200, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("test query with special characters")
+    void testqueryWithSpecialCharacters(Vertx vertx, VertxTestContext testContext) {
+        DataQuery dataQuery = new DataQuery("/io.neonbee.test1.TestService1/AllPropertiesNullable");
+        dataQuery.setRawQuery("$count=true&$orderby=PropertyString&$filter=contains(PropertyString,%20%27%26%27)");
+        var parameters = dataQuery.getParameters();
+        assertThat(parameters).isNotNull();
+
+        EntityVerticle.parseUriInfo(vertx, dataQuery).onSuccess(uriInfo -> {
+            assertThat(uriInfo).isNotNull();
+            testContext.completeNow();
+        }).onFailure(t -> testContext.failNow(t));
+    }
 }
 
 @SuppressWarnings("PMD.TestClassWithoutTestCases")

--- a/src/test/java/io/neonbee/entity/EntityVerticleTest.java
+++ b/src/test/java/io/neonbee/entity/EntityVerticleTest.java
@@ -158,6 +158,7 @@ class EntityVerticleTest extends EntityVerticleTestBase {
     @Test
     @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Get URI info from query")
+    @SuppressWarnings("deprecation")
     void parseUriInfoTest(Vertx vertx, VertxTestContext testContext) {
         Checkpoint checkpoint = testContext.checkpoint(3);
 

--- a/src/test/java/io/neonbee/internal/codec/DataQueryMessageCodecTest.java
+++ b/src/test/java/io/neonbee/internal/codec/DataQueryMessageCodecTest.java
@@ -15,6 +15,7 @@ import io.vertx.core.buffer.Buffer;
 class DataQueryMessageCodecTest {
     private final DataQueryMessageCodec codec = new DataQueryMessageCodec();
 
+    @SuppressWarnings("deprecation")
     private final DataQuery query = new DataQuery(DataAction.UPDATE, "uri", "query1=value",
             Map.of("header1", List.of("value1")), Buffer.buffer("body"));
 


### PR DESCRIPTION
In this pull request two problems are fixed

1.  DataQuery cannot correctly process query strings
    The DataQuery expects a decoded query string in the setQuery method and
    in the constructors that accept a query parameter. These methods are
    now deprecated since this cannot be fixed. A new method setRawQuery is
    introduced which accepts the encoded query string and creates the
    parameters from it.

3. odata query encoding in EntityVerticle
    The parseUri method expects the query parameter to be in percent
    encoding, but it was decoded.