### PR TITLE
refactor(odata): implement ODataMetadataRequest and deprecate ODataRequest#setMetadata

### DIFF
--- a/docs/usage/test/odata.md
+++ b/docs/usage/test/odata.md
@@ -7,12 +7,13 @@ knowledge of the [OData protocol 4.0](http://docs.oasis-open.org/odata/odata/v4.
 
 > Hint: Current implementations follow OData protocol version 4.0
 
-| Class                                                                                                                    | Description                                                                                                                                                        |
-|--------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [io.neonbee.test.base.ODataRequest](../../../src/test/java/io/neonbee/test/base/ODataRequest.java)                       | Allows to create and dispatch an individual OData request for performing metadata and data requests on OData services.                                             |
-| [io.neonbee.test.base.ODataBatchRequest](../../../src/test/java/io/neonbee/test/base/ODataBatchRequest.java)             | Allows to create and dispatch an OData batch request constituting from one or more individual OData requests.                                                      |
-| [io.neonbee.test.helper.MultipartResponse](../../../src/test/java/io/neonbee/test/helper/MultipartResponse.java)         | Provides parsing and access to details of an HTTP multipart response as it is retrieved as a result OData batch requests.                                          |
-| [io.neonbee.test.helper.ODataResponseVerifier](../../../src/test/java/io/neonbee/test/helper/ODataResponseVerifier.java) | Provides common assertions for OData related test cases like response status code verification.                                                                    |
+| Class                                                                                                                    | Description                                                                                                               |
+|--------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| [io.neonbee.test.base.ODataMetadataRequest](../../../src/test/java/io/neonbee/test/base/ODataMetadataRequest.java)       | Allows to create and dispatch an individual OData request for performing metadata requests on OData services.             |
+| [io.neonbee.test.base.ODataRequest](../../../src/test/java/io/neonbee/test/base/ODataRequest.java)                       | Allows to create and dispatch an individual OData request for performing data requests on OData services.                 |
+| [io.neonbee.test.base.ODataBatchRequest](../../../src/test/java/io/neonbee/test/base/ODataBatchRequest.java)             | Allows to create and dispatch an OData batch request constituting from one or more individual OData requests.             |
+| [io.neonbee.test.helper.MultipartResponse](../../../src/test/java/io/neonbee/test/helper/MultipartResponse.java)         | Provides parsing and access to details of an HTTP multipart response as it is retrieved as a result OData batch requests. |
+| [io.neonbee.test.helper.ODataResponseVerifier](../../../src/test/java/io/neonbee/test/helper/ODataResponseVerifier.java) | Provides common assertions for OData related test cases like response status code verification.                           |
 
 ## OData batch request example
 

--- a/src/test/java/io/neonbee/endpoint/odatav4/ODataV4EndpointTest.java
+++ b/src/test/java/io/neonbee/endpoint/odatav4/ODataV4EndpointTest.java
@@ -39,6 +39,7 @@ import io.neonbee.entity.EntityVerticle;
 import io.neonbee.entity.EntityWrapper;
 import io.neonbee.internal.verticle.ServerVerticle;
 import io.neonbee.test.base.ODataEndpointTestBase;
+import io.neonbee.test.base.ODataMetadataRequest;
 import io.neonbee.test.base.ODataRequest;
 import io.neonbee.test.helper.WorkingDirectoryBuilder;
 import io.vertx.core.DeploymentOptions;
@@ -118,7 +119,7 @@ class ODataV4EndpointTest extends ODataEndpointTestBase {
 
     private Future<HttpResponse<Buffer>> requestMetadata(String namespace) {
         FullQualifiedName fqn = new FullQualifiedName(namespace, "WillBeIgnored");
-        return requestOData(new ODataRequest(fqn).setMetadata());
+        return requestOData(new ODataMetadataRequest(fqn));
     }
 
     @Test

--- a/src/test/java/io/neonbee/test/base/ODataMetadataRequest.java
+++ b/src/test/java/io/neonbee/test/base/ODataMetadataRequest.java
@@ -1,0 +1,23 @@
+package io.neonbee.test.base;
+
+import org.apache.olingo.commons.api.edm.FullQualifiedName;
+
+/**
+ * This class can be used to address the metadata of OData services that expose their entity model according to
+ * [OData-CSDLJSON] or [OData-CSDLXML] at the metadata URL.
+ */
+public class ODataMetadataRequest extends AbstractODataRequest<ODataMetadataRequest> {
+    public ODataMetadataRequest(FullQualifiedName entity) {
+        super(entity);
+    }
+
+    @Override
+    protected ODataMetadataRequest self() {
+        return this;
+    }
+
+    @Override
+    protected String getUri() {
+        return getUriNamespacePath() + "$metadata";
+    }
+}

--- a/src/test/java/io/neonbee/test/base/ODataMetadataRequestTest.java
+++ b/src/test/java/io/neonbee/test/base/ODataMetadataRequestTest.java
@@ -1,0 +1,50 @@
+package io.neonbee.test.base;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
+
+import org.apache.olingo.commons.api.edm.FullQualifiedName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.vertx.core.http.HttpMethod;
+
+class ODataMetadataRequestTest {
+
+    private ODataMetadataRequest metadataRequest;
+
+    static Stream<Arguments> withNamespaces() {
+        return Stream.of(arguments("my-namespace", "my-namespace/$metadata"), arguments("", "$metadata"));
+    }
+
+    @BeforeEach
+    void setUp() {
+        metadataRequest = new ODataMetadataRequest(new FullQualifiedName("my-namespace", "my-entity"));
+    }
+
+    @Test
+    void testMethod() {
+        assertThat(metadataRequest.method).isEqualTo(HttpMethod.GET);
+    }
+
+    @ParameterizedTest(name = "{index}: with namespace ''{0}''")
+    @MethodSource("withNamespaces")
+    @DisplayName("test for correct URI")
+    void testGetUri(String namespace, String expected) {
+        ODataMetadataRequest request =
+                new ODataMetadataRequest(new FullQualifiedName(namespace, "my-entity"));
+        assertThat(request.getUri()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Verify self() returns correct instance")
+    void testGetSelf() {
+        assertThat(metadataRequest.self()).isEqualTo(metadataRequest);
+    }
+}

--- a/src/test/java/io/neonbee/test/base/ODataRequest.java
+++ b/src/test/java/io/neonbee/test/base/ODataRequest.java
@@ -87,7 +87,10 @@ public class ODataRequest extends AbstractODataRequest<ODataRequest> {
      * </pre>
      *
      * @return An {@link ODataRequest} which considers the {@code $metadata} suffix when building the request
+     * @deprecated use {@link ODataMetadataRequest} focussing on dispatching OData metadata requests and separating away
+     *             from data-centric requests.
      */
+    @Deprecated(forRemoval = true)
     public ODataRequest setMetadata() {
         this.metadata = true;
         return this;

--- a/src/test/java/io/neonbee/test/base/ODataRequestTest.java
+++ b/src/test/java/io/neonbee/test/base/ODataRequestTest.java
@@ -28,6 +28,8 @@ class ODataRequestTest {
 
     @Test
     @DisplayName("with $metadata set")
+    @Deprecated(forRemoval = true)
+    @SuppressWarnings({ "removal" })
     void testGetUriWithMetadata() {
         odataRequest.setMetadata();
         assertThat(odataRequest.getUri()).isEqualTo(EXPECTED_SERVICE_ROOT_URL + "/$metadata");

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataReadEntityTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataReadEntityTest.java
@@ -9,8 +9,6 @@ import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle
 
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.apache.olingo.commons.api.edm.FullQualifiedName;
@@ -28,11 +26,7 @@ import io.neonbee.test.base.ODataRequest;
 import io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle;
 import io.neonbee.test.endpoint.odata.verticle.TestService3EntityVerticle;
 import io.vertx.core.CompositeFuture;
-import io.vertx.core.MultiMap;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.junit5.VertxTestContext;
 
 class ODataReadEntityTest extends ODataEndpointTestBase {
@@ -120,84 +114,6 @@ class ODataReadEntityTest extends ODataEndpointTestBase {
 
         ODataRequestMod(FullQualifiedName entity) {
             super(entity);
-        }
-
-        @Override
-        public ODataRequest setMethod(HttpMethod method) {
-            super.setMethod(method);
-            return this;
-        }
-
-        @Override
-        public ODataRequest setBody(Buffer body) {
-            super.setBody(body);
-            return this;
-        }
-
-        @Override
-        public ODataRequest setMetadata() {
-            super.setMetadata();
-            return this;
-        }
-
-        @Override
-        public ODataRequest setCount() {
-            super.setCount();
-            return this;
-        }
-
-        @Override
-        public ODataRequestMod setKey(String id) {
-            super.setKey(id);
-            return this;
-        }
-
-        @Override
-        public ODataRequest setKey(long id) {
-            super.setKey(id);
-            return this;
-        }
-
-        @Override
-        public ODataRequest setKey(Map<String, Object> compositeKey) {
-            super.setKey(compositeKey);
-            return this;
-        }
-
-        @Override
-        public ODataRequest setProperty(String propertyName) {
-            super.setProperty(propertyName);
-            return this;
-        }
-
-        @Override
-        public ODataRequest addQueryParam(String key, String value) {
-            super.addQueryParam(key, value);
-            return this;
-        }
-
-        @Override
-        public ODataRequest setQuery(Map<String, String> parameters) {
-            super.setQuery(parameters);
-            return this;
-        }
-
-        @Override
-        public ODataRequest addHeader(String key, String value) {
-            super.addHeader(key, value);
-            return this;
-        }
-
-        @Override
-        public ODataRequest setHeaders(MultiMap headers) {
-            super.setHeaders(headers);
-            return this;
-        }
-
-        @Override
-        public ODataRequest interceptRequest(Consumer<HttpRequest<Buffer>> rawRequest) {
-            super.interceptRequest(rawRequest);
-            return this;
         }
 
         @Override


### PR DESCRIPTION
Introduction of ODataMetadataRequest inheriting from AbstractODataRequest and replacing ODataRequest#setMetadata for a clearer API