### PR TITLE
chore(codeql): update CodeQL Action to v3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         packs: carlspring/vertx-codeql-queries
         languages: java
@@ -52,7 +52,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -65,6 +65,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
           category: "/language:java"


### PR DESCRIPTION
CodeQL Action major versions v1 and v2 have been deprecated. This updates all occurrences of CodeQL Action to v3 to ensure compatibility.

Reference: https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/