### PR TITLE
fix: mitigate problem with ChainAuthHandler

### DIFF
--- a/src/main/java/io/neonbee/internal/handler/ChainAuthHandler.java
+++ b/src/main/java/io/neonbee/internal/handler/ChainAuthHandler.java
@@ -29,16 +29,16 @@ public interface ChainAuthHandler extends AuthenticationHandler {
             return NOOP_AUTHENTICATION_HANDLER;
         }
 
-        io.vertx.ext.web.handler.ChainAuthHandler chainAuthHandler = io.vertx.ext.web.handler.ChainAuthHandler.any();
-        List<AuthenticationHandler> authHandlers =
-                authChainConfig.stream().map(config -> config.createAuthHandler(vertx)).toList();
-        authHandlers.forEach(chainAuthHandler::add);
+        List<AuthenticationHandler> authHandlers = authChainConfig.stream()
+                .map(config -> config.createAuthHandler(vertx)).toList();
 
-        return new ChainAuthHandler() {
-            @Override
-            public void handle(RoutingContext event) {
-                chainAuthHandler.handle(event);
-            }
-        };
+        if (authHandlers.size() == 1) {
+            AuthenticationHandler authenticationHandler = authHandlers.get(0);
+            return authenticationHandler::handle;
+        }
+
+        io.vertx.ext.web.handler.ChainAuthHandler chainAuthHandler = io.vertx.ext.web.handler.ChainAuthHandler.any();
+        authHandlers.forEach(chainAuthHandler::add);
+        return chainAuthHandler::handle;
     }
 }


### PR DESCRIPTION
A problem with the ChainAuthHandler was introduced in vert.x version 4.5.6. To mitigate the issue, we do not use the vert.x ChainAuthHandler when only one AuthenticationHandler is used. The problem still exists when more than one AuthenticationHandler is used.

https://github.com/vert-x3/vertx-web/issues/2611