### PR TITLE
fix: dynatrace null or empty dimension warning

### DIFF
--- a/src/main/java/io/neonbee/data/DataVerticle.java
+++ b/src/main/java/io/neonbee/data/DataVerticle.java
@@ -494,7 +494,7 @@ public abstract class DataVerticle<T> extends AbstractVerticle implements DataAd
 
     private <U> void reportRequestDataMetrics(DataRequest request, Future<U> future) {
         List<Tag> tags;
-        if (request.getQuery() == null) {
+        if (request.getQuery() == null || request.getQuery().getRawQuery().isEmpty()) {
             tags = List.of();
         } else {
             tags = List.of(new ImmutableTag("query", request.getQuery().getRawQuery()));

--- a/src/test/java/io/neonbee/data/internal/metrics/DataVerticleMetricsImplTest.java
+++ b/src/test/java/io/neonbee/data/internal/metrics/DataVerticleMetricsImplTest.java
@@ -47,18 +47,18 @@ class DataVerticleMetricsImplTest extends DataVerticleTestBase {
                 .onSuccess(resp -> testContext.verify(() -> {
                     assertThat(resp.statusCode()).isEqualTo(200);
                     assertThat(resp.bodyAsString())
-                            .contains("request_data_timer_test_TestSourceDataVerticle_seconds_count{query=\"\",} ");
+                            .contains("request_data_timer_test_TestSourceDataVerticle_seconds_count ");
                     assertThat(resp.bodyAsString())
-                            .contains("request_data_timer_test_TestSourceDataVerticle_seconds_sum{query=\"\",} ");
+                            .contains("request_data_timer_test_TestSourceDataVerticle_seconds_sum ");
                     assertThat(resp.bodyAsString())
-                            .contains("request_data_timer_test_TestSourceDataVerticle_seconds_max{query=\"\",} ");
+                            .contains("request_data_timer_test_TestSourceDataVerticle_seconds_max ");
 
                     assertThat(resp.bodyAsString()).contains(
-                            "request_data_counter_test_TestSourceDataVerticle_total{query=\"\",succeeded=\"true\",} 1.0");
+                            "request_data_counter_test_TestSourceDataVerticle_total{succeeded=\"true\",} 1.0");
                     assertThat(resp.bodyAsString())
                             .contains("request_data_active_requests_test_TestSourceDataVerticle 0.0");
                     assertThat(resp.bodyAsString())
-                            .contains("request_counter_test_TestSourceDataVerticle_total{query=\"\",} 1.0");
+                            .contains("request_counter_test_TestSourceDataVerticle_total 1.0");
 
                     assertThat(resp.bodyAsString()).contains(
                             "retrieve_data_timer_DataVerticle_test_TestSourceDataVerticle__seconds_max{name=\"TestSourceDataVerticle\",namespace=\"test\",} ");


### PR DESCRIPTION
dynatrace logs the following warning when a Tag with a null or empty value is added:
Warning: null or empty dimension value passed to normalization. To avoid this warning, an additional check if the value is empty is added.