### PR TITLE
feat: introduce in-memory caching / request coalescing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,8 @@ dependencies {
 
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.7'
-    implementation group: 'com.google.guava', name: 'guava', version: '32.0.0-jre'
+    def guava_version = '32.0.0-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: guava_version
     implementation group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.7.3'
 
     // Compile only
@@ -92,6 +93,8 @@ dependencies {
     def truth_version = '1.1.3'
     testImplementation group: 'com.google.truth', name: 'truth', version: truth_version
     testImplementation group: 'com.google.truth.extensions', name: 'truth-java8-extension', version: truth_version
+
+    testImplementation group: 'com.google.guava', name: 'guava-testlib', version: guava_version
 
     def mockito_version = '5.1.1'
     testImplementation group: 'org.mockito', name: 'mockito-inline', version: mockito_version

--- a/src/main/java/io/neonbee/cache/BufferingDataVerticle.java
+++ b/src/main/java/io/neonbee/cache/BufferingDataVerticle.java
@@ -1,0 +1,102 @@
+package io.neonbee.cache;
+
+import static io.vertx.core.Future.succeededFuture;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
+
+import io.neonbee.data.DataContext;
+import io.neonbee.logging.LoggingFacade;
+import io.vertx.core.Future;
+
+/**
+ * This class extends the in-memory caching possibilities of the {@link CachingDataVerticle} by an arbitrary second
+ * stage buffering concept. E.g. storing data in a database or likewise. Caching being the most volatile form of storage
+ * it is first checked if the data is cached already, before attempting to read it from the buffer.
+ */
+public abstract class BufferingDataVerticle<T> extends CachingDataVerticle<T> {
+    private static final LoggingFacade LOGGER = LoggingFacade.create();
+
+    /**
+     * Initializes a {@link BufferingDataVerticle} with a refresh cache interval of 5 minutes by default and request
+     * coalescing turned on.
+     */
+    protected BufferingDataVerticle() {
+        super();
+    }
+
+    /**
+     * Initializes a {@link BufferingDataVerticle} with a custom refresh cache interval and request coalescing turned
+     * on.
+     *
+     * @param cacheLifetime refresh interval
+     * @param timeUnit      defines the time unit like seconds, minutes or hours
+     */
+    protected BufferingDataVerticle(long cacheLifetime, TimeUnit timeUnit) {
+        super(cacheLifetime, timeUnit);
+    }
+
+    /**
+     * Initializes a {@link BufferingDataVerticle} with a custom refresh cache interval and turning request coalescing
+     * on or off.
+     *
+     * @param cacheLifetime   cache lifetime
+     * @param timeUnit        defines the time unit like seconds, minutes or hours
+     * @param coalesceTimeout the timeout in milliseconds to wait for parallel requests, before attempting to receive
+     *                        data on our own. if set to 0 or lower, requests will not be coalesced
+     */
+    protected BufferingDataVerticle(long cacheLifetime, TimeUnit timeUnit, long coalesceTimeout) {
+        super(cacheLifetime, timeUnit, coalesceTimeout);
+    }
+
+    /**
+     * Read data from the buffer (after checking the in-memory cache was empty).
+     *
+     * @param cacheKey the cached key to read the data for
+     * @param context  the context the data should be read for
+     * @return a future to the buffered data or an empty future in case there is no data in the buffer
+     */
+    public abstract Future<T> readDataFromBuffer(Object cacheKey, DataContext context);
+
+    /**
+     * Write data to the buffer.
+     *
+     * @param <U>      any type
+     * @param cacheKey the cache key to write the data for
+     * @param data     the data to write
+     * @param context  the context in which the data was retrieved in
+     * @return any kind of future, note that the callee will only wait for this future to complete, but the result of
+     *         the future is neglected. this also allows for a "fire &amp; forget" strategy, if this method is returned
+     *         immediately with a succeeded future
+     */
+    public abstract <U> Future<U> writeDataToBuffer(Object cacheKey, T data, DataContext context);
+
+    @Override
+    protected Future<T> retrieveDataFromCache(Object cacheKey, DataContext context) {
+        return super.retrieveDataFromCache(cacheKey, context).compose(cachedData -> {
+            if (cachedData != null) {
+                return succeededFuture(cachedData);
+            }
+
+            // if data could not be read, treat it as if no data is in the buffer / falling back to retrieving the data
+            return readDataFromBuffer(cacheKey, context).onSuccess(data -> {
+                // in case data was buffered, also repopulate the in-memory cache
+                if (data != null) {
+                    putDataToCache(cacheKey, data);
+                }
+            }).onFailure(throwable -> {
+                // the only expected exception is a NoSuchElement exception, treat it as if no buffer entry exists
+                if (!(throwable instanceof NoSuchElementException)) {
+                    LOGGER.correlateWith(context).warn("Failed to read from buffer", throwable);
+                }
+            }).otherwiseEmpty();
+        });
+    }
+
+    @Override
+    protected <U> Future<U> retrievedDataToCache(Object cacheKey, T data, DataContext context) {
+        return writeDataToBuffer(cacheKey, data, context).onFailure(throwable -> {
+            LOGGER.correlateWith(context).warn("Failed to write to buffer", throwable);
+        }).mapEmpty(); // the result of this method anyways never influences the result
+    }
+}

--- a/src/main/java/io/neonbee/cache/CachingDataVerticle.java
+++ b/src/main/java/io/neonbee/cache/CachingDataVerticle.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -42,7 +43,7 @@ public abstract class CachingDataVerticle<T> extends DataVerticle<T> {
      * requests / queries. Thus use a cache map, correlating all caches by the implementation class of the verticle.
      */
     @VisibleForTesting
-    static final Map<Class<?>, Cache<Object, ?>> CACHES = new HashMap<>();
+    static final Map<Class<?>, Cache<Object, ?>> CACHES = new ConcurrentHashMap<>();
 
     private static final long DEFAULT_COALESCING_TIMEOUT = 10L * 1000;
 
@@ -262,7 +263,7 @@ public abstract class CachingDataVerticle<T> extends DataVerticle<T> {
 
                             // in case we do not coalesce requests, or we are the one who got the lock and thus
                             // "rightfully" retrieved the data, notify the retrievedDataToCache that we got new data,
-                            // however, neglect the the outcome and always return the data
+                            // however, neglect the outcome and always return the data
                             if (optionalCacheKey.isPresent() && (coalescingTimeout <= 0 || lock != null)) {
                                 return retrievedDataToCache(optionalCacheKey.get(), data, context)
                                         .map(data).otherwise(data);

--- a/src/main/java/io/neonbee/cache/CachingDataVerticle.java
+++ b/src/main/java/io/neonbee/cache/CachingDataVerticle.java
@@ -1,0 +1,374 @@
+package io.neonbee.cache;
+
+import static io.vertx.core.Future.succeededFuture;
+import static java.util.Collections.emptyList;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import io.neonbee.data.DataContext;
+import io.neonbee.data.DataMap;
+import io.neonbee.data.DataQuery;
+import io.neonbee.data.DataRequest;
+import io.neonbee.data.DataVerticle;
+import io.neonbee.internal.SharedDataAccessor;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.shareddata.Lock;
+
+/**
+ * An abstract class that you can extend to write a {@link DataVerticle} with a in-memory caching functionality.
+ *
+ * The usage and method signatures are the same as in a {@link DataVerticle} but instead of overriding
+ * {@link DataVerticle#requireData(DataQuery, DataContext)} and
+ * {@link DataVerticle#retrieveData(DataQuery, DataMap, DataContext)} you should implement
+ * {@link #requireDataForCaching(DataQuery, DataContext)} and
+ * {@link #retrieveDataToCache(DataQuery, DataMap, DataContext)}.
+ */
+public abstract class CachingDataVerticle<T> extends DataVerticle<T> {
+    /**
+     * If we have multiple instances of a single verticle, they should all share the same cache / coalesce on the same
+     * requests / queries. Thus use a cache map, correlating all caches by the implementation class of the verticle.
+     */
+    @VisibleForTesting
+    static final Map<Class<?>, Cache<Object, ?>> CACHES = new HashMap<>();
+
+    private static final long DEFAULT_COALESCING_TIMEOUT = 10L * 1000;
+
+    @SuppressWarnings("InlineFormatString")
+    private static final String COALESCING_LOCK_NAME = "#coalescing_%h"; // %h hashCode of the cacheKey
+
+    private final Cache<Object, T> cache;
+
+    private final Map<Object, T> cacheRegister = new HashMap<>();
+
+    private final long coalescingTimeout;
+
+    private SharedDataAccessor sharedDataAccessor;
+
+    /**
+     * Initializes a {@link CachingDataVerticle} with a cache lifetime of fife minutes and request coalescing.
+     */
+    @SuppressWarnings("checkstyle:MagicNumber")
+    protected CachingDataVerticle() {
+        this(5, TimeUnit.MINUTES);
+    }
+
+    /**
+     * Initializes a {@link CachingDataVerticle} with a custom cache lifetime and request coalescing.
+     *
+     * Note, in order to only use request coalescing without caching the data in the verticle, you can set the cache
+     * lifetime to a very small value, e.g. 1 second. This will result in the verticle coalescing requests to the same
+     * verticle only if they are made in parallel, however each subsequent request, will again trigger a new request.
+     *
+     * @param cacheLifetime cache lifetime
+     * @param timeUnit      defines the time unit like seconds, minutes or hours
+     */
+    protected CachingDataVerticle(long cacheLifetime, TimeUnit timeUnit) {
+        this(cacheLifetime, timeUnit, DEFAULT_COALESCING_TIMEOUT);
+    }
+
+    /**
+     * Initializes a {@link CachingDataVerticle} with a custom cache lifetime and optional request coalescing.
+     *
+     * @param cacheLifetime     cache lifetime
+     * @param timeUnit          defines the time unit like seconds, minutes or hours
+     * @param coalescingTimeout the timeout in milliseconds to wait for parallel requests, before attempting to receive
+     *                          data on our own. if set to 0 or lower, requests will not be coalesced
+     */
+    @SuppressWarnings("unchecked")
+    protected CachingDataVerticle(long cacheLifetime, TimeUnit timeUnit, long coalescingTimeout) {
+        super();
+        // we want to have every instance of the same verticle share the same cache / coalesce the same requests
+        cache = (Cache<Object, T>) CACHES.computeIfAbsent(getClass(), verticleClass -> {
+            return CacheBuilder.newBuilder().expireAfterWrite(cacheLifetime, timeUnit).build();
+        });
+        this.coalescingTimeout = coalescingTimeout;
+    }
+
+    @Override
+    public void init(Vertx vertx, Context context) {
+        super.init(vertx, context);
+
+        // we will only need to retrieve locks if we coalesce requests
+        if (coalescingTimeout > 0) {
+            sharedDataAccessor = new SharedDataAccessor(vertx, getClass());
+        }
+    }
+
+    /**
+     * Return a unique cache key. The cache key could be any object. In the default implementation of this method a
+     * tuple of the user principal and the query will be returned, which means every same query for one user will be
+     * cached.
+     *
+     * @param query   the query of the request
+     * @param context the context
+     * @return any object identifying the cached object
+     */
+    @VisibleForTesting
+    protected Future<Object> getCacheKey(DataQuery query, DataContext context) {
+        return succeededFuture(new CacheTuple(context.userPrincipal(), query));
+    }
+
+    /**
+     * Same as {@link DataVerticle#requireData(DataQuery query, DataContext context)} but if there is a cache entry for
+     * the request no data will actually be required and the cache result is returned from {@link #requireData}.
+     *
+     * @param query   The query describing the data requested
+     * @param context A context object passed through the whole data retrieving life cycle
+     * @return Future
+     */
+    @SuppressWarnings("PMD.UnusedFormalParameter")
+    public Future<Collection<DataRequest>> requireDataForCaching(DataQuery query, DataContext context) {
+        return succeededFuture(emptyList());
+    }
+
+    @Override
+    public final Future<Collection<DataRequest>> requireData(DataQuery query, DataContext context) {
+        return getCacheKey(query, context).compose(cacheKey -> {
+            // no cache key signals us, that this request should not get cached
+            if (cacheKey == null) {
+                return requireDataForCaching(query, context);
+            }
+
+            return retrieveDataFromCache(cacheKey, context).compose(cachedData -> {
+                // avoid unnecessary query processing in case of an available entry in the cache
+                if (cachedData != null) {
+                    // temporarily put the cached object into the volatile cacheRegister, so we can be sure it'll be
+                    // available in the retrieveData method, the object might be purged from the cache otherwise
+                    cacheRegister.put(cacheKey, cachedData);
+                    return succeededFuture(emptyList());
+                }
+
+                // otherwise require the data that the verticle needs for caching
+                return requireDataForCaching(query, context);
+            });
+        });
+    }
+
+    /**
+     * Returns the cached data for a given cache key.
+     *
+     * Note that this method might get overridden, in order to implement a multi-stage caching / buffering approach. Use
+     * {@link #getDataFromCache(Object)}, if you want to be sure to retrieve data from the in-memory cache instead.
+     *
+     * @param cacheKey the cache key to retrieve the cached data for
+     * @param context  the context the cacheKey was used in
+     * @return a future to the data, or an empty future, in case no data is cached
+     */
+    protected Future<T> retrieveDataFromCache(Object cacheKey, DataContext context) {
+        return succeededFuture(getDataFromCache(cacheKey));
+    }
+
+    /**
+     * Get data from the in-memory cache.
+     *
+     * @param cacheKey the cache key to get the data for if present
+     * @return the cached data or {@code null}, in case no data was cached
+     */
+    protected final T getDataFromCache(Object cacheKey) {
+        return cache.getIfPresent(cacheKey);
+    }
+
+    /**
+     * Put data into the in-memory cache.
+     *
+     * @param cacheKey the cache key to put into the cache
+     * @param data     the data to put into the cache
+     */
+    protected final void putDataToCache(Object cacheKey, T data) {
+        cache.put(cacheKey, data);
+    }
+
+    /**
+     * Purges the whole in-memory cache.
+     */
+    protected final void purgeDataFromCache() {
+        cache.invalidateAll();
+    }
+
+    /**
+     * Same as {@link DataVerticle#retrieveData(DataQuery query, DataContext context)} but if there is a cache entry for
+     * the request no data will actually be required/calculated and instead the cache result is returned. When there is
+     * no cache entry, a new one will be created.
+     *
+     * @see #retrieveData(DataQuery, DataMap, DataContext)
+     * @param query   The query describing the data requested
+     * @param require A map of the results required via {@link #requireData(DataQuery, DataContext)}
+     * @param context A context object passed through the whole data retrieving life cycle
+     * @return A future to the data requested
+     */
+    public abstract Future<T> retrieveDataToCache(DataQuery query, DataMap require, DataContext context);
+
+    @Override
+    public final Future<T> retrieveData(DataQuery query, DataMap require, DataContext context) {
+        return getCacheKey(query, context).map(Optional::ofNullable).compose(optionalCacheKey -> {
+            // when we do not get a cache key, skip the cache and do not coalesce any requests
+            Future<Lock> lockFuture = succeededFuture();
+            if (optionalCacheKey.isPresent()) {
+                Object cacheKey = optionalCacheKey.get();
+
+                // remove the cache data from the volatile cache register, if there is any we not need to retrieve it
+                T cachedData = cacheRegister.remove(cacheKey);
+                if (cachedData != null) {
+                    return succeededFuture(cachedData);
+                }
+
+                // in order to coalesce requests, wait until we receive a lock and check the cache again
+                if (coalescingTimeout > 0) {
+                    // note that the hash that is part of the lock name is unsafe, meaning that if there is a chance for
+                    // a hash collision. in this case two requests are coalesced / may wait for each other, even if they
+                    // do not share the same cache key. however the likelihood is small and the cache is still safe
+                    // because the data read from the cache will not be affected by the collision, so this is neglected
+                    lockFuture = sharedDataAccessor.getLocalLockWithTimeout(
+                            String.format(COALESCING_LOCK_NAME, cacheKey), coalescingTimeout);
+                }
+            }
+
+            // if we got the lock and the cache contains data, some other request already retrieved it already and we
+            // can coalesce the two requests by returning the data immediately. if the cache does not contain data yet,
+            // we are "responsible" for receiving it. if we did not get the lock (so lock == null), it either means we
+            // should not coalesce parallel requests, or we don't know who got the lock because the other process is
+            // taking too long to get the data, so in any case we will fall back requesting it on our own. to avoid a
+            // conflict with the original owner of the lock, we not call the retrievedDataToCache method afterwards
+            return lockFuture.otherwiseEmpty().compose(lock -> optionalCacheKey.map(cache::getIfPresent)
+                    .map(Future::succeededFuture).orElseGet(() -> {
+                        return retrieveDataToCache(query, require, context).compose(data -> {
+                            if (data == null) {
+                                return succeededFuture();
+                            }
+
+                            // if data was returned, cache it right now (always only into the in-memory cache, for a
+                            // multi-stage caching / buffering, the retrievedDataToCache can be utilized)
+                            optionalCacheKey.ifPresent(cacheKey -> cache.put(cacheKey, data));
+
+                            // if we have a lock, we can already release it right here, as other waiting verticles check
+                            // the cache right after. this is a small potential time safe, as the other requests will
+                            // not have to wait for the retrievedDataToCache future to complete
+                            if (lock != null) {
+                                lock.release();
+                            }
+
+                            // in case we do not coalesce requests, or we are the one who got the lock and thus
+                            // "rightfully" retrieved the data, notify the retrievedDataToCache that we got new data,
+                            // however, neglect the the outcome and always return the data
+                            if (optionalCacheKey.isPresent() && (coalescingTimeout <= 0 || lock != null)) {
+                                return retrievedDataToCache(optionalCacheKey.get(), data, context)
+                                        .map(data).otherwise(data);
+                            }
+
+                            // if we did not retrieve the lock in the first place, we cannot know when the future that
+                            // got the lock completes, so better *not* execute the retrievedDataToCache method, in order
+                            // to prevent any conflict / race condition with the owner of the lock
+                            return succeededFuture(data);
+                        });
+                    }).onComplete(result -> {
+                        if (lock != null) {
+                            lock.release(); // safety-safe, or if data was cached in the meantime!
+                        }
+                    })).compose(data -> filterDataFromCache(query, data, context));
+        });
+    }
+
+    /**
+     * This method is called whenever new data was stored in the cache. Note that the result of the returned future will
+     * have no impact, on the result of the call that cached the data, other than that the call that made the request
+     * will wait for the future to complete. In order to optimize performance, this call should return immediately with
+     * a succeeded future, in order to implement a "fire &amp; forget" strategy.
+     *
+     * By default this method does nothing, it may be used in order to provide multi-level caching, e.g. by storing it
+     * on the database, in addition to storing it in the in-memory cache of the {@link CachingDataVerticle}.
+     *
+     * This method will never be called for queries that {@link #getCacheKey(DataQuery, DataContext)} returned a
+     * {@code null} value.
+     *
+     * @param <U>      any type
+     * @param cacheKey the key the data should be cached for
+     * @param data     the data that should be cached
+     * @param context  the context the data was retrieved in
+     * @return any future, signaling completion of the operation
+     */
+    protected <U> Future<U> retrievedDataToCache(Object cacheKey, T data, DataContext context) {
+        return succeededFuture();
+    }
+
+    /**
+     * A method that can be used to based on the query / context filter the data before it is being returned from cache
+     * or from the {@link #retrieveDataToCache(DataQuery, DataMap, DataContext)} method. The filter does not influence
+     * what data is being cached, so when the data is read from cache based on the {@code cacheKey} it might still
+     * contain data that is not returned by the verticle, after being processed by this method.
+     *
+     * @param query   the query to filter the data by
+     * @param data    the data to filter
+     * @param context the context in which to filter the data
+     * @return the data to return from the verticle
+     */
+    protected Future<T> filterDataFromCache(DataQuery query, T data, DataContext context) {
+        return succeededFuture(data);
+    }
+
+    /**
+     * The {@link CacheTuple} is the default {@code cacheKey} used by the {@link CachingDataVerticle} and can be used to
+     * combine multiple objects of any type.
+     */
+    public static class CacheTuple {
+        private final List<Object> values;
+
+        /**
+         * Creates a {@link CacheTuple} with any number of values.
+         *
+         * @param values the values of the tuple
+         */
+        public CacheTuple(Object... values) {
+            this.values = Collections.unmodifiableList(Arrays.asList(values));
+        }
+
+        /**
+         * Return a single tuple value.
+         *
+         * @param <T>   the type of the tuple value
+         * @param index the index of the tuple value to return
+         * @return the value of the tuple at that index
+         */
+        @SuppressWarnings("unchecked")
+        public <T> T get(int index) {
+            return (T) values.get(index);
+        }
+
+        /**
+         * Return the size of the tuple.
+         *
+         * @return the size of the tuple
+         */
+        public int size() {
+            return values.size();
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            if (object == this) {
+                return true;
+            } else if (!(object instanceof CacheTuple)) {
+                return false;
+            }
+
+            return values.equals(((CacheTuple) object).values);
+        }
+
+        @Override
+        public int hashCode() {
+            return values.hashCode();
+        }
+    }
+}

--- a/src/main/java/io/neonbee/hook/HookRegistration.java
+++ b/src/main/java/io/neonbee/hook/HookRegistration.java
@@ -30,7 +30,7 @@ public interface HookRegistration {
     /**
      * Unregister the hook.
      *
-     * @return A future that is succeed if the the hook was successfully undeployed, otherwise a failed future.
+     * @return A future that is succeed if the hook was successfully undeployed, otherwise a failed future.
      */
     Future<Void> unregister();
 }

--- a/src/test/java/io/neonbee/cache/BufferingDataVerticleTest.java
+++ b/src/test/java/io/neonbee/cache/BufferingDataVerticleTest.java
@@ -1,0 +1,189 @@
+package io.neonbee.cache;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import io.neonbee.data.DataContext;
+import io.neonbee.data.DataMap;
+import io.neonbee.data.DataQuery;
+import io.neonbee.data.DataRequest;
+import io.neonbee.test.base.DataVerticleTestBase;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+
+@Execution(ExecutionMode.SAME_THREAD)
+class BufferingDataVerticleTest extends DataVerticleTestBase {
+    AtomicInteger requireDataCount = new AtomicInteger();
+
+    AtomicInteger retrieveDataCount = new AtomicInteger();
+
+    AtomicInteger readDataFromBufferCount = new AtomicInteger();
+
+    AtomicInteger writeDataToBufferCount = new AtomicInteger();
+
+    AtomicBoolean delayResponse = new AtomicBoolean();
+
+    AtomicBoolean respondFromBuffer = new AtomicBoolean();
+
+    BufferingDataVerticle<String> testVerticle;
+
+    DataRequest dr;
+
+    @BeforeEach
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    void reset(VertxTestContext testContext) {
+        CachingDataVerticle.CACHES.clear();
+        requireDataCount.set(0);
+        retrieveDataCount.set(0);
+        readDataFromBufferCount.set(0);
+        writeDataToBufferCount.set(0);
+        delayResponse.set(false);
+        respondFromBuffer.set(false);
+        deployVerticle(testVerticle = new BufferingDataVerticle<>(500, TimeUnit.MILLISECONDS) {
+            @Override
+            public String getName() {
+                return "TestBufferVerticle";
+            }
+
+            @Override
+            protected Future<Object> getCacheKey(DataQuery query, DataContext context) {
+                return Future.succeededFuture("OK");
+            }
+
+            @Override
+            public Future<Collection<DataRequest>> requireDataForCaching(DataQuery query, DataContext context) {
+                requireDataCount.incrementAndGet();
+                return Future.succeededFuture(List.of());
+            }
+
+            @Override
+            public Future<String> retrieveDataToCache(DataQuery query, DataMap require, DataContext context) {
+                retrieveDataCount.incrementAndGet();
+                Promise<Long> delayPromise = Promise.promise();
+                if (delayResponse.get()) {
+                    vertx.setTimer(100, delayPromise::complete);
+                } else {
+                    delayPromise.complete();
+                }
+                return delayPromise.future().map("Test");
+            }
+
+            @Override
+            public Future<String> readDataFromBuffer(Object cacheKey, DataContext context) {
+                readDataFromBufferCount.incrementAndGet();
+                return Future.succeededFuture(respondFromBuffer.get() ? "Test2" : null); // NOPMD
+            }
+
+            @Override
+            public <U> Future<U> writeDataToBuffer(Object cacheKey, String data, DataContext context) {
+                writeDataToBufferCount.incrementAndGet();
+                return Future.succeededFuture();
+            }
+        }).onSuccess(any -> {
+            dr = new DataRequest(testVerticle.getName());
+        }).onComplete(testContext.succeedingThenComplete());
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("Expect another read from buffer after expiry")
+    void expectReadFromBuffer(Vertx vertx, VertxTestContext testContext) {
+        requestData(dr)
+                .onComplete(testContext.succeeding(v -> testContext.verify(() -> {
+                    assertThat(requireDataCount.get()).isEqualTo(1);
+                    assertThat(retrieveDataCount.get()).isEqualTo(1);
+                    assertThat(readDataFromBufferCount.get()).isEqualTo(1);
+                    assertThat(writeDataToBufferCount.get()).isEqualTo(1);
+                }))).compose(id -> requestData(dr))
+                .onComplete(testContext.succeeding(v -> testContext.verify(() -> {
+                    assertThat(requireDataCount.get()).isEqualTo(1);
+                    assertThat(retrieveDataCount.get()).isEqualTo(1);
+                    assertThat(readDataFromBufferCount.get()).isEqualTo(1);
+                    assertThat(writeDataToBufferCount.get()).isEqualTo(1);
+                }))).compose(id -> Future.future(promise -> vertx.setTimer(750, promise::complete)))
+                .compose(id -> requestData(dr))
+                .onComplete(testContext.succeeding(v -> testContext.verify(() -> {
+                    assertThat(requireDataCount.get()).isEqualTo(2);
+                    assertThat(retrieveDataCount.get()).isEqualTo(2);
+                    assertThat(readDataFromBufferCount.get()).isEqualTo(2);
+                    assertThat(writeDataToBufferCount.get()).isEqualTo(2);
+                })))
+                .onComplete(testContext.succeedingThenComplete());
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("Expect only one write to buffer on two parallel requests")
+    void expectOneWriteToBuffer(Vertx vertx, VertxTestContext testContext) {
+        delayResponse.set(true);
+        CompositeFuture.all(requestData(dr), requestData(dr))
+                .onComplete(testContext.succeeding(v -> testContext.verify(() -> {
+                    assertThat(requireDataCount.get()).isEqualTo(2);
+                    assertThat(retrieveDataCount.get()).isEqualTo(1);
+                    assertThat(readDataFromBufferCount.get()).isEqualTo(2);
+                    assertThat(writeDataToBufferCount.get()).isEqualTo(1);
+                })))
+                .onComplete(testContext.succeedingThenComplete());
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("Expect no retrieve data in case data is in buffer")
+    void expectOneReadFromBuffer(Vertx vertx, VertxTestContext testContext) {
+        respondFromBuffer.set(true);
+        delayResponse.set(true);
+        CompositeFuture.all(requestData(dr), requestData(dr))
+                .onComplete(testContext.succeeding(v -> testContext.verify(() -> {
+                    assertThat(requireDataCount.get()).isEqualTo(0);
+                    assertThat(retrieveDataCount.get()).isEqualTo(0);
+                    assertThat(readDataFromBufferCount.get()).isEqualTo(1);
+                    assertThat(writeDataToBufferCount.get()).isEqualTo(0);
+
+                    delayResponse.set(false);
+                }))).compose(id -> requestData(dr))
+                .onComplete(testContext.succeeding(v -> testContext.verify(() -> {
+                    assertThat(requireDataCount.get()).isEqualTo(0);
+                    assertThat(retrieveDataCount.get()).isEqualTo(0);
+                    assertThat(readDataFromBufferCount.get()).isEqualTo(1);
+                    assertThat(writeDataToBufferCount.get()).isEqualTo(0);
+                }))).compose(id -> Future.future(promise -> vertx.setTimer(750, promise::complete)))
+                .compose(id -> requestData(dr))
+                .onComplete(testContext.succeeding(v -> testContext.verify(() -> {
+                    assertThat(requireDataCount.get()).isEqualTo(0);
+                    assertThat(retrieveDataCount.get()).isEqualTo(0);
+                    assertThat(readDataFromBufferCount.get()).isEqualTo(2);
+                    assertThat(writeDataToBufferCount.get()).isEqualTo(0);
+
+                    respondFromBuffer.set(false);
+                }))).compose(id -> requestData(dr))
+                .onComplete(testContext.succeeding(v -> testContext.verify(() -> {
+                    assertThat(requireDataCount.get()).isEqualTo(0);
+                    assertThat(retrieveDataCount.get()).isEqualTo(0);
+                    assertThat(readDataFromBufferCount.get()).isEqualTo(2);
+                    assertThat(writeDataToBufferCount.get()).isEqualTo(0);
+                }))).compose(id -> Future.future(promise -> vertx.setTimer(750, promise::complete)))
+                .compose(id -> requestData(dr))
+                .onComplete(testContext.succeeding(v -> testContext.verify(() -> {
+                    assertThat(requireDataCount.get()).isEqualTo(1);
+                    assertThat(retrieveDataCount.get()).isEqualTo(1);
+                    assertThat(readDataFromBufferCount.get()).isEqualTo(3);
+                    assertThat(writeDataToBufferCount.get()).isEqualTo(1);
+                })))
+                .onComplete(testContext.succeedingThenComplete());
+    }
+}

--- a/src/test/java/io/neonbee/cache/CachingDataVerticleTest.java
+++ b/src/test/java/io/neonbee/cache/CachingDataVerticleTest.java
@@ -92,14 +92,6 @@ class CachingDataVerticleTest extends DataVerticleTestBase {
     }
 
     static class MyCachingVerticle extends CachingDataVerticle<String> {
-        MyCachingVerticle() {
-            super();
-        }
-
-        MyCachingVerticle(long refreshInterval, TimeUnit timeUnit) {
-            super(refreshInterval, timeUnit);
-        }
-
         @Override
         public Future<String> retrieveDataToCache(DataQuery query, DataMap require, DataContext context) {
             return Future.succeededFuture("SUCCESS");

--- a/src/test/java/io/neonbee/cache/CachingDataVerticleTest.java
+++ b/src/test/java/io/neonbee/cache/CachingDataVerticleTest.java
@@ -1,0 +1,301 @@
+package io.neonbee.cache;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.testing.EqualsTester;
+
+import io.neonbee.cache.CachingDataVerticle.CacheTuple;
+import io.neonbee.data.DataContext;
+import io.neonbee.data.DataMap;
+import io.neonbee.data.DataQuery;
+import io.neonbee.data.DataRequest;
+import io.neonbee.test.base.DataVerticleTestBase;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Checkpoint;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+
+class CachingDataVerticleTest extends DataVerticleTestBase {
+    @BeforeEach
+    void reset() {
+        CachingDataVerticle.CACHES.clear();
+    }
+
+    @Test
+    @DisplayName("Should compute an unique but deterministic cache key with the default implementation")
+    void getCacheKeyTest() {
+        CachingDataVerticle<JsonArray> testVerticle = new CachingDataVerticle<>() {
+            @Override
+            public String getName() {
+                return "TestCachingVerticle";
+            }
+
+            @Override
+            public Future<Collection<DataRequest>> requireDataForCaching(DataQuery query, DataContext context) {
+                return null;
+            }
+
+            @Override
+            public Future<JsonArray> retrieveDataToCache(DataQuery query, DataMap require, DataContext context) {
+                return null;
+            }
+        };
+
+        DataContext context = mock(DataContext.class);
+        JsonObject userPrincipal = new JsonObject().put("user_name", "Lord Citrange");
+        when(context.userPrincipal()).thenReturn(userPrincipal);
+
+        DataContext context2 = mock(DataContext.class);
+        JsonObject userPrincipal2 = new JsonObject().put("user_name", "Lord Citrange");
+        when(context.userPrincipal()).thenReturn(userPrincipal2);
+
+        // Check that the ID changes with a different query and same with the same query
+        Object got1 = testVerticle.getCacheKey(new DataQuery(), context).result();
+        assertThat(got1).isEqualTo(testVerticle.getCacheKey(new DataQuery(), context).result());
+        assertThat(got1).isNotEqualTo(testVerticle.getCacheKey(new DataQuery(), context2).result());
+
+        Object got2 = testVerticle.getCacheKey(new DataQuery("/some/path"), context).result();
+        assertThat(got2).isNotEqualTo(got1);
+        assertThat(got2).isEqualTo(testVerticle.getCacheKey(new DataQuery("/some/path"), context).result());
+        assertThat(got2).isNotEqualTo(testVerticle.getCacheKey(new DataQuery("/some/path"), context2).result());
+
+        Object got3 = testVerticle.getCacheKey(new DataQuery().setParameter("foo", "bar"), context).result();
+        assertThat(got3).isNotEqualTo(got1);
+        assertThat(got3).isNotEqualTo(got2);
+        assertThat(got3)
+                .isEqualTo(testVerticle.getCacheKey(new DataQuery().setParameter("foo", "bar"), context).result());
+        assertThat(got3)
+                .isNotEqualTo(testVerticle.getCacheKey(new DataQuery().setParameter("foo", "bar"), context2).result());
+
+        JsonObject body = new JsonObject();
+        Object got4 = testVerticle.getCacheKey(new DataQuery().setBody(body.toBuffer()), context).result();
+        assertThat(got4).isNotEqualTo(got1);
+        assertThat(got4).isNotEqualTo(got2);
+        assertThat(got4).isNotEqualTo(got3);
+        assertThat(got4)
+                .isEqualTo(testVerticle.getCacheKey(new DataQuery().setBody(body.toBuffer()), context).result());
+        assertThat(got4)
+                .isNotEqualTo(testVerticle.getCacheKey(new DataQuery().setBody(body.toBuffer()), context2).result());
+    }
+
+    static class MyCachingVerticle extends CachingDataVerticle<String> {
+        MyCachingVerticle() {
+            super();
+        }
+
+        MyCachingVerticle(long refreshInterval, TimeUnit timeUnit) {
+            super(refreshInterval, timeUnit);
+        }
+
+        @Override
+        public Future<String> retrieveDataToCache(DataQuery query, DataMap require, DataContext context) {
+            return Future.succeededFuture("SUCCESS");
+        }
+
+        @Override
+        public String getName() {
+            return "MY_CACHING_TEST";
+        }
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("requireData should call requireDataBeforeCache on cache miss")
+    void requireDataRequiresDataOnCacheMiss(VertxTestContext testContext) {
+        Checkpoint requireCheckpoint = testContext.checkpoint();
+        Checkpoint retrieveCheckpoint = testContext.checkpoint();
+
+        CachingDataVerticle<JsonArray> testClass = new CachingDataVerticle<>() {
+            @Override
+            public String getName() {
+                return "TestCachingVerticle";
+            }
+
+            @Override
+            public Future<Collection<DataRequest>> requireDataForCaching(DataQuery query, DataContext context) {
+                requireCheckpoint.flag();
+                return Future.succeededFuture(List.of());
+            }
+
+            @Override
+            public Future<JsonArray> retrieveDataToCache(DataQuery query, DataMap require, DataContext context) {
+                retrieveCheckpoint.flag();
+                return Future.succeededFuture();
+            }
+        };
+        deployVerticle(testClass).compose(s -> assertData(requestData(new DataRequest(testClass.getName())), resp -> {
+            // When the request returned the cachedData methods should already be called
+            // don't wait for a timeout if not and fail immediately
+            if (!testContext.completed()) {
+                testContext.failNow(new Throwable("CachedData methods not called"));
+            }
+        }, testContext));
+    }
+
+    @Test
+    void testCacheTupleEquals() {
+        CacheTuple t = new CacheTuple("foo", "bar", "bla");
+        CacheTuple t2 = new CacheTuple("foo", "bar", "bla");
+        new EqualsTester().addEqualityGroup(t).testEquals();
+        assertThat(t).isEqualTo(t2);
+    }
+
+    @Test
+    void testRequireDataBeforeCacheIsEmpty() {
+        MyCachingVerticle v = new MyCachingVerticle();
+        assertThat(v.requireDataForCaching(null, null).result()).isEmpty();
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("Neither requireDataBeforeCache nor retrieveDataToCache should be called on cache hit")
+    void dontCallDataOnCacheHit(VertxTestContext testContext) {
+        JsonArray expected = new JsonArray(List.of(1, 1));
+
+        CachingDataVerticle<JsonArray> testClass = new CachingDataVerticle<>() {
+            int requireCallCounter;
+
+            int retrieveCallCounter;
+
+            @Override
+            public String getName() {
+                return "TestCachingVerticle";
+            }
+
+            @Override
+            public Future<Collection<DataRequest>> requireDataForCaching(DataQuery query, DataContext context) {
+                if (requireCallCounter++ > 0) {
+                    testContext.failNow(new Throwable("requireDataBeforeCache should only be called once"));
+                }
+                return Future.succeededFuture(List.of());
+            }
+
+            @Override
+            public Future<JsonArray> retrieveDataToCache(DataQuery query, DataMap require, DataContext context) {
+                if (retrieveCallCounter++ > 0) {
+                    testContext.failNow(new Throwable("retrieveDataToCache should only be called once"));
+                }
+                return Future.succeededFuture(new JsonArray(List.of(requireCallCounter, retrieveCallCounter)));
+            }
+        };
+
+        DataRequest dr = new DataRequest(testClass.getName());
+        deployVerticle(testClass).compose(id -> assertDataEquals(requestData(dr), expected, testContext))
+                .onComplete(testContext.succeeding(v ->
+                // Request *again* and check response is the cached one
+                assertDataEquals(requestData(dr), expected, testContext)))
+                .onComplete(testContext.succeedingThenComplete());
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("Multiple parallel request should be coalesced into one request, if no data is in the cache")
+    void coalescedMultipleParallelRequests(VertxTestContext testContext) {
+        CachingDataVerticle<Integer> testClass = new CachingDataVerticle<>() {
+            int retrieveCallCounter;
+
+            @Override
+            public String getName() {
+                return "TestCachingVerticle";
+            }
+
+            @Override
+            public Future<Collection<DataRequest>> requireDataForCaching(DataQuery query, DataContext context) {
+                return Future.succeededFuture(List.of());
+            }
+
+            @Override
+            public Future<Integer> retrieveDataToCache(DataQuery query, DataMap require, DataContext context) {
+                retrieveCallCounter++;
+                return Future.future(promise -> vertx.setTimer(100, promise::complete))
+                        .map(timerId -> retrieveCallCounter);
+            }
+        };
+
+        DataRequest dr = new DataRequest(testClass.getName());
+        deployVerticle(testClass)
+                .compose(id -> CompositeFuture.all(assertDataEquals(requestData(dr), 1, testContext),
+                        assertDataEquals(requestData(dr), 1, testContext)))
+                .onComplete(testContext.succeedingThenComplete());
+    }
+
+    @Test
+    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("Multiple requests should not be coalesced into one request, if no data is in the cache and coalescing is turned off")
+    void doNotCoalescedMultipleParallelRequests(VertxTestContext testContext) {
+        CachingDataVerticle<Integer> testClass = new CachingDataVerticle<>(10, TimeUnit.SECONDS, 0) {
+            int retrieveCallCounter;
+
+            @Override
+            public String getName() {
+                return "TestCachingVerticle";
+            }
+
+            @Override
+            public Future<Collection<DataRequest>> requireDataForCaching(DataQuery query, DataContext context) {
+                return Future.succeededFuture(List.of());
+            }
+
+            @Override
+            public Future<Integer> retrieveDataToCache(DataQuery query, DataMap require, DataContext context) {
+                retrieveCallCounter++;
+                return Future.future(promise -> vertx.setTimer(100, promise::complete))
+                        .map(timerId -> retrieveCallCounter);
+            }
+        };
+
+        DataRequest dr = new DataRequest(testClass.getName());
+        deployVerticle(testClass)
+                .compose(id -> CompositeFuture.all(assertDataEquals(requestData(dr), 2, testContext),
+                        assertDataEquals(requestData(dr), 2, testContext)))
+                .onComplete(testContext.succeeding(v ->
+                // Once the data is buffered though, and we *again* do a request and check response is the cached one
+                assertDataEquals(requestData(dr), 2, testContext)))
+                .onComplete(testContext.succeedingThenComplete());
+    }
+
+    @Test
+    @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("If multiple parallel requests should be coalesced into one request and the request takes too long, it should trigger another request anyways, if no data is in the cache")
+    void coalescedMultipleParallelRequestsFallback(VertxTestContext testContext) {
+        CachingDataVerticle<Integer> testClass = new CachingDataVerticle<>(5, TimeUnit.MINUTES, 1000) {
+            int retrieveCallCounter;
+
+            @Override
+            public String getName() {
+                return "TestCachingVerticle";
+            }
+
+            @Override
+            public Future<Collection<DataRequest>> requireDataForCaching(DataQuery query, DataContext context) {
+                return Future.succeededFuture(List.of());
+            }
+
+            @Override
+            public Future<Integer> retrieveDataToCache(DataQuery query, DataMap require, DataContext context) {
+                return Future.future(
+                        promise -> vertx.setTimer(retrieveCallCounter++ == 0 ? 2000 : 100, promise::complete))
+                        .map(timerId -> retrieveCallCounter);
+            }
+        };
+
+        DataRequest dr = new DataRequest(testClass.getName());
+        deployVerticle(testClass)
+                .compose(id -> CompositeFuture.all(assertDataEquals(requestData(dr), 2, testContext),
+                        assertDataEquals(requestData(dr), 2, testContext)))
+                .onComplete(testContext.succeedingThenComplete());
+    }
+}


### PR DESCRIPTION
This change introduces a in-memory caching concept for DataVerticle, as well as an option to coalesce same requests sent to a verticle in parallel. The new CachingDataVerticle allows to define an arbitrary cacheKey that is used to store responses received by the DataVerticle in-memory. The next time data with the same cacheKey is requested, neither the required data verticles, nor the original requireData method is being invoked. Instead the data is returned straight from the in-memory cache. This also allows for request coalescing, meaning that if multiple requests are sent to the verticle with the same cacheKey at the same time, the verticle will only do one call to requestData and return the data straight from cache for the other request instead.