### PR TITLE
fix: make ClassPathScanner ignore abstract classes

### DIFF
--- a/src/main/java/io/neonbee/internal/scanner/AnnotationClassVisitor.java
+++ b/src/main/java/io/neonbee/internal/scanner/AnnotationClassVisitor.java
@@ -70,7 +70,8 @@ class AnnotationClassVisitor extends ClassVisitor {
 
     @Override
     public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-        if (includeTypes && ((this.access & Opcodes.ACC_PUBLIC) != 0) && annotationClassDescriptor.equals(desc)) {
+        if (includeTypes && ((this.access & Opcodes.ACC_PUBLIC) != 0) && (this.access & Opcodes.ACC_ABSTRACT) == 0
+                && annotationClassDescriptor.equals(desc)) {
             classNames.add(className);
         }
 

--- a/src/test/java/io/neonbee/internal/scanner/AnnotatedClassTemplate.java
+++ b/src/test/java/io/neonbee/internal/scanner/AnnotatedClassTemplate.java
@@ -15,6 +15,8 @@ public class AnnotatedClassTemplate implements ClassTemplate {
 
     private static final String PLACEHOLDER_IMPORTS = "<imports>";
 
+    private static final String PLACEHOLDER_VISIBILITY = "<visibility>";
+
     private static final String PLACEHOLDER_CLASS_NAME = "<ClassName>";
 
     private static final String PLACEHOLDER_TYPE_ANNOTATION = "<TypeAnnotation>";
@@ -22,6 +24,8 @@ public class AnnotatedClassTemplate implements ClassTemplate {
     private static final String PLACEHOLDER_FIELD_ANNOTATION = "<FieldAnnotation>";
 
     private static final String PLACEHOLDER_METHOD_ANNOTATION = "<MethodAnnotation>";
+
+    private final String visibility;
 
     private final String packageName;
 
@@ -55,6 +59,19 @@ public class AnnotatedClassTemplate implements ClassTemplate {
      * @throws IOException Template file could not be read
      */
     public AnnotatedClassTemplate(String simpleClassName, String packageName) throws IOException {
+        this(null, simpleClassName, packageName);
+    }
+
+    /**
+     * Creates a dummy annotated class
+     *
+     * @param visibility      The visibility of the class (public, private, protected, default)
+     * @param simpleClassName The simple class name of the new class
+     * @param packageName     The package name of the class. Pass null for default package
+     * @throws IOException Template file could not be read
+     */
+    public AnnotatedClassTemplate(String visibility, String simpleClassName, String packageName) throws IOException {
+        this.visibility = visibility != null ? visibility : "public";
         this.packageName = packageName;
         this.simpleClassName = simpleClassName;
         this.template = TEST_RESOURCES.getRelated("AnnotatedClass.java.template").toString();
@@ -98,7 +115,8 @@ public class AnnotatedClassTemplate implements ClassTemplate {
             packageNameReplacement = "package " + packageName + ";";
         }
 
-        return template.replace(PLACEHOLDER_CLASS_NAME, simpleClassName)
+        return template.replace(PLACEHOLDER_VISIBILITY, visibility)
+                .replace(PLACEHOLDER_CLASS_NAME, simpleClassName)
                 .replace(PLACEHOLDER_IMPORTS, buildImportString()).replace(PLACEHOLDER_PACKAGE, packageNameReplacement)
                 .replace(PLACEHOLDER_TYPE_ANNOTATION, Optional.ofNullable(typeAnnotation).orElse(""))
                 .replace(PLACEHOLDER_FIELD_ANNOTATION, Optional.ofNullable(fieldAnnotation).orElse(""))

--- a/src/test/java/io/neonbee/internal/scanner/ClassPathScannerTest.java
+++ b/src/test/java/io/neonbee/internal/scanner/ClassPathScannerTest.java
@@ -126,6 +126,9 @@ class ClassPathScannerTest {
     void scanForAnnotation(Vertx vertx, VertxTestContext testContext) throws IOException {
         BasicJar jarWithTypeAnnotatedClass =
                 new AnnotatedClassTemplate("Hodor", "type").setTypeAnnotation("@Deprecated").asJar();
+        BasicJar jarWithAbstractTypeAnnotatedClass =
+                new AnnotatedClassTemplate("public abstract", "AbstractHodor", "type").setTypeAnnotation("@Deprecated")
+                        .asJar();
         BasicJar jarWithFieldAnnotatedClass =
                 new AnnotatedClassTemplate("Hodor", "field").setFieldAnnotation("@Deprecated").asJar();
         BasicJar jarWithMethodAnnotatedClass =
@@ -135,8 +138,11 @@ class ClassPathScannerTest {
                 .setMethodAnnotation("@Transient").setImports(List.of("java.beans.Transient")).asJar();
 
         URL[] urlc = Stream
-                .of(jarWithTypeAnnotatedClass.writeToTempURL(), jarWithFieldAnnotatedClass.writeToTempURL(),
-                        jarWithMethodAnnotatedClass.writeToTempURL(), jarWithMethodAnnotatedClass2.writeToTempURL())
+                .of(jarWithTypeAnnotatedClass.writeToTempURL(),
+                        jarWithAbstractTypeAnnotatedClass.writeToTempURL(),
+                        jarWithFieldAnnotatedClass.writeToTempURL(),
+                        jarWithMethodAnnotatedClass.writeToTempURL(),
+                        jarWithMethodAnnotatedClass2.writeToTempURL())
                 .flatMap(Stream::of).toArray(URL[]::new);
         ClassPathScanner cps = new ClassPathScanner(new URLClassLoader(urlc, null));
 
@@ -144,7 +150,6 @@ class ClassPathScannerTest {
 
         futureContainsExactly(testContext, annotationsScanned, cps.scanForAnnotation(vertx, Deprecated.class, TYPE),
                 "type.Hodor");
-
         futureContainsExactly(testContext, annotationsScanned, cps.scanForAnnotation(vertx, Deprecated.class, FIELD),
                 "field.Hodor");
         futureContainsExactly(testContext, annotationsScanned, cps.scanForAnnotation(vertx, Deprecated.class, METHOD),

--- a/src/test/resources/io/neonbee/internal/scanner/AnnotatedClass.java.template
+++ b/src/test/resources/io/neonbee/internal/scanner/AnnotatedClass.java.template
@@ -3,7 +3,7 @@
 <imports>
 
 <TypeAnnotation>
-public class <ClassName> {
+<visibility> class <ClassName> {
 
     <FieldAnnotation>
     private String hodor = "hodor";


### PR DESCRIPTION
Currently ClassPathScanner is returning public abstract classes, which fail to initialize, e.g. when trying deploying NeonBeeDeployable. This change fixes this by limiting ClassPathScanner for classes that are public and non-abstract.