### PR TITLE
fix(ci): update actions/cache to v4 to prevent deprecation issues

### DIFF
--- a/.github/workflows/voter.yml
+++ b/.github/workflows/voter.yml
@@ -33,7 +33,7 @@ jobs:
         cache: 'gradle'
 
     - name: Cache SonarCloud packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar


### PR DESCRIPTION
This commit updates the GitHub Actions workflow to use `actions/cache@v4` instead of the deprecated `actions/cache@v2`. Failure was caused by GitHub's deprecation of v1/v2, effective December 5, 2024. See: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-break