### PR TITLE
fix: removed Timout annotations

### DIFF
--- a/src/test/java/io/neonbee/cache/BufferingDataVerticleTest.java
+++ b/src/test/java/io/neonbee/cache/BufferingDataVerticleTest.java
@@ -23,7 +23,6 @@ import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
 @Execution(ExecutionMode.SAME_THREAD)
@@ -45,7 +44,6 @@ class BufferingDataVerticleTest extends DataVerticleTestBase {
     DataRequest dr;
 
     @BeforeEach
-    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     void reset(VertxTestContext testContext) {
         CachingDataVerticle.CACHES.clear();
         requireDataCount.set(0);
@@ -100,7 +98,6 @@ class BufferingDataVerticleTest extends DataVerticleTestBase {
     }
 
     @Test
-    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Expect another read from buffer after expiry")
     void expectReadFromBuffer(Vertx vertx, VertxTestContext testContext) {
         requestData(dr)
@@ -127,7 +124,6 @@ class BufferingDataVerticleTest extends DataVerticleTestBase {
     }
 
     @Test
-    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Expect only one write to buffer on two parallel requests")
     void expectOneWriteToBuffer(Vertx vertx, VertxTestContext testContext) {
         delayResponse.set(true);
@@ -142,7 +138,6 @@ class BufferingDataVerticleTest extends DataVerticleTestBase {
     }
 
     @Test
-    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Expect no retrieve data in case data is in buffer")
     void expectOneReadFromBuffer(Vertx vertx, VertxTestContext testContext) {
         respondFromBuffer.set(true);

--- a/src/test/java/io/neonbee/cache/CachingDataVerticleTest.java
+++ b/src/test/java/io/neonbee/cache/CachingDataVerticleTest.java
@@ -25,7 +25,6 @@ import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.Checkpoint;
-import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
 class CachingDataVerticleTest extends DataVerticleTestBase {
@@ -104,7 +103,6 @@ class CachingDataVerticleTest extends DataVerticleTestBase {
     }
 
     @Test
-    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("requireData should call requireDataBeforeCache on cache miss")
     void requireDataRequiresDataOnCacheMiss(VertxTestContext testContext) {
         Checkpoint requireCheckpoint = testContext.checkpoint();
@@ -152,7 +150,6 @@ class CachingDataVerticleTest extends DataVerticleTestBase {
     }
 
     @Test
-    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Neither requireDataBeforeCache nor retrieveDataToCache should be called on cache hit")
     void dontCallDataOnCacheHit(VertxTestContext testContext) {
         JsonArray expected = new JsonArray(List.of(1, 1));
@@ -193,7 +190,6 @@ class CachingDataVerticleTest extends DataVerticleTestBase {
     }
 
     @Test
-    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Multiple parallel request should be coalesced into one request, if no data is in the cache")
     void coalescedMultipleParallelRequests(VertxTestContext testContext) {
         CachingDataVerticle<Integer> testClass = new CachingDataVerticle<>() {
@@ -225,7 +221,6 @@ class CachingDataVerticleTest extends DataVerticleTestBase {
     }
 
     @Test
-    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("Multiple requests should not be coalesced into one request, if no data is in the cache and coalescing is turned off")
     void doNotCoalescedMultipleParallelRequests(VertxTestContext testContext) {
         CachingDataVerticle<Integer> testClass = new CachingDataVerticle<>(10, TimeUnit.SECONDS, 0) {
@@ -260,7 +255,6 @@ class CachingDataVerticleTest extends DataVerticleTestBase {
     }
 
     @Test
-    @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
     @DisplayName("If multiple parallel requests should be coalesced into one request and the request takes too long, it should trigger another request anyways, if no data is in the cache")
     void coalescedMultipleParallelRequestsFallback(VertxTestContext testContext) {
         CachingDataVerticle<Integer> testClass = new CachingDataVerticle<>(5, TimeUnit.MINUTES, 1000) {

--- a/src/test/java/io/neonbee/endpoint/health/HealthEndpointTest.java
+++ b/src/test/java/io/neonbee/endpoint/health/HealthEndpointTest.java
@@ -4,7 +4,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.util.stream.Collectors.toList;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.DisplayName;
@@ -15,7 +14,6 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.HttpResponse;
-import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
 class HealthEndpointTest extends NeonBeeTestBase {
@@ -46,7 +44,6 @@ class HealthEndpointTest extends NeonBeeTestBase {
     }
 
     @Test
-    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("should only return health info of passed check")
     void testHealthEndpointSingle(VertxTestContext testContext) {
         createRequest(HttpMethod.GET, "/health/os.memory")

--- a/src/test/java/io/neonbee/endpoint/health/StatusEndpointTest.java
+++ b/src/test/java/io/neonbee/endpoint/health/StatusEndpointTest.java
@@ -2,21 +2,17 @@ package io.neonbee.endpoint.health;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.util.concurrent.TimeUnit;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import io.neonbee.test.base.NeonBeeTestBase;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
-import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
 class StatusEndpointTest extends NeonBeeTestBase {
 
     @Test
-    @Timeout(value = 2, timeUnit = TimeUnit.SECONDS)
     @DisplayName("should return health info of the default checks")
     void testHealthEndpointData(VertxTestContext testContext) {
         createRequest(HttpMethod.GET, "/status").send(testContext.succeeding(response -> testContext.verify(() -> {


### PR DESCRIPTION
The timeouts for unit tests are controlled via the environment, see [1].

[1] https://github.com/SAP/neonbee/commit/02d22528