### PR TITLE
chore: Change spotless code formatter

### DIFF
--- a/gradle/spotless/eclipse-formatter.xml
+++ b/gradle/spotless/eclipse-formatter.xml
@@ -169,7 +169,7 @@
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert" />
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert" />
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0" />
-        <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true" />
+        <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false" />
         <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert" />
         <setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true" />
         <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true" />


### PR DESCRIPTION
Never join lines that have already been wrapped.

Disabling the join_wrapped_lines formatting option allows the code to be formatted a bit more freely, but gives us the opportunity to make the code more readable. 

For example, the code below is quite confusing:
```
deployVerticle(firstCustomerEV).compose(x -> deployVerticle(financeEV)).compose(x -> requestEntity(CUSTOMER))
        .onSuccess(entityWrapper -> context.verify(() -> {
                    // ...
        })).compose(x -> requestEntity(CUSTOMER)).onSuccess(entityWrapper -> context.verify(() -> {
                    // ...
        })).onFailure(context::failNow);
```

Now it is possible to write the code in a better structured way:
```
deployVerticle(firstCustomerEV)
        .compose(x -> deployVerticle(financeEV))
        .compose(x -> requestEntity(CUSTOMER))
        .onSuccess(entityWrapper -> context.verify(() -> {
                    // ...
        }))
        .compose(x -> requestEntity(CUSTOMER))
        .onSuccess(entityWrapper -> context.verify(() -> {
                    //...
        }))
        .onFailure(context::failNow);
```