### PR TITLE
feat: bump Vert.x to 4.4.3 and deprecate joinComposite and allComposite

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 
 dependencies {
     // Framework dependencies
-    def vertx_version = '4.4.2'
+    def vertx_version = '4.4.3'
     implementation group: 'io.vertx', name: 'vertx-core', version: vertx_version
     implementation group: 'io.vertx', name: 'vertx-web', version: vertx_version
     implementation group: 'io.vertx', name: 'vertx-web-client', version: vertx_version

--- a/src/main/java/io/neonbee/endpoint/odatav4/internal/olingo/processor/BatchProcessor.java
+++ b/src/main/java/io/neonbee/endpoint/odatav4/internal/olingo/processor/BatchProcessor.java
@@ -1,6 +1,5 @@
 package io.neonbee.endpoint.odatav4.internal.olingo.processor;
 
-import static io.neonbee.internal.helper.AsyncHelper.allComposite;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 
 import java.io.InputStream;
@@ -23,6 +22,7 @@ import org.apache.olingo.server.api.deserializer.batch.BatchRequestPart;
 import org.apache.olingo.server.api.deserializer.batch.ODataResponsePart;
 import org.apache.olingo.server.api.serializer.BatchSerializerException;
 
+import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.RoutingContext;
@@ -67,7 +67,7 @@ public class BatchProcessor extends AsynchronousProcessor
         }
 
         // wrap up the batch processing here, which will complete the current processing phase
-        allComposite(wrapUpBatchProcessing()).onComplete(resultHandler -> {
+        Future.all(wrapUpBatchProcessing()).onComplete(resultHandler -> {
             if (resultHandler.failed()) {
                 processPromise.fail(resultHandler.cause());
                 return;

--- a/src/main/java/io/neonbee/endpoint/odatav4/internal/olingo/processor/EntityExpander.java
+++ b/src/main/java/io/neonbee/endpoint/odatav4/internal/olingo/processor/EntityExpander.java
@@ -2,7 +2,6 @@ package io.neonbee.endpoint.odatav4.internal.olingo.processor;
 
 import static io.neonbee.endpoint.odatav4.internal.olingo.processor.NavigationPropertyHelper.fetchReferencedEntities;
 import static io.neonbee.endpoint.odatav4.internal.olingo.processor.NavigationPropertyHelper.getRelatedEntities;
-import static io.neonbee.internal.helper.AsyncHelper.allComposite;
 import static io.vertx.core.Future.succeededFuture;
 import static java.util.stream.Collectors.toList;
 
@@ -53,7 +52,7 @@ public final class EntityExpander {
                 return fetchReferencedEntities(navProb, vertx, routingContext)
                         .map(entities -> fetchedEntities.put(navProb.getType(), entities));
             }).collect(toList());
-            return allComposite(fetchFutures).map(v -> new EntityExpander(navigationProperties, fetchedEntities));
+            return Future.all(fetchFutures).map(v -> new EntityExpander(navigationProperties, fetchedEntities));
         } else {
             return succeededFuture(new EntityExpander(List.of(), Map.of()));
         }

--- a/src/main/java/io/neonbee/entity/EntityVerticle.java
+++ b/src/main/java/io/neonbee/entity/EntityVerticle.java
@@ -2,7 +2,6 @@ package io.neonbee.entity;
 
 import static io.neonbee.entity.EntityModelManager.EVENT_BUS_MODELS_LOADED_ADDRESS;
 import static io.neonbee.entity.EntityModelManager.getBufferedOData;
-import static io.neonbee.internal.helper.AsyncHelper.allComposite;
 import static io.neonbee.internal.helper.StringHelper.EMPTY;
 import static io.neonbee.internal.verticle.ConsolidationVerticle.ENTITY_TYPE_NAME_HEADER;
 import static io.vertx.core.Future.failedFuture;
@@ -276,7 +275,7 @@ public abstract class EntityVerticle extends DataVerticle<EntityWrapper> {
                     List<Future<Void>> announceFutures =
                             entityTypeNames.stream().map(EntityVerticle::sharedEntityMapName)
                                     .map(name -> announceOrConceal.apply(name)).collect(toList());
-                    return allComposite(announceFutures).mapEmpty();
+                    return Future.all(announceFutures).mapEmpty();
                 });
     }
 

--- a/src/main/java/io/neonbee/hook/internal/DefaultHookRegistry.java
+++ b/src/main/java/io/neonbee/hook/internal/DefaultHookRegistry.java
@@ -1,7 +1,5 @@
 package io.neonbee.hook.internal;
 
-import static io.neonbee.internal.helper.AsyncHelper.allComposite;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -71,7 +69,7 @@ public class DefaultHookRegistry implements HookRegistry {
                         registration, DefaultHookContext.of(type, parameters)))
                 .collect(Collectors.toList());
 
-        return allComposite(hookExecutions);
+        return Future.all(hookExecutions);
     }
 
     @Override

--- a/src/main/java/io/neonbee/internal/deploy/DeployableModels.java
+++ b/src/main/java/io/neonbee/internal/deploy/DeployableModels.java
@@ -15,7 +15,6 @@ import io.neonbee.NeonBee;
 import io.neonbee.entity.EntityModelDefinition;
 import io.neonbee.internal.helper.AsyncHelper;
 import io.neonbee.internal.scanner.ClassPathScanner;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
@@ -48,7 +47,7 @@ public class DeployableModels extends Deployable {
 
     @VisibleForTesting
     static Future<DeployableModels> scanClassPath(Vertx vertx, ClassPathScanner classPathScanner) {
-        // to load the models, we can use the same class-loader that the class-path-scanner uses, because we anyways
+        // to load the models, we can use the same class-loader that the class-path-scanner uses, because we anyway
         // just use it to read the resources
         ClassLoader classLoader = classPathScanner.getClassLoader(); // NOPMD false positive getClassLoader
         Future<Map<String, byte[]>> csnModelDefinitions = classPathScanner.scanManifestFiles(vertx, NEONBEE_MODELS)
@@ -56,7 +55,7 @@ public class DeployableModels extends Deployable {
         Future<Map<String, byte[]>> associatedModelDefinitions =
                 classPathScanner.scanManifestFiles(vertx, NEONBEE_MODEL_EXTENSIONS)
                         .compose(associatedModelNames -> readModelPayloads(vertx, classLoader, associatedModelNames));
-        return CompositeFuture.all(csnModelDefinitions, associatedModelDefinitions)
+        return Future.all(csnModelDefinitions, associatedModelDefinitions)
                 .map(compositeResult -> new EntityModelDefinition(csnModelDefinitions.result(),
                         associatedModelDefinitions.result()))
                 .map(DeployableModels::new);

--- a/src/main/java/io/neonbee/internal/deploy/DeployableModule.java
+++ b/src/main/java/io/neonbee/internal/deploy/DeployableModule.java
@@ -20,7 +20,6 @@ import io.neonbee.internal.SelfFirstClassLoader;
 import io.neonbee.internal.helper.AsyncHelper;
 import io.neonbee.internal.scanner.ClassPathScanner;
 import io.neonbee.logging.LoggingFacade;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
@@ -86,7 +85,7 @@ public class DeployableModule extends Deployables {
                         DeployableVerticle.scanClassPath(vertx, classPathScanner, moduleClassLoader.get());
                 Future<DeployableModels> deployableModels = DeployableModels.scanClassPath(vertx, classPathScanner);
 
-                return CompositeFuture.all(deployableVerticles, deployableModels).onComplete(scanResult -> {
+                return Future.all(deployableVerticles, deployableModels).onComplete(scanResult -> {
                     // in case scanning failed, or there are no verticles, immediately close the module class loader
                     if (scanResult.failed() || deployableVerticles.result().isEmpty()) {
                         try {

--- a/src/main/java/io/neonbee/internal/deploy/DeployableVerticle.java
+++ b/src/main/java/io/neonbee/internal/deploy/DeployableVerticle.java
@@ -1,6 +1,5 @@
 package io.neonbee.internal.deploy;
 
-import static io.neonbee.internal.helper.AsyncHelper.allComposite;
 import static io.neonbee.internal.helper.ConfigHelper.readConfig;
 import static io.vertx.core.Future.succeededFuture;
 
@@ -72,7 +71,7 @@ public class DeployableVerticle extends Deployable {
             List<Future<DeployableVerticle>> deployables =
                     classNames.stream().map(className -> fromClassName(vertx, className, verticleClassLoader))
                             .collect(Collectors.toList());
-            return allComposite(deployables).map(CompositeFuture::list);
+            return Future.all(deployables).map(CompositeFuture::list);
         });
     }
 

--- a/src/main/java/io/neonbee/internal/helper/AsyncHelper.java
+++ b/src/main/java/io/neonbee/internal/helper/AsyncHelper.java
@@ -23,11 +23,12 @@ public final class AsyncHelper {
      * {@link CompositeFuture#all(List)} again).
      *
      * @param futures The futures to be checked for completeness
-     * @return A {@link CompositeFuture}, succeeded if all of the passed futures succeeded, failing otherwise.
+     * @return A {@link CompositeFuture}, succeeded if all the passed futures succeeded, failing otherwise.
+     * @deprecated Vert.x now supports Lists containing typed Futures
      */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Deprecated(forRemoval = true)
     public static CompositeFuture allComposite(List<? extends Future<?>> futures) {
-        return CompositeFuture.all((List<Future>) (Object) futures);
+        return Future.all(futures);
     }
 
     /**
@@ -36,10 +37,11 @@ public final class AsyncHelper {
      *
      * @param futures A list of futures to be converted
      * @return A {@link CompositeFuture} containing the passed futures
+     * @deprecated Vert.x now supports Lists containing typed Futures
      */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Deprecated(forRemoval = true)
     public static CompositeFuture joinComposite(List<? extends Future<?>> futures) {
-        return CompositeFuture.join((List<Future>) (Object) futures);
+        return Future.join(futures);
     }
 
     /**

--- a/src/main/java/io/neonbee/internal/registry/SelfCleaningRegistryController.java
+++ b/src/main/java/io/neonbee/internal/registry/SelfCleaningRegistryController.java
@@ -1,7 +1,7 @@
 package io.neonbee.internal.registry;
 
-import static io.neonbee.internal.helper.AsyncHelper.allComposite;
 import static io.neonbee.internal.registry.SelfCleaningRegistry.NODE_ID_SEPARATOR;
+import static io.vertx.core.Future.all;
 import static java.util.stream.Collectors.toList;
 
 import java.util.ArrayList;
@@ -93,7 +93,7 @@ public class SelfCleaningRegistryController extends WriteSafeRegistry<String> {
                     .map(regName -> removeAllKeysForNode(nodeId, regName)
                             .compose(v -> refreshReadOnlyMap(regName)))
                     .collect(toList());
-            return allComposite(cleanedRegistries).mapEmpty();
+            return all(cleanedRegistries).mapEmpty();
         });
     }
 
@@ -116,7 +116,7 @@ public class SelfCleaningRegistryController extends WriteSafeRegistry<String> {
 
         Future<Void> valuesRemovedFuture =
                 entriesToRemove.compose(entries -> getRegistryMap(registryName).compose(registryMap -> {
-                    return allComposite(entries.stream().map(registryMap::remove).collect(toList()));
+                    return all(entries.stream().map(registryMap::remove).collect(toList()));
                 })).mapEmpty();
 
         return valuesRemovedFuture
@@ -146,7 +146,7 @@ public class SelfCleaningRegistryController extends WriteSafeRegistry<String> {
         return getReadOnlyMap(registryName).compose(readOnlyMap -> readOnlyMap.clear().compose(v -> {
             List<Future<Void>> written = new ArrayList<>();
             accumulatedValues.forEach((key, values) -> written.add(readOnlyMap.put(key, values)));
-            return allComposite(written).mapEmpty();
+            return all(written).mapEmpty();
         }));
     }
 

--- a/src/main/java/io/neonbee/internal/scanner/ClassPathScanner.java
+++ b/src/main/java/io/neonbee/internal/scanner/ClassPathScanner.java
@@ -43,7 +43,6 @@ import io.neonbee.internal.helper.FileSystemHelper;
 import io.neonbee.internal.helper.JarHelper;
 import io.neonbee.internal.helper.ThreadHelper;
 import io.neonbee.logging.LoggingFacade;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
@@ -200,7 +199,7 @@ public class ClassPathScanner {
         Future<List<String>> classesFromJars = scanJarFilesWithPredicate(vertx, ClassPathScanner::isClassFile)
                 .map(classes -> classes.stream().map(JarHelper::extractFilePath).collect(Collectors.toList()));
 
-        return CompositeFuture.all(classesFromDirectories, classesFromJars)
+        return Future.all(classesFromDirectories, classesFromJars)
                 .compose(compositeResult -> AsyncHelper.executeBlocking(vertx, () -> {
                     List<AnnotationClassVisitor> classVisitors = annotationClasses.stream()
                             .map(annotationClass -> new AnnotationClassVisitor(annotationClass, elementTypes))

--- a/src/main/java/io/neonbee/internal/scanner/DeployableScanner.java
+++ b/src/main/java/io/neonbee/internal/scanner/DeployableScanner.java
@@ -10,7 +10,6 @@ import io.neonbee.internal.deploy.DeployableVerticle;
 import io.neonbee.internal.helper.AsyncHelper;
 import io.neonbee.internal.helper.ThreadHelper;
 import io.neonbee.logging.LoggingFacade;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
@@ -37,9 +36,9 @@ public class DeployableScanner {
         Future<List<String>> deployablesFromManifest =
                 scanner.scanManifestFiles(vertx, DeployableVerticle.NEONBEE_DEPLOYABLES);
 
-        return CompositeFuture.all(deployablesFromClassPath, deployablesFromManifest)
+        return Future.all(deployablesFromClassPath, deployablesFromManifest)
                 .compose(compositeResult -> AsyncHelper.executeBlocking(vertx, () -> {
-                    // Use distinct because the Deployables mentioned in the manifest could also exists as file.
+                    // Use distinct because the Deployables mentioned in the manifest could also exist as file.
                     List<String> deployableFQNs = Streams.concat(deployablesFromClassPath.result().stream(),
                             deployablesFromManifest.result().stream()).distinct().collect(Collectors.toList());
 

--- a/src/main/java/io/neonbee/internal/scanner/HookScanner.java
+++ b/src/main/java/io/neonbee/internal/scanner/HookScanner.java
@@ -14,7 +14,6 @@ import io.neonbee.hook.Hooks;
 import io.neonbee.internal.helper.AsyncHelper;
 import io.neonbee.internal.helper.ThreadHelper;
 import io.neonbee.logging.LoggingFacade;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
@@ -65,7 +64,7 @@ public class HookScanner {
         Future<List<String>> hooksFromManifest = scanner.scanManifestFiles(vertx, NEONBEE_HOOKS)
                 .map(names -> names.stream().map(name -> name + ".class").collect(Collectors.toList()));
 
-        return CompositeFuture.all(hookClassesWithAnnotations, hooksFromManifest)
+        return Future.all(hookClassesWithAnnotations, hooksFromManifest)
                 .compose(compositeResult -> AsyncHelper.executeBlocking(vertx, () -> {
                     if (LOGGER.isInfoEnabled()) {
                         LOGGER.info("Annotated hook classes on class path {}.",

--- a/src/main/java/io/neonbee/internal/verticle/HealthCheckVerticle.java
+++ b/src/main/java/io/neonbee/internal/verticle/HealthCheckVerticle.java
@@ -11,7 +11,6 @@ import io.neonbee.NeonBeeDeployable;
 import io.neonbee.data.DataContext;
 import io.neonbee.data.DataQuery;
 import io.neonbee.data.DataVerticle;
-import io.neonbee.internal.helper.AsyncHelper;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonArray;
@@ -47,7 +46,7 @@ public class HealthCheckVerticle extends DataVerticle<JsonArray> {
     public Future<JsonArray> retrieveData(DataQuery query, DataContext context) {
         List<Future<JsonObject>> checkList = NeonBee.get(vertx).getHealthCheckRegistry().getHealthChecks().values()
                 .stream().map(hc -> hc.result().map(CheckResult::toJson)).collect(toList());
-        return AsyncHelper.allComposite(checkList).map(v -> new JsonArray(
+        return Future.all(checkList).map(v -> new JsonArray(
                 checkList.stream().map(Future::result).peek(r -> r.remove("outcome")).collect(toList())));
     }
 

--- a/src/test/java/io/neonbee/cache/BufferingDataVerticleTest.java
+++ b/src/test/java/io/neonbee/cache/BufferingDataVerticleTest.java
@@ -19,7 +19,6 @@ import io.neonbee.data.DataMap;
 import io.neonbee.data.DataQuery;
 import io.neonbee.data.DataRequest;
 import io.neonbee.test.base.DataVerticleTestBase;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -127,7 +126,7 @@ class BufferingDataVerticleTest extends DataVerticleTestBase {
     @DisplayName("Expect only one write to buffer on two parallel requests")
     void expectOneWriteToBuffer(Vertx vertx, VertxTestContext testContext) {
         delayResponse.set(true);
-        CompositeFuture.all(requestData(dr), requestData(dr))
+        Future.all(requestData(dr), requestData(dr))
                 .onComplete(testContext.succeeding(v -> testContext.verify(() -> {
                     assertThat(requireDataCount.get()).isEqualTo(2);
                     assertThat(retrieveDataCount.get()).isEqualTo(1);
@@ -142,7 +141,7 @@ class BufferingDataVerticleTest extends DataVerticleTestBase {
     void expectOneReadFromBuffer(Vertx vertx, VertxTestContext testContext) {
         respondFromBuffer.set(true);
         delayResponse.set(true);
-        CompositeFuture.all(requestData(dr), requestData(dr))
+        Future.all(requestData(dr), requestData(dr))
                 .onComplete(testContext.succeeding(v -> testContext.verify(() -> {
                     assertThat(requireDataCount.get()).isEqualTo(0);
                     assertThat(retrieveDataCount.get()).isEqualTo(0);

--- a/src/test/java/io/neonbee/cache/CachingDataVerticleTest.java
+++ b/src/test/java/io/neonbee/cache/CachingDataVerticleTest.java
@@ -20,7 +20,6 @@ import io.neonbee.data.DataMap;
 import io.neonbee.data.DataQuery;
 import io.neonbee.data.DataRequest;
 import io.neonbee.test.base.DataVerticleTestBase;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -215,7 +214,7 @@ class CachingDataVerticleTest extends DataVerticleTestBase {
 
         DataRequest dr = new DataRequest(testClass.getName());
         deployVerticle(testClass)
-                .compose(id -> CompositeFuture.all(assertDataEquals(requestData(dr), 1, testContext),
+                .compose(id -> Future.all(assertDataEquals(requestData(dr), 1, testContext),
                         assertDataEquals(requestData(dr), 1, testContext)))
                 .onComplete(testContext.succeedingThenComplete());
     }
@@ -246,7 +245,7 @@ class CachingDataVerticleTest extends DataVerticleTestBase {
 
         DataRequest dr = new DataRequest(testClass.getName());
         deployVerticle(testClass)
-                .compose(id -> CompositeFuture.all(assertDataEquals(requestData(dr), 2, testContext),
+                .compose(id -> Future.all(assertDataEquals(requestData(dr), 2, testContext),
                         assertDataEquals(requestData(dr), 2, testContext)))
                 .onComplete(testContext.succeeding(v ->
                 // Once the data is buffered though, and we *again* do a request and check response is the cached one
@@ -280,7 +279,7 @@ class CachingDataVerticleTest extends DataVerticleTestBase {
 
         DataRequest dr = new DataRequest(testClass.getName());
         deployVerticle(testClass)
-                .compose(id -> CompositeFuture.all(assertDataEquals(requestData(dr), 2, testContext),
+                .compose(id -> Future.all(assertDataEquals(requestData(dr), 2, testContext),
                         assertDataEquals(requestData(dr), 2, testContext)))
                 .onComplete(testContext.succeedingThenComplete());
     }

--- a/src/test/java/io/neonbee/cluster/LocalPreferredClusterTest.java
+++ b/src/test/java/io/neonbee/cluster/LocalPreferredClusterTest.java
@@ -25,7 +25,6 @@ import io.neonbee.data.DataQuery;
 import io.neonbee.data.DataRequest;
 import io.neonbee.data.DataVerticle;
 import io.neonbee.data.internal.DataContextImpl;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.junit5.VertxTestContext;
 
@@ -104,7 +103,7 @@ class LocalPreferredClusterTest extends NeonBeeExtension.TestBase {
     }
 
     private Future<Map<String, Long>> fireRequests(DataRequest request) {
-        return CompositeFuture.all(IntStream.rangeClosed(1, REPETITION.intValue())
+        return Future.all(IntStream.rangeClosed(1, REPETITION.intValue())
                 .mapToObj(i -> DataVerticle.requestData(localNode.getVertx(), request, new DataContextImpl()))
                 .collect(Collectors.toList())).map(cpf -> mapResponses(cpf.list()));
     }

--- a/src/test/java/io/neonbee/config/NeonBeeConfigTest.java
+++ b/src/test/java/io/neonbee/config/NeonBeeConfigTest.java
@@ -4,7 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.neonbee.config.NeonBeeConfig.DEFAULT_EVENT_BUS_TIMEOUT;
 import static io.neonbee.config.NeonBeeConfig.DEFAULT_TIME_ZONE;
 import static io.neonbee.config.NeonBeeConfig.DEFAULT_TRACKING_DATA_HANDLING_STRATEGY;
-import static io.vertx.core.CompositeFuture.all;
+import static io.vertx.core.Future.all;
 
 import java.lang.reflect.Method;
 import java.util.List;

--- a/src/test/java/io/neonbee/data/internal/metrics/DataVerticleMetricsImplTest.java
+++ b/src/test/java/io/neonbee/data/internal/metrics/DataVerticleMetricsImplTest.java
@@ -12,8 +12,8 @@ import io.neonbee.config.NeonBeeConfig;
 import io.neonbee.data.DataVerticle;
 import io.neonbee.test.base.DataVerticleTestBase;
 import io.neonbee.test.helper.WorkingDirectoryBuilder;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxTestContext;
 
@@ -33,9 +33,8 @@ class DataVerticleMetricsImplTest extends DataVerticleTestBase {
         deploymentOptions.setConfig(new JsonObject().put(DataVerticle.CONFIG_METRICS_KEY,
                 new JsonObject().put(ConfiguredDataVerticleMetrics.ENABLED, true)));
 
-        CompositeFuture
-                .all(deployVerticle(new TestSourceDataVerticle(), deploymentOptions),
-                        deployVerticle(new TestRequireDataVerticle(), deploymentOptions))
+        Future.all(deployVerticle(new TestSourceDataVerticle(), deploymentOptions),
+                deployVerticle(new TestRequireDataVerticle(), deploymentOptions))
                 .onComplete(testContext.succeedingThenComplete());
     }
 

--- a/src/test/java/io/neonbee/endpoint/odatav4/ODataV4EndpointTest.java
+++ b/src/test/java/io/neonbee/endpoint/odatav4/ODataV4EndpointTest.java
@@ -9,7 +9,7 @@ import static io.neonbee.internal.helper.CollectionHelper.multiMapToMap;
 import static io.neonbee.internal.helper.StringHelper.EMPTY;
 import static io.neonbee.test.helper.ResourceHelper.TEST_RESOURCES;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
-import static io.vertx.core.CompositeFuture.all;
+import static io.vertx.core.Future.all;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;

--- a/src/test/java/io/neonbee/entity/EntityModelLoaderTest.java
+++ b/src/test/java/io/neonbee/entity/EntityModelLoaderTest.java
@@ -20,7 +20,6 @@ import com.sap.cds.reflect.CdsModel;
 
 import io.neonbee.NeonBeeOptions;
 import io.neonbee.test.base.NeonBeeTestBase;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -49,9 +48,8 @@ class EntityModelLoaderTest extends NeonBeeTestBase {
     @DisplayName("check if multiple models can be loaded from files")
     void loadEDMXModelsTest(Vertx vertx, VertxTestContext testContext) {
         EntityModelLoader loader = new EntityModelLoader(vertx);
-        CompositeFuture
-                .all(loader.loadModel(TEST_SERVICE_1_MODEL_PATH), loader.loadModel(TEST_SERVICE_2_MODEL_PATH),
-                        loader.loadModel(REFERENCE_SERVICE_MODEL_PATH))
+        Future.all(loader.loadModel(TEST_SERVICE_1_MODEL_PATH), loader.loadModel(TEST_SERVICE_2_MODEL_PATH),
+                loader.loadModel(REFERENCE_SERVICE_MODEL_PATH))
                 .onComplete(testContext.succeeding(result -> testContext.verify(() -> {
                     assertThat(loader.models.get("io.neonbee.test1").getEdmxMetadata().getEdm().getEntityContainer()
                             .getNamespace()).isEqualTo("io.neonbee.test1.TestService1");
@@ -70,9 +68,8 @@ class EntityModelLoaderTest extends NeonBeeTestBase {
     @DisplayName("check if models from file system can be loaded")
     void loadModelsFileSystemTest(Vertx vertx, VertxTestContext testContext) {
         EntityModelLoader loader = new EntityModelLoader(vertx);
-        CompositeFuture
-                .all(loader.loadModel(TEST_SERVICE_1_MODEL_PATH), loader.loadModel(TEST_SERVICE_2_MODEL_PATH),
-                        loader.loadModel(REFERENCE_SERVICE_MODEL_PATH))
+        Future.all(loader.loadModel(TEST_SERVICE_1_MODEL_PATH), loader.loadModel(TEST_SERVICE_2_MODEL_PATH),
+                loader.loadModel(REFERENCE_SERVICE_MODEL_PATH))
                 .onComplete(testContext.succeeding(result -> testContext.verify(() -> {
                     EntityModel model = loader.models.get("io.neonbee.test1");
                     assertThat(model.getAllEdmxMetadata()).hasSize(1);

--- a/src/test/java/io/neonbee/entity/EntityModelManagerTest.java
+++ b/src/test/java/io/neonbee/entity/EntityModelManagerTest.java
@@ -29,7 +29,7 @@ import io.neonbee.NeonBeeOptions;
 import io.neonbee.test.base.NeonBeeTestBase;
 import io.neonbee.test.helper.FileSystemHelper;
 import io.neonbee.test.helper.WorkingDirectoryBuilder;
-import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxTestContext;
 
@@ -133,8 +133,7 @@ public class EntityModelManagerTest extends NeonBeeTestBase { // NOPMD (public d
                 defaultOptions().clearActiveProfiles().setWorkingDirectory(workingDir));
         EntityModelManager modelManager = neonBee.getModelManager();
 
-        CompositeFuture
-                .all(modelManager.getSharedModel("io.neonbee.test1"), modelManager.getSharedModel("io.neonbee.test2"))
+        Future.all(modelManager.getSharedModel("io.neonbee.test1"), modelManager.getSharedModel("io.neonbee.test2"))
                 .onComplete(testContext.succeeding(models -> testContext.verify(() -> {
                     assertThat(models.<EntityModel>resultAt(0).getEdmxMetadata().getEdm().getEntityContainer()
                             .getNamespace()).isEqualTo("io.neonbee.test1.TestService1");

--- a/src/test/java/io/neonbee/entity/EntityVerticleTest.java
+++ b/src/test/java/io/neonbee/entity/EntityVerticleTest.java
@@ -65,7 +65,7 @@ class EntityVerticleTest extends EntityVerticleTestBase {
     void deployEntityVerticles(VertxTestContext testContext) {
         entityVerticleImpl1 = new EntityVerticleImpl1();
         entityVerticleImpl2 = new EntityVerticleImpl2();
-        CompositeFuture.all(deployVerticle(entityVerticleImpl1), deployVerticle(entityVerticleImpl2),
+        Future.all(deployVerticle(entityVerticleImpl1), deployVerticle(entityVerticleImpl2),
                 deployVerticle(new EntityVerticleImpl3())).onComplete(testContext.succeedingThenComplete());
     }
 
@@ -94,9 +94,8 @@ class EntityVerticleTest extends EntityVerticleTestBase {
     @Test
     @DisplayName("Check if registered entity types are returned via verticlesForEntityType")
     void queryVerticlesForEntityType(Vertx vertx, VertxTestContext testContext) {
-        CompositeFuture
-                .join(EntityVerticle.getVerticlesForEntityType(vertx, new FullQualifiedName("ERP", "Customers")),
-                        EntityVerticle.getVerticlesForEntityType(vertx, new FullQualifiedName("Sales.Orders")))
+        Future.join(EntityVerticle.getVerticlesForEntityType(vertx, new FullQualifiedName("ERP", "Customers")),
+                EntityVerticle.getVerticlesForEntityType(vertx, new FullQualifiedName("Sales.Orders")))
                 .onComplete(asyncComposite -> {
                     CompositeFuture future = asyncComposite.result();
                     testContext.verify(() -> {

--- a/src/test/java/io/neonbee/health/HealthCheckRegistryTest.java
+++ b/src/test/java/io/neonbee/health/HealthCheckRegistryTest.java
@@ -33,7 +33,6 @@ import io.neonbee.data.internal.DataContextImpl;
 import io.neonbee.health.internal.HealthCheck;
 import io.neonbee.internal.SharedDataAccessor;
 import io.neonbee.internal.codec.DataQueryMessageCodec;
-import io.neonbee.internal.helper.AsyncHelper;
 import io.neonbee.internal.registry.Registry;
 import io.neonbee.internal.registry.WriteSafeRegistry;
 import io.neonbee.internal.verticle.HealthCheckVerticle;
@@ -214,7 +213,7 @@ class HealthCheckRegistryTest {
 
         // undeploy the system deployed health check verticles of neonbee
         DeploymentHelper.undeployAllVerticlesOfClass(neonBee.getVertx(), HealthCheckVerticle.class)
-                .compose(v -> AsyncHelper.allComposite(
+                .compose(v -> Future.all(
                         List.of(vertx.deployVerticle(healthCheckVerticle1), vertx.deployVerticle(healthCheckVerticle2),
                                 neonBee.getHealthCheckRegistry().register(new DummyHealthCheck(neonBee)))))
                 .onSuccess(v -> {

--- a/src/test/java/io/neonbee/helper/FileSystemHelperTest.java
+++ b/src/test/java/io/neonbee/helper/FileSystemHelperTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -50,7 +49,7 @@ class FileSystemHelperTest {
         Path subDir = tempDir.resolve("subDir");
         Path subFile = tempDir.resolve("subFile");
 
-        CompositeFuture.all(createDirs(vertx, subDir), writeFile(vertx, subFile, Buffer.buffer()))
+        Future.all(createDirs(vertx, subDir), writeFile(vertx, subFile, Buffer.buffer()))
                 .compose(v -> readDir(vertx, tempDir)).onComplete(testContext.succeeding(dirContent -> {
                     testContext.verify(() -> {
                         List<Path> tempDirContent = List.of(subFile.toRealPath(), subDir.toRealPath());
@@ -66,7 +65,7 @@ class FileSystemHelperTest {
         Path subDir = tempDir.resolve("subDir");
         Path subFile = tempDir.resolve("subFile.edmx");
 
-        CompositeFuture.all(createDirs(vertx, subDir), writeFile(vertx, subFile, Buffer.buffer()))
+        Future.all(createDirs(vertx, subDir), writeFile(vertx, subFile, Buffer.buffer()))
                 .compose(v -> readDir(vertx, tempDir, "(.+)(\\.edmx$)"))
                 .onComplete(testContext.succeeding(dirContent -> {
                     testContext.verify(() -> assertThat(dirContent).containsExactly(subFile.toRealPath()));

--- a/src/test/java/io/neonbee/internal/registry/StringRegistryTestBase.java
+++ b/src/test/java/io/neonbee/internal/registry/StringRegistryTestBase.java
@@ -1,6 +1,7 @@
 package io.neonbee.internal.registry;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.vertx.core.Future.all;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,7 +19,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import io.neonbee.internal.helper.AsyncHelper;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -75,7 +75,7 @@ abstract class StringRegistryTestBase {
 
         List<Future<Void>> registerFutures = new ArrayList<>();
         dataToFill.forEach((key, values) -> registerFutures.add(stringRegistry.register(key, values)));
-        AsyncHelper.allComposite(registerFutures).<Void>mapEmpty()
+        all(registerFutures).<Void>mapEmpty()
                 .onSuccess(verify(stringRegistry, effectiveExpected, entriesVerified, testContext))
                 .onFailure(testContext::failNow);
     }
@@ -128,7 +128,7 @@ abstract class StringRegistryTestBase {
                     List<Future<Void>> unregisterFutures = new ArrayList<>();
                     dataToUnregister
                             .forEach((key, values) -> unregisterFutures.add(stringRegistry.unregister(key, values)));
-                    return AsyncHelper.allComposite(unregisterFutures).<Void>mapEmpty();
+                    return all(unregisterFutures).<Void>mapEmpty();
                 })
                 .onSuccess(verify(stringRegistry, expected, entriesVerified, testContext))
                 .onFailure(testContext::failNow);
@@ -171,7 +171,7 @@ abstract class StringRegistryTestBase {
     private static Future<Void> fillRegistry(Registry<String> registry, Map<String, List<String>> testData) {
         List<Future<Void>> registerFutures = new ArrayList<>();
         testData.forEach((key, values) -> registerFutures.add(registry.register(key, values)));
-        return AsyncHelper.allComposite(registerFutures).mapEmpty();
+        return all(registerFutures).mapEmpty();
     }
 
     private static Future<Void> removeFromRegistry(Registry<String> registry,
@@ -179,6 +179,6 @@ abstract class StringRegistryTestBase {
         List<Future<Void>> unregisterFutures = new ArrayList<>();
         dataToUnregister.forEach((key, valueList) -> valueList
                 .forEach(value -> unregisterFutures.add(registry.unregister(key, value))));
-        return AsyncHelper.allComposite(unregisterFutures).mapEmpty();
+        return all(unregisterFutures).mapEmpty();
     }
 }

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataExpandEntityCollectionTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataExpandEntityCollectionTest.java
@@ -27,7 +27,7 @@ import io.neonbee.test.base.ODataEndpointTestBase;
 import io.neonbee.test.base.ODataRequest;
 import io.neonbee.test.endpoint.odata.verticle.NavPropsCategoriesEntityVerticle;
 import io.neonbee.test.endpoint.odata.verticle.NavPropsProductsEntityVerticle;
-import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxTestContext;
 
@@ -47,9 +47,8 @@ class ODataExpandEntityCollectionTest extends ODataEndpointTestBase {
 
     @BeforeEach
     void setUp(VertxTestContext testContext) {
-        CompositeFuture
-                .all(deployVerticle(new NavPropsProductsEntityVerticle()),
-                        deployVerticle(new NavPropsCategoriesEntityVerticle()))
+        Future.all(deployVerticle(new NavPropsProductsEntityVerticle()),
+                deployVerticle(new NavPropsCategoriesEntityVerticle()))
                 .onComplete(testContext.succeedingThenComplete());
     }
 

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataExpandEntityTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataExpandEntityTest.java
@@ -31,7 +31,7 @@ import io.neonbee.test.base.ODataEndpointTestBase;
 import io.neonbee.test.base.ODataRequest;
 import io.neonbee.test.endpoint.odata.verticle.NavPropsCategoriesEntityVerticle;
 import io.neonbee.test.endpoint.odata.verticle.NavPropsProductsEntityVerticle;
-import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxTestContext;
 
@@ -52,9 +52,8 @@ class ODataExpandEntityTest extends ODataEndpointTestBase {
 
     @BeforeEach
     void setUp(VertxTestContext testContext) {
-        CompositeFuture
-                .all(deployVerticle(new NavPropsProductsEntityVerticle()),
-                        deployVerticle(new NavPropsCategoriesEntityVerticle()))
+        Future.all(deployVerticle(new NavPropsProductsEntityVerticle()),
+                deployVerticle(new NavPropsCategoriesEntityVerticle()))
                 .onComplete(testContext.succeedingThenComplete());
     }
 

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataNavigationPropertiesTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataNavigationPropertiesTest.java
@@ -30,7 +30,7 @@ import io.neonbee.test.base.ODataEndpointTestBase;
 import io.neonbee.test.base.ODataRequest;
 import io.neonbee.test.endpoint.odata.verticle.NavPropsCategoriesEntityVerticle;
 import io.neonbee.test.endpoint.odata.verticle.NavPropsProductsEntityVerticle;
-import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxTestContext;
 
@@ -51,9 +51,8 @@ class ODataNavigationPropertiesTest extends ODataEndpointTestBase {
 
     @BeforeEach
     void setUp(VertxTestContext testContext) {
-        CompositeFuture
-                .all(deployVerticle(new NavPropsProductsEntityVerticle()),
-                        deployVerticle(new NavPropsCategoriesEntityVerticle()))
+        Future.all(deployVerticle(new NavPropsProductsEntityVerticle()),
+                deployVerticle(new NavPropsCategoriesEntityVerticle()))
                 .onComplete(testContext.succeedingThenComplete());
     }
 

--- a/src/test/java/io/neonbee/test/endpoint/odata/ODataReadEntityTest.java
+++ b/src/test/java/io/neonbee/test/endpoint/odata/ODataReadEntityTest.java
@@ -25,7 +25,7 @@ import io.neonbee.test.base.ODataEndpointTestBase;
 import io.neonbee.test.base.ODataRequest;
 import io.neonbee.test.endpoint.odata.verticle.TestService1EntityVerticle;
 import io.neonbee.test.endpoint.odata.verticle.TestService3EntityVerticle;
-import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxTestContext;
 
@@ -40,8 +40,7 @@ class ODataReadEntityTest extends ODataEndpointTestBase {
 
     @BeforeEach
     void setUp(VertxTestContext testContext) {
-        CompositeFuture
-                .all(deployVerticle(new TestService1EntityVerticle()), deployVerticle(new TestService3EntityVerticle()))
+        Future.all(deployVerticle(new TestService1EntityVerticle()), deployVerticle(new TestService3EntityVerticle()))
                 .onComplete(testContext.succeedingThenComplete());
         oDataRequest = new ODataRequestMod(TEST_ENTITY_SET_FQN);
     }

--- a/src/test/java/io/neonbee/test/helper/DeploymentHelper.java
+++ b/src/test/java/io/neonbee/test/helper/DeploymentHelper.java
@@ -6,7 +6,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
 import io.vertx.core.Verticle;
@@ -63,7 +62,7 @@ public final class DeploymentHelper {
      * @return A succeeded future, or a failed future with the cause.
      */
     public static Future<Void> undeployAllVerticlesOfClass(Vertx vertx, Class<? extends Verticle> verticleClass) {
-        return CompositeFuture
+        return Future
                 .all(getAllDeployments(vertx)
                         .filter(deployment -> deployment.getVerticles().stream().anyMatch(verticleClass::isInstance))
                         .map(deployment -> undeployVerticle(vertx, deployment.deploymentID())).collect(toList()))


### PR DESCRIPTION
In Vert.x 4.4.3 the Future API supports lists with typed Futures, which makes the AsyncHelper methods joinComposite and allComposite unnecessary. For this reason they have been marked as deprecated.