### PR TITLE
bug: caching data verticle filter fix

### DIFF
--- a/src/main/java/io/neonbee/cache/CachingDataVerticle.java
+++ b/src/main/java/io/neonbee/cache/CachingDataVerticle.java
@@ -348,8 +348,8 @@ public abstract class CachingDataVerticle<T> extends DataVerticle<T> {
                         if (lock != null) {
                             lock.release(); // safety-safe, or if data was cached in the meantime!
                         }
-                    })).compose(data -> filterDataFromCache(query, data, context));
-        });
+                    }));
+        }).compose(data -> filterDataFromCache(query, data, context));
     }
 
     /**


### PR DESCRIPTION
Previously, the `CachingDataVerticle` would not call `FilterDataFromCache` if the data was already cached in `cacheRegister`, as the future would succeed directly, bypassing `FilterDataFromCache` inside the `retrieveData` method. The fix involves attaching the `FilterDataFromCache` composition to the outer future instead of the inner future that handles locking. This ensures that `FilterDataFromCache` is executed in all cases, whether the data is fetched from `cacheRegister` or retrieved via `cache` or `retrieveDataToCache`.