### PR TITLE
chore: remove webserver name from X-Instance-Info header

### DIFF
--- a/src/main/java/io/neonbee/NeonBeeOptions.java
+++ b/src/main/java/io/neonbee/NeonBeeOptions.java
@@ -610,7 +610,7 @@ public interface NeonBeeOptions {
         }
 
         private String generateName() {
-            return String.format("%s-%s", NeonBee.class.getSimpleName(), UUID.randomUUID().toString());
+            return UUID.randomUUID().toString();
         }
     }
 

--- a/src/main/java/io/neonbee/internal/handler/InstanceInfoHandler.java
+++ b/src/main/java/io/neonbee/internal/handler/InstanceInfoHandler.java
@@ -5,6 +5,11 @@ import io.vertx.core.MultiMap;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.PlatformHandler;
 
+/**
+ * This Vert.x handler sets the "X-Instance-Info" header in the HTTP response, if not already set. The value of this
+ * header is set to a unique identifier for the NeonBee instance which is handling the request. This handler should be
+ * used in a Vert.x router to set the instance info header for all outgoing HTTP responses.
+ */
 public class InstanceInfoHandler implements PlatformHandler {
     static final String X_INSTANCE_INFO_HEADER = "X-Instance-Info";
 

--- a/src/test/java/io/neonbee/NeonBeeOptionsTest.java
+++ b/src/test/java/io/neonbee/NeonBeeOptionsTest.java
@@ -26,16 +26,10 @@ import io.vertx.core.eventbus.EventBusOptions;
 
 class NeonBeeOptionsTest {
     @Test
-    @DisplayName("should generate an instance name if no instance name is passed")
-    void generateNameIfNoIsPassed() {
-        assertThat(new NeonBeeOptions.Mutable().getInstanceName()).containsMatch("^NeonBee-.{36}$");
-    }
-
-    @Test
-    @DisplayName("should generate an instance name if null is passed as an instance name")
-    void generateNameIfNullIsPassed() {
-        assertThat(new NeonBeeOptions.Mutable().setInstanceName(null).getInstanceName())
-                .containsMatch("^NeonBee-.{36}$");
+    @DisplayName("should generate an instance name if no instance name or null is passed")
+    void generateNameIfNothingIsPassed() {
+        assertThat(new NeonBeeOptions.Mutable().getInstanceName()).hasLength(36);
+        assertThat(new NeonBeeOptions.Mutable().setInstanceName(null).getInstanceName()).hasLength(36);
     }
 
     @Test


### PR DESCRIPTION
For security reasons, the webserver name should not be public, because this allows attackers to gather information about the application and potentially identify new attack surfaces. The NeonBee prefix in the X-Instance-Info header does not provide any benefit, and therefore can be removed.

Closes #268