### PR TITLE
feat: allow to pass count value via response hints

### DIFF
--- a/src/main/java/io/neonbee/endpoint/odatav4/internal/olingo/processor/ProcessorHelper.java
+++ b/src/main/java/io/neonbee/endpoint/odatav4/internal/olingo/processor/ProcessorHelper.java
@@ -49,6 +49,9 @@ public final class ProcessorHelper {
     /** OData key predicate key. */
     public static final String ODATA_KEY_PREDICATE_KEY = "OData.key";
 
+    /** OData count size key. */
+    public static final String ODATA_COUNT_SIZE_KEY = "OData.count.size";
+
     private ProcessorHelper() {}
 
     private static DataQuery odataRequestToQuery(ODataRequest request, DataAction action, Buffer body) {

--- a/src/test/java/io/neonbee/endpoint/odatav4/internal/olingo/processor/ProcessorHelperTest.java
+++ b/src/test/java/io/neonbee/endpoint/odatav4/internal/olingo/processor/ProcessorHelperTest.java
@@ -1,6 +1,7 @@
 package io.neonbee.endpoint.odatav4.internal.olingo.processor;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.neonbee.endpoint.odatav4.internal.olingo.processor.ProcessorHelper.ODATA_COUNT_SIZE_KEY;
 import static io.neonbee.endpoint.odatav4.internal.olingo.processor.ProcessorHelper.ODATA_EXPAND_KEY;
 import static io.neonbee.endpoint.odatav4.internal.olingo.processor.ProcessorHelper.ODATA_FILTER_KEY;
 import static io.neonbee.endpoint.odatav4.internal.olingo.processor.ProcessorHelper.ODATA_SKIP_KEY;
@@ -34,10 +35,12 @@ class ProcessorHelperTest {
         DataContext dataContext = new DataContextImpl();
         dataContext.responseData().put(ODATA_FILTER_KEY, Boolean.TRUE);
         dataContext.responseData().put(ODATA_EXPAND_KEY, Boolean.FALSE);
+        dataContext.responseData().put(ODATA_COUNT_SIZE_KEY, 42);
         ProcessorHelper.transferResponseHint(dataContext, routingContext);
         assertThat(routingContext.<Boolean>get(RESPONSE_HEADER_PREFIX + ODATA_FILTER_KEY)).isTrue();
         assertThat(routingContext.<Boolean>get(RESPONSE_HEADER_PREFIX + ODATA_EXPAND_KEY)).isFalse();
         assertThat(routingContext.<Boolean>get(RESPONSE_HEADER_PREFIX + ODATA_SKIP_KEY)).isNull();
         assertThat(routingContext.<Boolean>get(RESPONSE_HEADER_PREFIX + ODATA_TOP_KEY)).isNull();
+        assertThat(routingContext.<Integer>get(RESPONSE_HEADER_PREFIX + ODATA_COUNT_SIZE_KEY)).isEqualTo(42);
     }
 }

--- a/src/test/java/io/neonbee/test/endpoint/odata/verticle/ODataCountTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/verticle/ODataCountTest.java
@@ -1,0 +1,55 @@
+package io.neonbee.test.endpoint.odata.verticle;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.neonbee.endpoint.odatav4.internal.olingo.processor.ProcessorHelper.ODATA_COUNT_SIZE_KEY;
+import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.TEST_ENTITY_SET_FQN;
+import static io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle.getDeclaredEntityModel;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.neonbee.entity.EntityWrapper;
+import io.neonbee.test.base.ODataEndpointTestBase;
+import io.neonbee.test.base.ODataRequest;
+import io.vertx.core.Future;
+import io.vertx.junit5.VertxTestContext;
+
+class ODataCountTest extends ODataEndpointTestBase {
+
+    @Override
+    protected List<Path> provideEntityModels() {
+        return List.of(getDeclaredEntityModel());
+    }
+
+    private Future<Void> deployVerticleWithResponseHintCount(int count) {
+        return deployVerticle(createDummyEntityVerticle(TEST_ENTITY_SET_FQN).withDynamicResponse((query, context) -> {
+            context.responseData().put(ODATA_COUNT_SIZE_KEY, count);
+            return new EntityWrapper(TEST_ENTITY_SET_FQN, List.of());
+        })).mapEmpty();
+    }
+
+    @Test
+    @DisplayName("Respond with 200 and includes inline count read from the response hint")
+    void entitiesWithInlineCountFromHintTest(VertxTestContext testContext) {
+        deployVerticleWithResponseHintCount(42).onSuccess(v -> {
+            Map<String, String> countQuery = Map.of("$count", "true");
+            assertOData(requestOData(new ODataRequest(TEST_ENTITY_SET_FQN).setQuery(countQuery)),
+                    body -> assertThat(body.toJsonObject().getMap()).containsAtLeast("@odata.count",
+                            42),
+                    testContext).onComplete(testContext.succeedingThenComplete());
+        }).onFailure(testContext::failNow);
+    }
+
+    @Test
+    @DisplayName("Test /$count returns the value passed via response hint")
+    void countEntitiesViaCountFromHintTest(VertxTestContext testContext) {
+        deployVerticleWithResponseHintCount(1337)
+                .onSuccess(v -> assertOData(requestOData(new ODataRequest(TEST_ENTITY_SET_FQN).setCount()), "1337",
+                        testContext).onComplete(testContext.succeedingThenComplete()))
+                .onFailure(testContext::failNow);
+    }
+}


### PR DESCRIPTION
This commit allows to pass the count information via response hint, which is a hugh performance benefit, because it is no longer necessary to send all entities back to the ODataEndpoint.