### PR TITLE
build(docker): pin gradle version to 7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.4.2-jdk11 AS builder
+FROM gradle:7.2-jdk11 AS builder
 
 RUN mkdir app
 WORKDIR /app


### PR DESCRIPTION
Keeps the gradle version of the project in sync with the one used to build neonbee within docker.