### PR TITLE
BREAKING CHANGE: set Automatic-Module-Name

### DIFF
--- a/gradle/distribution.gradle
+++ b/gradle/distribution.gradle
@@ -13,6 +13,7 @@ task coreJar(type: Jar) {
     manifest {
         attributes 'Main-Class': "${mainClass}"
         attributes 'Multi-Release': 'true' // see https://github.com/infinispan/infinispan-quarkus/issues/55#issuecomment-995027501
+        attributes('Automatic-Module-Name': 'io.neonbee.core')
     }
 
     exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/NOTICE', 'META-INF/LICENSE'


### PR DESCRIPTION
Currently, the automatic module name is resolved to `neonbee.core`. This commit changes the automatic module name to `io.neonbee.core`.