### PR TITLE
fix: null check

### DIFF
--- a/src/main/java/io/neonbee/internal/cluster/entity/ClusterEntityRegistry.java
+++ b/src/main/java/io/neonbee/internal/cluster/entity/ClusterEntityRegistry.java
@@ -77,7 +77,7 @@ public class ClusterEntityRegistry implements Registry<String> {
     @Override
     public Future<Void> unregister(String sharedMapKey, String value) {
         return Future.all(entityRegistry.unregister(sharedMapKey, value), clusteringInformation
-                        .unregister(getClusterNodeId(), clusterRegistrationInformation(sharedMapKey, value)))
+                .unregister(getClusterNodeId(), clusterRegistrationInformation(sharedMapKey, value)))
                 .mapEmpty();
     }
 

--- a/src/test/java/io/neonbee/internal/cluster/entity/ClusterEntityRegistryTest.java
+++ b/src/test/java/io/neonbee/internal/cluster/entity/ClusterEntityRegistryTest.java
@@ -99,6 +99,14 @@ class ClusterEntityRegistryTest {
     }
 
     @Test
+    @DisplayName("unregister non-existing node")
+    void unregisterEmptyNode(Vertx vertx, VertxTestContext context) {
+        ClusterEntityRegistry registry = new TestClusterEntityRegistry(vertx, REGISTRY_NAME);
+        registry.unregisterNode("TestClusterEntityRegistry.CLUSTER_NODE_ID")
+                .onSuccess(mapValue -> context.completeNow()).onFailure(context::failNow);
+    }
+
+    @Test
     @DisplayName("unregister node with two nodes with same entities")
     void unregisterNode2(Vertx vertx, VertxTestContext context) {
         Checkpoint checkpoint = context.checkpoint(5);


### PR DESCRIPTION
The following exception potentially breaks the hazelcast cluster and we need to restart the cluster + approuter.

```
java.lang.NullPointerException: Cannot invoke "io.vertx.core.json.JsonArray.copy()" because the return value of "java.util.Map.remove(Object)" is null,
at io.neonbee.internal.cluster.entity.ClusterEntityRegistry.lambda$unregisterNode$1(ClusterEntityRegistry.java:127),
```