### PR TITLE
refactor: extract registry logic

### DIFF
--- a/src/main/java/io/neonbee/NeonBee.java
+++ b/src/main/java/io/neonbee/NeonBee.java
@@ -45,6 +45,7 @@ import io.neonbee.config.ServerConfig;
 import io.neonbee.data.DataException;
 import io.neonbee.data.DataQuery;
 import io.neonbee.entity.EntityModelManager;
+import io.neonbee.entity.EntityVerticle;
 import io.neonbee.entity.EntityWrapper;
 import io.neonbee.health.EventLoopHealthCheck;
 import io.neonbee.health.HazelcastClusterHealthCheck;
@@ -55,7 +56,9 @@ import io.neonbee.health.internal.HealthCheck;
 import io.neonbee.hook.HookRegistry;
 import io.neonbee.hook.HookType;
 import io.neonbee.hook.internal.DefaultHookRegistry;
+import io.neonbee.internal.Registry;
 import io.neonbee.internal.SharedDataAccessor;
+import io.neonbee.internal.WriteSafeRegistry;
 import io.neonbee.internal.buffer.ImmutableBuffer;
 import io.neonbee.internal.codec.DataExceptionMessageCodec;
 import io.neonbee.internal.codec.DataQueryMessageCodec;
@@ -172,6 +175,8 @@ public class NeonBee {
     private final Set<String> localConsumers = new ConcurrentHashSet<>();
 
     private final EntityModelManager modelManager;
+
+    private final Registry<String> entityRegistry;
 
     private final CompositeMeterRegistry compositeMeterRegistry;
 
@@ -591,6 +596,7 @@ public class NeonBee {
 
         this.healthRegistry = new HealthCheckRegistry(vertx);
         this.modelManager = new EntityModelManager(this);
+        this.entityRegistry = new WriteSafeRegistry<>(vertx, EntityVerticle.REGISTRY_NAME);
         this.compositeMeterRegistry = compositeMeterRegistry;
 
         // to be able to retrieve the NeonBee instance from any point you have a Vert.x instance add it to a global map
@@ -731,6 +737,15 @@ public class NeonBee {
      */
     public EntityModelManager getModelManager() {
         return modelManager;
+    }
+
+    /**
+     * Get the {@link WriteSafeRegistry} for {@link EntityVerticle}.
+     *
+     * @return the entity verticle {@link WriteSafeRegistry}
+     */
+    public Registry<String> getEntityRegistry() {
+        return entityRegistry;
     }
 
     /**

--- a/src/main/java/io/neonbee/internal/Registry.java
+++ b/src/main/java/io/neonbee/internal/Registry.java
@@ -1,0 +1,36 @@
+package io.neonbee.internal;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
+
+/**
+ * Interface for an asynchronous registry implementation.
+ */
+public interface Registry<T> {
+
+    /**
+     * Register a value in the registry.
+     *
+     * @param key   a key
+     * @param value the value to register
+     * @return the future
+     */
+    Future<Void> register(String key, T value);
+
+    /**
+     * Unregister a value.
+     *
+     * @param key   a key
+     * @param value the value to unregister
+     * @return the future
+     */
+    Future<Void> unregister(String key, T value);
+
+    /**
+     * Get the registered values for the key.
+     *
+     * @param key a key
+     * @return future with a JsonArray of the registered values
+     */
+    Future<JsonArray> get(String key);
+}

--- a/src/main/java/io/neonbee/internal/WriteSafeRegistry.java
+++ b/src/main/java/io/neonbee/internal/WriteSafeRegistry.java
@@ -1,0 +1,132 @@
+package io.neonbee.internal;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import java.util.function.Supplier;
+
+import io.neonbee.NeonBee;
+import io.neonbee.logging.LoggingFacade;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.shareddata.AsyncMap;
+
+/**
+ * A registry to manage values in the {@link SharedDataAccessor} shared map.
+ * <p>
+ * The values under the key are stored in a JsonArray.
+ */
+public class WriteSafeRegistry<T> implements Registry<T> {
+
+    private final LoggingFacade logger = LoggingFacade.create();
+
+    private final SharedDataAccessor sharedDataAccessor;
+
+    private final String registryName;
+
+    /**
+     * Create a new {@link WriteSafeRegistry}.
+     *
+     * @param vertx        the {@link Vertx} instance
+     * @param registryName the name of the map registry
+     */
+    public WriteSafeRegistry(Vertx vertx, String registryName) {
+        this.registryName = registryName;
+        this.sharedDataAccessor = new SharedDataAccessor(vertx, this.getClass());
+    }
+
+    /**
+     * Register a value in the async shared map of {@link NeonBee} by key.
+     *
+     * @param sharedMapKey the shared map key
+     * @param value        the value to register
+     * @return the future
+     */
+    @Override
+    public Future<Void> register(String sharedMapKey, T value) {
+        logger.info("register value: \"{}\" in shared map: \"{}\"", sharedMapKey, value);
+
+        return lock(sharedMapKey, () -> addValue(sharedMapKey, value));
+    }
+
+    @Override
+    public Future<JsonArray> get(String sharedMapKey) {
+        return getSharedMap().compose(map -> map.get(sharedMapKey)).map(o -> (JsonArray) o);
+    }
+
+    /**
+     * Method that acquires a lock for the sharedMapKey and released the lock after the futureSupplier is executed.
+     *
+     * @param sharedMapKey   the shared map key
+     * @param futureSupplier supplier for the future to be secured by the lock
+     * @return the futureSupplier
+     */
+    private Future<Void> lock(String sharedMapKey, Supplier<Future<Void>> futureSupplier) {
+        logger.debug("Get lock for {}", sharedMapKey);
+        return sharedDataAccessor.getLock(sharedMapKey).onFailure(throwable -> {
+            logger.error("Error acquiring lock for {}", sharedMapKey, throwable);
+        }).compose(lock -> futureSupplier.get().onComplete(anyResult -> {
+            logger.debug("Releasing lock for {}", sharedMapKey);
+            lock.release();
+        }));
+    }
+
+    private Future<Void> addValue(String sharedMapKey, Object value) {
+        Future<AsyncMap<String, Object>> sharedMap = getSharedMap();
+
+        return sharedMap.compose(map -> map.get(sharedMapKey))
+                .map(valueOrNull -> valueOrNull != null ? (JsonArray) valueOrNull : new JsonArray())
+                .compose(valueArray -> {
+                    if (!valueArray.contains(value)) {
+                        valueArray.add(value);
+                    }
+
+                    if (logger.isInfoEnabled()) {
+                        logger.info("Registered verticle {} in shared map.", value);
+                    }
+
+                    return sharedMap.compose(map -> map.put(sharedMapKey, valueArray));
+                });
+    }
+
+    /**
+     * Unregister the value in the {@link NeonBee} async shared map from the sharedMapKey.
+     *
+     * @param sharedMapKey the shared map key
+     * @param value        the value to unregister
+     * @return the future
+     */
+    @Override
+    public Future<Void> unregister(String sharedMapKey, T value) {
+        logger.debug("unregister value: \"{}\" from shared map: \"{}\"", sharedMapKey, value);
+
+        return lock(sharedMapKey, () -> removeValue(sharedMapKey, value));
+    }
+
+    private Future<Void> removeValue(String sharedMapKey, Object value) {
+        Future<AsyncMap<String, Object>> sharedMap = getSharedMap();
+
+        return sharedMap.compose(map -> map.get(sharedMapKey)).map(jsonArray -> (JsonArray) jsonArray)
+                .compose(values -> {
+                    if (values == null) {
+                        return succeededFuture();
+                    }
+
+                    if (logger.isInfoEnabled()) {
+                        logger.info("Unregistered verticle {} in shared map.", value);
+                    }
+
+                    values.remove(value);
+                    return sharedMap.compose(map -> map.put(sharedMapKey, values));
+                });
+    }
+
+    /**
+     * Shared map that is used as registry.
+     *
+     * @return Future to the shared map
+     */
+    public Future<AsyncMap<String, Object>> getSharedMap() {
+        return sharedDataAccessor.getAsyncMap(registryName);
+    }
+}

--- a/src/test/java/io/neonbee/internal/WriteSafeRegistryTest.java
+++ b/src/test/java/io/neonbee/internal/WriteSafeRegistryTest.java
@@ -1,0 +1,61 @@
+package io.neonbee.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class WriteSafeRegistryTest {
+
+    public static final String REGISTRY_NAME = "TEST_REGISTRY";
+
+    @Test
+    @DisplayName("register value in registry")
+    void testRegister(Vertx vertx, VertxTestContext context) {
+        WriteSafeRegistry<String> registry = new WriteSafeRegistry<>(vertx, REGISTRY_NAME);
+        String key = "key";
+        String value = "value";
+        registry.register(key, value).compose(unused -> registry.get(key)).onSuccess(mapValue -> context.verify(() -> {
+            assertThat(mapValue).isEqualTo(new JsonArray().add(value));
+            context.completeNow();
+        })).onFailure(context::failNow);
+    }
+
+    @Test
+    @DisplayName("unregister value from registry")
+    void unregister(Vertx vertx, VertxTestContext context) {
+        WriteSafeRegistry<String> registry = new WriteSafeRegistry<>(vertx, REGISTRY_NAME);
+        String key = "key";
+        String value = "value";
+
+        registry.register(key, value).compose(unused -> registry.unregister(key, "value2"))
+                .compose(unused -> registry.get(key)).onSuccess(mapValue -> context.verify(() -> {
+                    assertThat(mapValue).isEqualTo(new JsonArray().add(value));
+                })).compose(unused -> registry.unregister(key, value)).compose(unused -> registry.get(key))
+                .onSuccess(mapValue -> context.verify(() -> {
+                    assertThat(mapValue).isEqualTo(new JsonArray());
+                    context.completeNow();
+                })).onFailure(context::failNow);
+    }
+
+    @Test
+    @DisplayName("get value from registry")
+    void get(Vertx vertx, VertxTestContext context) {
+        String key = "key";
+        String value = "value";
+
+        WriteSafeRegistry<String> registry = new WriteSafeRegistry<>(vertx, REGISTRY_NAME);
+        registry.register(key, value).compose(unused -> registry.get(key)).onSuccess(jsonArray -> context.verify(() -> {
+            assertThat(jsonArray).isNotNull();
+            assertThat(jsonArray.contains(value)).isTrue();
+            context.completeNow();
+        })).onFailure(context::failNow);
+    }
+}


### PR DESCRIPTION
There is a registry logic that is commonly used. In order to reuse this logic, I have moved this logic to a new WriteSafeRegistry class.