### PR TITLE
feat(health): add status endpoint & support filtering

### DIFF
--- a/src/main/java/io/neonbee/config/ServerConfig.java
+++ b/src/main/java/io/neonbee/config/ServerConfig.java
@@ -17,6 +17,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableBiMap;
 
 import io.neonbee.endpoint.health.HealthEndpoint;
+import io.neonbee.endpoint.health.StatusEndpoint;
 import io.neonbee.endpoint.metrics.MetricsEndpoint;
 import io.neonbee.endpoint.odatav4.ODataV4Endpoint;
 import io.neonbee.endpoint.raw.RawEndpoint;
@@ -94,9 +95,15 @@ import io.vertx.ext.web.handler.ErrorHandler;
  *       authenticationChain: array, // a specific authentication chain for this endpoint, defaults to an empty array / no auth.
  *     }
  *     health: {
- *       type: "io.neonbee.endpoint.health.HealthEndpoint", // provides an endpoint with health information
- *       enabled: boolean, // enable the metrics endpoint, defaults to true
+ *       type: "io.neonbee.endpoint.health.HealthEndpoint", // provides an endpoint with verbose health information
+ *       enabled: boolean, // enable the health endpoint, defaults to true
  *       basePath: string // the base path to map this endpoint to, defaults to /health/
+ *       authenticationChain: array, // a specific authentication chain for this endpoint, defaults to an empty array / no auth.
+ *     }
+ *     status: {
+ *       type: "io.neonbee.endpoint.health.StatusEndpoint", // provides an endpoint with non-verbose health information
+ *       enabled: boolean, // enable the status endpoint, defaults to true
+ *       basePath: string // the base path to map this endpoint to, defaults to /status/
  *       authenticationChain: array, // a specific authentication chain for this endpoint, defaults to an empty array / no auth.
  *     }
  *   ],
@@ -219,7 +226,8 @@ public class ServerConfig extends HttpServerOptions {
     private static final String PROPERTY_PORT = "port";
 
     private static final List<EndpointConfig> DEFAULT_ENDPOINT_CONFIGS = Collections.unmodifiableList(Stream
-            .of(RawEndpoint.class, ODataV4Endpoint.class, MetricsEndpoint.class, HealthEndpoint.class)
+            .of(RawEndpoint.class, ODataV4Endpoint.class, MetricsEndpoint.class, HealthEndpoint.class,
+                    StatusEndpoint.class)
             .map(endpointClass -> new EndpointConfig().setType(endpointClass.getName())).collect(Collectors.toList()));
 
     private static final ImmutableBiMap<String, String> REPHRASE_MAP = ImmutableBiMap.of("endpointConfigs", "endpoints",

--- a/src/main/java/io/neonbee/endpoint/health/HealthCheckHandler.java
+++ b/src/main/java/io/neonbee/endpoint/health/HealthCheckHandler.java
@@ -1,64 +1,171 @@
 package io.neonbee.endpoint.health;
 
+import static io.neonbee.internal.helper.StringHelper.EMPTY;
 import static java.util.Objects.requireNonNull;
 
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import org.apache.olingo.commons.api.http.HttpStatusCode;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 
 import io.neonbee.data.internal.DataContextImpl;
 import io.neonbee.health.HealthCheckRegistry;
 import io.neonbee.logging.LoggingFacade;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.healthchecks.CheckResult;
+import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
 
+/**
+ * {@link HealthCheckHandler} is a class that implements the Vert.x {@link RoutingContext} Handler interface. It is used
+ * to handle health check requests by providing a RESTful API for the health status.
+ *
+ * The class collects the health check results from a central {@link HealthCheckRegistry} and formats the response with
+ * appropriate status codes based on the results. This can be retrieved for all checks, or, if a specific and existing
+ * health check name is passed in the request path, only health checks for the single health check are returned. By
+ * default, the HTTP response is verbose and provide detailed information about every single health check. If the
+ * verbose flag is set to false via the constructor, only the overall status and a version number is returned.
+ */
 public class HealthCheckHandler implements Handler<RoutingContext> {
     @VisibleForTesting
     static final String APPLICATION_JSON_CHARSET_UTF_8 = "application/json;charset=UTF-8";
+
+    @VisibleForTesting
+    static final String VERSION_FILE = "META-INF/neonbee/neonbee-version.txt";
+
+    private static final String DEV_VERSION = "0.0.0+dev";
 
     private static final LoggingFacade LOGGER = LoggingFacade.create();
 
     private final HealthCheckRegistry registry;
 
+    private final boolean verbose;
+
+    private final Vertx vertx;
+
+    private final AtomicReference<String> version = new AtomicReference<>();
+
     /**
      * Constructs an instance of {@link HealthCheckHandler}.
      *
      * @param registry a health check registry
+     * @param vertx    the current Vert.x instance
      */
-    public HealthCheckHandler(HealthCheckRegistry registry) {
+    public HealthCheckHandler(HealthCheckRegistry registry, Vertx vertx) {
+        this(registry, true, vertx);
+    }
+
+    /**
+     * Constructs an instance of {@link HealthCheckHandler}.
+     *
+     * @param registry a health check registry
+     * @param verbose  whether response should contain verbose health information or not
+     * @param vertx    the current Vert.x instance
+     * @see HealthCheckHandler#HealthCheckHandler(HealthCheckRegistry, Vertx)
+     */
+    HealthCheckHandler(HealthCheckRegistry registry, boolean verbose, Vertx vertx) {
         this.registry = registry;
+        this.verbose = verbose;
+        this.vertx = vertx;
     }
 
     @Override
     public void handle(RoutingContext rc) {
-        registry.collectHealthCheckResults(new DataContextImpl(rc)).onSuccess(resp -> handleRequest(rc, resp))
-                .onFailure(t -> handleFailure(rc, t));
+        String checkName = parseCheck(rc);
+        registry.collectHealthCheckResults(new DataContextImpl(rc), checkName)
+                .onFailure(t -> handleFailure(rc, t))
+                .compose(resp -> handleRequest(rc, resp, verbose));
     }
 
-    private static void handleRequest(RoutingContext rc, JsonObject json) {
+    /**
+     * Parses the health check name from the request path if provided.
+     *
+     * @param rc the {@link RoutingContext} with the request
+     * @return the health check name if provided, empty String otherwise
+     */
+    private String parseCheck(RoutingContext rc) {
+        String requestPath = rc.request().path();
+        String routePath = Optional.ofNullable(rc.currentRoute())
+                .map(Route::getPath)
+                .map(path -> path.replaceAll("/+$", EMPTY) + "/")
+                .orElse("/");
+
+        if (!requestPath.contains(routePath)) {
+            requestPath += '/';
+        }
+
+        String baseRoute = (rc.mountPoint() + routePath).replaceAll("/{2,}", "/");
+        if (!requestPath.startsWith(baseRoute)) {
+            return EMPTY;
+        }
+
+        String checkName = requestPath.substring(baseRoute.length());
+        if (!Strings.isNullOrEmpty(checkName)) {
+            String[] segments = checkName.split("/", 2);
+            checkName = segments[0];
+        }
+        return checkName;
+    }
+
+    /**
+     * Sets the status code of the response object based on the value of "status" key in the input JsonObject. It also
+     * adds the response header and based on verbose mode sets a detailed or non-detailed response body.
+     *
+     * @param rc      the current {@link RoutingContext}
+     * @param json    all consolidated health checks
+     * @param verbose if response should be verbose or not
+     * @return a succeeded Future if handling the requests is successful, a failed Future otherwise.
+     */
+    private Future<Void> handleRequest(RoutingContext rc, JsonObject json, boolean verbose) {
         requireNonNull(json);
+
         HttpServerResponse response = rc.response().putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_CHARSET_UTF_8);
-
-        int status = isUp(json) ? HttpResponseStatus.OK.code() : HttpResponseStatus.SERVICE_UNAVAILABLE.code();
-        if (status == HttpResponseStatus.SERVICE_UNAVAILABLE.code() && hasProcedureError(json)) {
-            status = HttpResponseStatus.INTERNAL_SERVER_ERROR.code();
+        if (!isUp(json)) {
+            if (hasProcedureError(json)) {
+                response.setStatusCode(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+            } else {
+                response.setStatusCode(HttpResponseStatus.SERVICE_UNAVAILABLE.code());
+            }
+        } else if (isNoCheckAvailable(json)) {
+            return response.setStatusCode(HttpStatusCode.NO_CONTENT.getStatusCode()).end()
+                    .recover(t -> Future.succeededFuture());
+        } else {
+            response.setStatusCode(HttpResponseStatus.OK.code());
         }
 
-        if ((status == HttpStatusCode.OK.getStatusCode()) && getChecks(json).findAny().isEmpty()) {
-            // Special case; no checks available
-            response.setStatusCode(HttpStatusCode.NO_CONTENT.getStatusCode()).end();
-            return;
+        if (verbose) {
+            return response.end(json.encode()).recover(t -> Future.succeededFuture());
         }
 
-        response.setStatusCode(status).end(json.encode());
+        return Future.succeededFuture(version.get()).compose(cachedVersion -> {
+            if (cachedVersion != null) {
+                return Future.succeededFuture(cachedVersion);
+            }
+            return vertx.fileSystem().readFile(VERSION_FILE).map(Buffer::toString).onComplete(ar -> {
+                if (ar.succeeded()) {
+                    version.set(ar.result());
+                } else {
+                    version.set(DEV_VERSION);
+                    if (LOGGER.isErrorEnabled()) {
+                        LOGGER.error("Failed to read version file: " + VERSION_FILE, ar.cause());
+                    }
+                }
+            }).recover(t -> Future.succeededFuture(version.get()));
+        }).compose(neonbeeVersion -> response
+                .end(new JsonObject().put("status", json.getString("status")).put("version", neonbeeVersion).encode()))
+                .mapEmpty();
     }
 
     private static void handleFailure(RoutingContext rc, Throwable throwable) {
@@ -83,11 +190,14 @@ public class HealthCheckHandler implements Handler<RoutingContext> {
         if (data != null && data.getBoolean("procedure-execution-failure", false)) {
             return true;
         }
-
         return getChecks(json).anyMatch(HealthCheckHandler::hasProcedureError);
     }
 
     private static Stream<JsonObject> getChecks(JsonObject json) {
         return json.getJsonArray("checks", new JsonArray()).stream().map(j -> (JsonObject) j);
+    }
+
+    private boolean isNoCheckAvailable(JsonObject json) {
+        return (isUp(json) && getChecks(json).findAny().isEmpty());
     }
 }

--- a/src/main/java/io/neonbee/endpoint/health/HealthEndpoint.java
+++ b/src/main/java/io/neonbee/endpoint/health/HealthEndpoint.java
@@ -11,6 +11,11 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 
+/**
+ * This endpoint is targeted for manual use with cURL or similar command line tools, and can be used to quickly obtain
+ * information on the overall health of the system and the individual checks. To protect the information about the
+ * system, which are not meant for public usage, only authenticated requests are allowed in the default configuration.
+ */
 public class HealthEndpoint implements Endpoint {
     /**
      * The default path that is used by NeonBee to expose the health endpoint.
@@ -25,6 +30,6 @@ public class HealthEndpoint implements Endpoint {
     @Override
     public Future<Router> createEndpointRouter(Vertx vertx, String basePath, JsonObject config) {
         HealthCheckRegistry registry = NeonBee.get(vertx).getHealthCheckRegistry();
-        return Future.succeededFuture(createRouter(vertx, new HealthCheckHandler(registry)));
+        return Future.succeededFuture(createRouter(vertx, new HealthCheckHandler(registry, vertx)));
     }
 }

--- a/src/main/java/io/neonbee/endpoint/health/StatusEndpoint.java
+++ b/src/main/java/io/neonbee/endpoint/health/StatusEndpoint.java
@@ -1,0 +1,44 @@
+package io.neonbee.endpoint.health;
+
+import static io.neonbee.endpoint.Endpoint.createRouter;
+
+import io.neonbee.NeonBee;
+import io.neonbee.config.EndpointConfig;
+import io.neonbee.endpoint.Endpoint;
+import io.neonbee.health.HealthCheckRegistry;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+
+/**
+ * This is a publicly available endpoint meant for external monitoring systems. The endpoint will return HTTP status
+ * code 200 if NeonBee is running, and code 503 service unavailable when the status is DOWN. The response contains a
+ * JSON like this:
+ * <p>
+ * <code>
+ *   {
+ *     "status": "UP",
+ *     "version": "1.2.3"
+ *   }
+ * </code>
+ * </p>
+ * The "status" is either "UP" or "DOWN", and the "version" is the current NeonBee release version.
+ */
+public class StatusEndpoint implements Endpoint {
+    /**
+     * The default path that is used by NeonBee to expose the health endpoint.
+     */
+    private static final String DEFAULT_BASE_PATH = "/status/";
+
+    @Override
+    public EndpointConfig getDefaultConfig() {
+        return new EndpointConfig().setType(StatusEndpoint.class.getName()).setBasePath(DEFAULT_BASE_PATH);
+    }
+
+    @Override
+    public Future<Router> createEndpointRouter(Vertx vertx, String basePath, JsonObject config) {
+        HealthCheckRegistry registry = NeonBee.get(vertx).getHealthCheckRegistry();
+        return Future.succeededFuture(createRouter(vertx, new HealthCheckHandler(registry, false, vertx)));
+    }
+}

--- a/src/test/java/io/neonbee/endpoint/health/HealthCheckHandlerTest.java
+++ b/src/test/java/io/neonbee/endpoint/health/HealthCheckHandlerTest.java
@@ -1,14 +1,18 @@
 package io.neonbee.endpoint.health;
 
 import static io.neonbee.endpoint.health.HealthCheckHandler.APPLICATION_JSON_CHARSET_UTF_8;
+import static io.neonbee.endpoint.health.HealthCheckHandler.VERSION_FILE;
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -18,25 +22,35 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentMatchers;
 
 import io.neonbee.data.DataContext;
 import io.neonbee.health.HealthCheckRegistry;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.file.FileSystem;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.junit5.VertxExtension;
 
+@ExtendWith(VertxExtension.class)
 class HealthCheckHandlerTest {
     HealthCheckRegistry registry;
 
     RoutingContext routingContext;
 
     HttpServerResponse httpServerResponse;
+
+    HttpServerRequest serverRequest;
 
     @BeforeEach
     void setUp() {
@@ -50,7 +64,15 @@ class HealthCheckHandlerTest {
                 .thenReturn(httpServerResponse);
         when(httpServerResponse.end()).thenReturn(succeededFuture());
         when(routingContext.response()).thenReturn(httpServerResponse);
-        when(routingContext.request()).thenReturn(mock(HttpServerRequest.class));
+
+        Route route = mock(Route.class);
+        when(route.getPath()).thenReturn("/");
+        when(routingContext.currentRoute()).thenReturn(route);
+        when(routingContext.mountPoint()).thenReturn("/health");
+
+        serverRequest = mock(HttpServerRequest.class);
+        when(serverRequest.path()).thenReturn("/health");
+        when(routingContext.request()).thenReturn(serverRequest);
     }
 
     private static JsonObject buildExpectedJson(String status, String outcome, JsonObject... checks) {
@@ -85,9 +107,10 @@ class HealthCheckHandlerTest {
     @DisplayName("should handle response, if")
     @SuppressWarnings("unused")
     void testHandle(JsonObject expectedResponse, int expectedStatusCode, String description) {
-        when(registry.collectHealthCheckResults(any(DataContext.class))).thenReturn(succeededFuture(expectedResponse));
+        when(registry.collectHealthCheckResults(any(DataContext.class), anyString()))
+                .thenReturn(succeededFuture(expectedResponse));
 
-        new HealthCheckHandler(registry).handle(routingContext);
+        new HealthCheckHandler(registry, null).handle(routingContext);
 
         verify(httpServerResponse).putHeader(eq(HttpHeaders.CONTENT_TYPE), eq(APPLICATION_JSON_CHARSET_UTF_8));
         verify(httpServerResponse).setStatusCode(eq(expectedStatusCode));
@@ -101,12 +124,54 @@ class HealthCheckHandlerTest {
     @Test
     @DisplayName("should return internal server error, if retrieving data fails")
     void testHandleFailure() {
-        when(registry.collectHealthCheckResults(any(DataContext.class)))
+        when(registry.collectHealthCheckResults(any(DataContext.class), anyString()))
                 .thenReturn(failedFuture(new Throwable("oops")));
 
-        new HealthCheckHandler(registry).handle(routingContext);
+        new HealthCheckHandler(registry, null).handle(routingContext);
 
         verify(httpServerResponse).setStatusCode(eq(500));
         verify(httpServerResponse).setStatusMessage(matches("Could not request any health data."));
+    }
+
+    @Test
+    @DisplayName("should handle requests of specific checks")
+    void testHandleCheck() {
+        String checkName = "dummy";
+        when(serverRequest.path()).thenReturn("/health/" + checkName);
+        JsonObject expectedResponse =
+                buildExpectedJson("UP", "UP", new JsonObject().put("id", checkName).put("status", "UP"));
+        when(registry.collectHealthCheckResults(any(DataContext.class), anyString()))
+                .thenReturn(succeededFuture(expectedResponse));
+
+        new HealthCheckHandler(registry, null).handle(routingContext);
+
+        verify(httpServerResponse).setStatusCode(eq(200));
+        verify(httpServerResponse).end(contains(checkName));
+        verify(registry).collectHealthCheckResults(any(DataContext.class), eq(checkName));
+    }
+
+    @Test
+    @DisplayName("should handle non-verbose checks")
+    void testHandleNonVerbose(Vertx vertx) {
+        String expectedStatus = "UP";
+        JsonObject expectedResponse = buildExpectedJson(expectedStatus, expectedStatus,
+                new JsonObject().put("id", "dummy").put("status", expectedStatus));
+        when(registry.collectHealthCheckResults(any(DataContext.class), anyString()))
+                .thenReturn(succeededFuture(expectedResponse));
+
+        Vertx vertxSpy = spy(vertx);
+        String expectedVersion = "1.0.1";
+        FileSystem fs = mock(FileSystem.class);
+        when(fs.readFile(eq(VERSION_FILE))).thenReturn(succeededFuture(Buffer.buffer(expectedVersion)));
+        doReturn(fs).when(vertxSpy).fileSystem();
+
+        new HealthCheckHandler(registry, false, vertxSpy).handle(routingContext);
+
+        verify(httpServerResponse).setStatusCode(eq(200));
+        verify(httpServerResponse).end(ArgumentMatchers.<String>argThat(m -> {
+            JsonObject entries = new JsonObject(m);
+            return entries.getString("status").equals(expectedStatus)
+                    && entries.getString("version").equals(expectedVersion);
+        }));
     }
 }

--- a/src/test/java/io/neonbee/endpoint/health/HealthEndpointTest.java
+++ b/src/test/java/io/neonbee/endpoint/health/HealthEndpointTest.java
@@ -4,33 +4,57 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.util.stream.Collectors.toList;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import io.neonbee.test.base.NeonBeeTestBase;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
 class HealthEndpointTest extends NeonBeeTestBase {
 
+    Function<HttpResponse<Buffer>, JsonObject> validateResponse = response -> {
+        assertThat(response.statusCode()).isEqualTo(200);
+        JsonObject body = response.bodyAsJsonObject();
+        assertThat(body.containsKey("outcome")).isTrue();
+        assertThat(body.containsKey("status")).isTrue();
+        assertThat(body.containsKey("checks")).isTrue();
+        return body;
+    };
+
+    Function<JsonObject, List<String>> getIds =
+            result -> result.getJsonArray("checks").stream().map(JsonObject.class::cast)
+                    .map(c -> c.getString("id")).collect(toList());
+
     @Test
     @DisplayName("should return health info of the default checks")
-    void testHealthEndpointData(VertxTestContext testContext) {
-        createRequest(HttpMethod.GET, "/health").send(testContext.succeeding(response -> testContext.verify(() -> {
-            assertThat(response.statusCode()).isEqualTo(200);
-
-            JsonObject result = response.bodyAsJsonObject();
-            assertThat(result.containsKey("outcome")).isTrue();
-            assertThat(result.containsKey("status")).isTrue();
-            assertThat(result.containsKey("checks")).isTrue();
-
-            List<String> ids = result.getJsonArray("checks").stream().map(JsonObject.class::cast)
-                    .map(c -> c.getString("id")).collect(toList());
+    void testHealthEndpointAll(VertxTestContext testContext) {
+        createRequest(HttpMethod.GET, "/health/").send(testContext.succeeding(response -> testContext.verify(() -> {
+            JsonObject body = validateResponse.apply(response);
+            List<String> ids = getIds.apply(body);
+            assertThat(ids.size()).isGreaterThan(1);
             assertThat(ids).contains(String.format("node.%s.os.memory", getNeonBee().getNodeId()));
-
             testContext.completeNow();
         })));
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("should only return health info of passed check")
+    void testHealthEndpointSingle(VertxTestContext testContext) {
+        createRequest(HttpMethod.GET, "/health/os.memory")
+                .send(testContext.succeeding(response -> testContext.verify(() -> {
+                    JsonObject body = validateResponse.apply(response);
+                    assertThat(getIds.apply(body))
+                            .containsExactly(String.format("node.%s.os.memory", getNeonBee().getNodeId()));
+                    testContext.completeNow();
+                })));
     }
 }

--- a/src/test/java/io/neonbee/endpoint/health/StatusEndpointTest.java
+++ b/src/test/java/io/neonbee/endpoint/health/StatusEndpointTest.java
@@ -1,0 +1,34 @@
+package io.neonbee.endpoint.health;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.neonbee.test.base.NeonBeeTestBase;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+
+class StatusEndpointTest extends NeonBeeTestBase {
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("should return health info of the default checks")
+    void testHealthEndpointData(VertxTestContext testContext) {
+        createRequest(HttpMethod.GET, "/status").send(testContext.succeeding(response -> testContext.verify(() -> {
+            assertThat(response.statusCode()).isEqualTo(200);
+
+            JsonObject result = response.bodyAsJsonObject();
+            assertThat(result.containsKey("status")).isTrue();
+            assertThat(result.containsKey("version")).isTrue();
+            assertThat(result.containsKey("outcome")).isFalse();
+            assertThat(result.containsKey("checks")).isFalse();
+
+            testContext.completeNow();
+        })));
+    }
+}


### PR DESCRIPTION
With this change a `StatusEndpoint` is introduced, which allows to display health onformation in a non-verbose way. This endpoint is meant to be public and usable for external system monitoring tools. The endpoint is mounted at /status and is part of the default endpoints of NeonBee. The /health endpoint will continue to serve health data in a verbose way, and it should be considered by the user to protect this endpoint as it might expose system information that should not be available to external parties.

In addition, the `HealthCheckHandler` is extended to support health check based filtering vie the request path of the /health endpoint.