### PR TITLE
Feat/http response headers nb0.31

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
 }
 
 group = 'io.neonbee'
-version = '0.31.1'
+version = '0.31.2-SNAPSHOT'
 mainClassName = 'io.neonbee.Launcher'
 archivesBaseName = 'neonbee-core'
 sourceCompatibility = 11

--- a/src/main/java/io/neonbee/endpoint/Endpoint.java
+++ b/src/main/java/io/neonbee/endpoint/Endpoint.java
@@ -1,6 +1,7 @@
 package io.neonbee.endpoint;
 
 import io.neonbee.config.EndpointConfig;
+import io.neonbee.data.DataContext;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -9,6 +10,26 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 
 public interface Endpoint {
+
+    /**
+     * This constant is used as a key within the {@link DataContext#responseData()} map to specify the content type of
+     * the HTTP response.
+     * <p>
+     * The value associated with this key is intended to be used as the value for the "Content-Type" header in the HTTP
+     * response.
+     */
+    String CONTENT_TYPE_HINT = "Content-Type";
+
+    /**
+     * This constant is used as a key within the {@link DataContext#responseData()} map to specify a map containing
+     * additional HTTP response header values.
+     * <p>
+     * All entries in the map specified by this key are added to the HTTP response headers, allowing for the flexible
+     * inclusion of various headers. If `CONTENT_TYPE_HINT` is specified both as a standalone key and within this map,
+     * the standalone `CONTENT_TYPE_HINT` takes precedence, and the entry within the map will be ignored.
+     */
+    String RESPONSE_HEADERS_HINT = "RESPONSE_HEADERS";
+
     /**
      * Get the default configuration for a given endpoint.
      * <p>


### PR DESCRIPTION
feat: allow to set HTTP response values

All HTTP headers from the `DataContext` response data
`RESPONSE_HEADERS` are set in the HTTP response.