### PR TITLE
chore: improve error message when no verticle is registered for an entity type

### DIFF
--- a/src/main/java/io/neonbee/entity/EntityVerticle.java
+++ b/src/main/java/io/neonbee/entity/EntityVerticle.java
@@ -129,7 +129,8 @@ public abstract class EntityVerticle extends DataVerticle<EntityWrapper> {
          */
         return getVerticlesForEntityType(vertx, entityTypeName).compose(qualifiedNames -> {
             if (qualifiedNames.isEmpty()) {
-                return failedFuture("No verticle registered listening to this entity type name");
+                return failedFuture("No verticle registered listening to entity type name "
+                        + entityTypeName.getFullQualifiedNameAsString());
             } else if (qualifiedNames.size() == 1) {
                 return requestData(vertx, new DataRequest(qualifiedNames.get(0), request.getQuery()), context);
             } else {


### PR DESCRIPTION
When a request is made to a verticle which requests data from other verticles, which due to some issue are not registered in the shared map, it becomes difficult to understand for which entity type there is no verticle registered. Providing the FQN of the entity type in the error message, makes it easier to identify for which entity type there is no verticle registered.