### PR TITLE
feat: deploy HealthCheckVerticle only if HealthChecks are enabled

### DIFF
--- a/src/main/java/io/neonbee/NeonBee.java
+++ b/src/main/java/io/neonbee/NeonBee.java
@@ -495,10 +495,12 @@ public class NeonBee {
         List<Future<? extends Deployable>> requiredVerticles = new ArrayList<>();
         requiredVerticles.add(fromClass(vertx, ConsolidationVerticle.class, new JsonObject().put("instances", 1)));
         requiredVerticles.add(fromVerticle(vertx, new MetricsVerticle(1, TimeUnit.SECONDS)));
-        requiredVerticles.add(fromVerticle(vertx, new HealthCheckVerticle()));
         requiredVerticles.add(fromClass(vertx, LoggerManagerVerticle.class));
 
         List<Future<Optional<? extends Deployable>>> optionalVerticles = new ArrayList<>();
+        if (Optional.ofNullable(config.getHealthConfig()).map(HealthConfig::isEnabled).orElse(true)) {
+            requiredVerticles.add(fromClass(vertx, HealthCheckVerticle.class));
+        }
         optionalVerticles.add(deployableWatchVerticle(options.getModelsDirectory(), ModelRefreshVerticle::new));
         optionalVerticles.add(deployableWatchVerticle(options.getVerticlesDirectory(), DeployerVerticle::new));
         optionalVerticles.add(deployableWatchVerticle(options.getModulesDirectory(), DeployerVerticle::new));

--- a/src/test/java/io/neonbee/NeonBeeTest.java
+++ b/src/test/java/io/neonbee/NeonBeeTest.java
@@ -121,6 +121,10 @@ class NeonBeeTest extends NeonBeeTestBase {
     @Override
     protected WorkingDirectoryBuilder provideWorkingDirectoryBuilder(TestInfo testInfo, VertxTestContext testContext) {
         switch (testInfo.getTestMethod().map(Method::getName).orElse(EMPTY)) {
+        case "testDeployNoneOptionalSystemVerticles":
+            NeonBeeConfig config = new NeonBeeConfig();
+            config.getHealthConfig().setEnabled(false);
+            return super.provideWorkingDirectoryBuilder(testInfo, testContext).setNeonBeeConfig(config);
         case "testStartWithNoWorkingDirectory":
             return WorkingDirectoryBuilder.none();
         case "testStartWithEmptyWorkingDirectory":
@@ -140,8 +144,16 @@ class NeonBeeTest extends NeonBeeTestBase {
 
     @Test
     @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
-    @DisplayName("NeonBee should deploy all system verticles")
-    void testDeploySystemVerticles(Vertx vertx) {
+    @DisplayName("NeonBee should deploy all none optional system verticles")
+    void testDeployNoneOptionalSystemVerticles(Vertx vertx) {
+        assertThat(getDeployedVerticles(vertx)).containsExactly(MetricsVerticle.class, ConsolidationVerticle.class,
+                LoggerManagerVerticle.class);
+    }
+
+    @Test
+    @Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("NeonBee should deploy all none optional system verticles plus HealthCheckVerticle")
+    void testDeployNoneOptionalSystemVerticlesPlusHealthCheckVerticle(Vertx vertx) {
         assertThat(getDeployedVerticles(vertx)).containsExactly(MetricsVerticle.class, ConsolidationVerticle.class,
                 LoggerManagerVerticle.class, HealthCheckVerticle.class);
     }


### PR DESCRIPTION
In case that HealthChecks are disabled by the config, there is no need to deploy the HealthCheckVerticle which is serving the results from the HealthChecks.