### PR TITLE
feat: remove future implementation from the pendingdeployment class

### DIFF
--- a/src/main/java/io/neonbee/NeonBee.java
+++ b/src/main/java/io/neonbee/NeonBee.java
@@ -621,7 +621,7 @@ public class NeonBee {
     private Future<Void> deployServerVerticle() {
         LOGGER.info("Deploying server verticle ...");
         return fromClass(vertx, ServerVerticle.class, new JsonObject().put("instances", NUMBER_DEFAULT_INSTANCES))
-                .compose(deployable -> deployable.deploy(this)).mapEmpty();
+                .compose(deployable -> deployable.deploy(this).getDeployment()).mapEmpty();
     }
 
     /**

--- a/src/main/java/io/neonbee/internal/deploy/PendingDeployment.java
+++ b/src/main/java/io/neonbee/internal/deploy/PendingDeployment.java
@@ -4,23 +4,14 @@ import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
 
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 import io.neonbee.NeonBee;
 import io.neonbee.logging.LoggingFacade;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Expectation;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.impl.ContextInternal;
-import io.vertx.core.impl.future.Expect;
-import io.vertx.core.impl.future.FutureInternal;
-import io.vertx.core.impl.future.Listener;
 
-public abstract class PendingDeployment extends Deployment implements FutureInternal<Deployment> {
+public abstract class PendingDeployment extends Deployment {
     private static final LoggingFacade LOGGER = LoggingFacade.create();
 
     private final Future<String> deployFuture;
@@ -58,13 +49,6 @@ public abstract class PendingDeployment extends Deployment implements FutureInte
     }
 
     @Override
-    public Future<Deployment> expecting(Expectation<? super Deployment> expectation) {
-        Expect<Deployment> expect = new Expect(context(), expectation);
-        this.addListener(expect);
-        return expect;
-    }
-
-    @Override
     public final Future<Void> undeploy() {
         Deployable deployable = getDeployable();
         if (!deployFuture.isComplete()) {
@@ -94,104 +78,12 @@ public abstract class PendingDeployment extends Deployment implements FutureInte
      */
     protected abstract Future<Void> undeploy(String deploymentId);
 
-    private Future<Deployment> mapDeployment() {
-        return deployFuture.map((Deployment) this);
-    }
-
-    @Override
-    public String getDeploymentId() {
-        return deployFuture.result();
-    }
-
-    @Override
-    public boolean isComplete() {
-        return deployFuture.isComplete();
-    }
-
-    @Override
-    public Future<Deployment> onComplete(Handler<AsyncResult<Deployment>> handler) {
-        return mapDeployment().onComplete(handler);
-    }
-
-    @Override
-    public Deployment result() {
-        return succeeded() ? this : null;
-    }
-
-    @Override
-    public Throwable cause() {
-        return deployFuture.cause();
-    }
-
-    @Override
-    public boolean succeeded() {
-        return deployFuture.succeeded();
-    }
-
-    @Override
-    public boolean failed() {
-        return deployFuture.failed();
-    }
-
-    @Override
-    public <U> Future<U> compose(Function<Deployment, Future<U>> successMapper,
-            Function<Throwable, Future<U>> failureMapper) {
-        return mapDeployment().compose(successMapper, failureMapper);
-    }
-
-    @Override
-    public <U> Future<U> transform(Function<AsyncResult<Deployment>, Future<U>> mapper) {
-        return mapDeployment().transform(mapper);
-    }
-
-    @Override
-    @Deprecated
-    public <U> Future<Deployment> eventually(Function<Void, Future<U>> mapper) {
-        return mapDeployment().eventually(mapper);
-    }
-
-    @Override
-    public <U> Future<Deployment> eventually(Supplier<Future<U>> supplier) {
-        return mapDeployment().eventually(supplier);
-    }
-
-    @Override
-    public <U> Future<U> map(Function<Deployment, U> mapper) {
-        return mapDeployment().map(mapper);
-    }
-
-    @Override
-    public <V> Future<V> map(V value) {
-        return mapDeployment().map(value);
-    }
-
-    @Override
-    public Future<Deployment> otherwise(Function<Throwable, Deployment> mapper) {
-        return mapDeployment().otherwise(mapper);
-    }
-
-    @Override
-    public Future<Deployment> otherwise(Deployment value) {
-        return mapDeployment().otherwise(value);
-    }
-
-    @Override
-    public ContextInternal context() {
-        return ((FutureInternal<String>) deployFuture).context();
-    }
-
-    @Override
-    public void addListener(Listener<Deployment> listener) {
-        ((FutureInternal<Deployment>) mapDeployment()).addListener(listener);
-    }
-
-    @Override
-    public void removeListener(Listener<Deployment> listener) {
-        ((FutureInternal<Deployment>) mapDeployment()).removeListener(listener);
-    }
-
-    @Override
-    public Future<Deployment> timeout(long delay, TimeUnit unit) {
-        return mapDeployment().timeout(delay, unit);
+    /**
+     * Returns the Deployment object after deployment is completed.
+     *
+     * @return future containing deployment object.
+     */
+    public Future<Deployment> getDeployment() {
+        return deployFuture.map(id -> this);
     }
 }

--- a/src/main/java/io/neonbee/internal/verticle/DeployerVerticle.java
+++ b/src/main/java/io/neonbee/internal/verticle/DeployerVerticle.java
@@ -57,7 +57,7 @@ public class DeployerVerticle extends WatchVerticle {
 
         DeployableModule.fromJar(vertx, affectedPath).compose(deployableModule -> {
             // The deploy method automatically cleans up in case of failure.
-            return deployableModule.deploy(NeonBee.get(vertx)).compose(deployment -> {
+            return deployableModule.deploy(NeonBee.get(vertx)).getDeployment().compose(deployment -> {
                 Deployment replacedModule = deployedModules.put(affectedPath, deployment);
                 if (Objects.isNull(replacedModule)) {
                     return Future.succeededFuture();

--- a/src/test/java/io/neonbee/internal/deploy/DeployableModelsTest.java
+++ b/src/test/java/io/neonbee/internal/deploy/DeployableModelsTest.java
@@ -60,7 +60,7 @@ class DeployableModelsTest {
         NeonBee neonBeeMock = newNeonBeeMockForDeployment(new NeonBeeOptions.Mutable().setIgnoreClassPath(true));
 
         PendingDeployment deployment = deployable.deploy(neonBeeMock);
-        assertThat(deployment.succeeded()).isTrue();
+        assertThat(deployment.getDeployment().succeeded()).isTrue();
         Set<EntityModelDefinition> definitions =
                 ReflectionHelper.getValueOfPrivateField(neonBeeMock.getModelManager(), "externalModelDefinitions");
         assertThat(definitions).contains(definition);
@@ -80,8 +80,8 @@ class DeployableModelsTest {
         when(vertxMock.fileSystem().readDir(any())).thenReturn(failedFuture("any failure"));
 
         PendingDeployment deployment = deployable.deploy(neonBeeMock);
-        assertThat(deployment.failed()).isTrue();
-        assertThat(deployment.cause()).hasMessageThat().isEqualTo("any failure");
+        assertThat(deployment.getDeployment().failed()).isTrue();
+        assertThat(deployment.getDeployment().cause()).hasMessageThat().isEqualTo("any failure");
         assertThat(deployment.undeploy().succeeded()).isTrue();
     }
 

--- a/src/test/java/io/neonbee/internal/deploy/DeployableModuleTest.java
+++ b/src/test/java/io/neonbee/internal/deploy/DeployableModuleTest.java
@@ -79,7 +79,7 @@ class DeployableModuleTest {
         URLClassLoader classLoaderMock = mock(URLClassLoader.class);
         PendingDeployment deployment = new DeployableModule("module", classLoaderMock, List.of())
                 .deploy(neonBeeMock);
-        assertThat(deployment.succeeded()).isTrue();
+        assertThat(deployment.getDeployment().succeeded()).isTrue();
         assertThat(deployment.undeploy().succeeded()).isTrue();
         verify(classLoaderMock).close();
     }

--- a/src/test/java/io/neonbee/internal/deploy/DeployableTest.java
+++ b/src/test/java/io/neonbee/internal/deploy/DeployableTest.java
@@ -35,15 +35,15 @@ class DeployableTest {
     @DisplayName("test deploy/undeploy of Deployable")
     void testDeployUndeploy() {
         DeployableThing deployable = new DeployableThing("foo");
-        assertThat(deployable.deploy().succeeded()).isTrue();
+        assertThat(deployable.deploy().getDeployment().succeeded()).isTrue();
         assertThat(deployable.deploy().undeploy().succeeded()).isTrue();
 
         deployable.undeployFuture = failedFuture("foo");
-        assertThat(deployable.deploy().succeeded()).isTrue();
+        assertThat(deployable.deploy().getDeployment().succeeded()).isTrue();
         assertThat(deployable.deploy().undeploy().failed()).isTrue();
 
         deployable.deployFuture = failedFuture("foo");
-        assertThat(deployable.deploy().failed()).isTrue();
+        assertThat(deployable.deploy().getDeployment().failed()).isTrue();
     }
 
     static class DeployableThing extends Deployable {

--- a/src/test/java/io/neonbee/internal/deploy/DeployableVerticleTest.java
+++ b/src/test/java/io/neonbee/internal/deploy/DeployableVerticleTest.java
@@ -82,7 +82,7 @@ class DeployableVerticleTest {
         assertThat(deployable1.getIdentifier()).isEqualTo(DUMMY_VERTICLE.getClass().getName());
 
         PendingDeployment deployment1 = deployable1.deploy(neonBeeMock);
-        assertThat(deployment1.succeeded()).isTrue();
+        assertThat(deployment1.getDeployment().succeeded()).isTrue();
         verify(vertxMock).deployVerticle(DUMMY_VERTICLE, deployable1.options);
 
         assertThat(deployment1.undeploy().succeeded()).isTrue();
@@ -92,7 +92,7 @@ class DeployableVerticleTest {
         assertThat(deployable2.getIdentifier()).isEqualTo(DUMMY_VERTICLE.getClass().getName());
 
         PendingDeployment deployment2 = deployable2.deploy(neonBeeMock);
-        assertThat(deployment2.succeeded()).isTrue();
+        assertThat(deployment2.getDeployment().succeeded()).isTrue();
         verify(vertxMock).deployVerticle(DUMMY_VERTICLE.getClass(), deployable2.options);
 
         assertThat(deployment2.undeploy().succeeded()).isTrue();
@@ -110,8 +110,8 @@ class DeployableVerticleTest {
         DeployableVerticle deployable = new DeployableVerticle(DUMMY_VERTICLE, new DeploymentOptions());
 
         PendingDeployment deployment = deployable.deploy(neonBeeMock);
-        assertThat(deployment.failed()).isTrue();
-        assertThat(deployment.cause()).hasMessageThat().isEqualTo("any failure");
+        assertThat(deployment.getDeployment().failed()).isTrue();
+        assertThat(deployment.getDeployment().cause()).hasMessageThat().isEqualTo("any failure");
         assertThat(deployment.undeploy().succeeded()).isTrue();
     }
 

--- a/src/test/java/io/neonbee/internal/deploy/DeployablesTest.java
+++ b/src/test/java/io/neonbee/internal/deploy/DeployablesTest.java
@@ -83,7 +83,7 @@ class DeployablesTest {
         PendingDeployment deployment = deployables.deploy(neonBeeMock);
 
         // regular deploying and undeploying works
-        assertThat(deployment.succeeded()).isTrue();
+        assertThat(deployment.getDeployment().succeeded()).isTrue();
         assertThat(deployable1.deploying).isTrue();
         assertThat(deployable2.deploying).isTrue();
         assertThat(deployable1.undeploying).isFalse();
@@ -96,7 +96,7 @@ class DeployablesTest {
         deployableThings.forEach(DeployableThing::reset);
         deployable1.deployFuture = failedFuture("fail");
         deployment = deployables.deploy(neonBeeMock);
-        assertThat(deployment.succeeded()).isFalse();
+        assertThat(deployment.getDeployment().succeeded()).isFalse();
         assertThat(deployable1.deploying).isTrue();
         assertThat(deployable2.deploying).isTrue();
         assertThat(deployable1.undeploying).isFalse(); // the deployment of 1 failed, so no need to undeploy
@@ -106,7 +106,7 @@ class DeployablesTest {
         deployableThings.forEach(DeployableThing::reset);
         deployable2.deployFuture = failedFuture("fail");
         deployment = deployables.deploy(neonBeeMock);
-        assertThat(deployment.succeeded()).isFalse();
+        assertThat(deployment.getDeployment().succeeded()).isFalse();
         assertThat(deployable1.deploying).isTrue();
         assertThat(deployable2.deploying).isTrue();
         assertThat(deployable1.undeploying).isTrue();
@@ -116,7 +116,7 @@ class DeployablesTest {
         deployableThings.forEach(DeployableThing::reset);
         deployable1.undeployFuture = failedFuture("fail");
         deployment = deployables.deploy(neonBeeMock);
-        assertThat(deployment.succeeded()).isTrue();
+        assertThat(deployment.getDeployment().succeeded()).isTrue();
         assertThat(deployable1.deploying).isTrue();
         assertThat(deployable2.deploying).isTrue();
         assertThat(deployable1.undeploying).isFalse();
@@ -130,19 +130,19 @@ class DeployablesTest {
         deployable1.deployFuture = failedFuture("deployfail");
         deployable2.undeployFuture = failedFuture("undeployfail");
         deployment = deployables.deploy(neonBeeMock);
-        assertThat(deployment.succeeded()).isFalse();
+        assertThat(deployment.getDeployment().succeeded()).isFalse();
         assertThat(deployable1.deploying).isTrue();
         assertThat(deployable2.deploying).isTrue();
         assertThat(deployable1.undeploying).isFalse(); // because it failed in the first place
         assertThat(deployable2.undeploying).isTrue();
-        assertThat(deployment.cause().getMessage()).isEqualTo("deployfail");
+        assertThat(deployment.getDeployment().cause().getMessage()).isEqualTo("deployfail");
 
         // undeploy hook should be called and be able to influence the result on success
         deployableThings.forEach(DeployableThing::reset);
         deployment = deployables.deploy(neonBeeMock, undeploymentResult -> {
             return failedFuture("testfailed");
         });
-        assertThat(deployment.succeeded()).isTrue();
+        assertThat(deployment.getDeployment().succeeded()).isTrue();
         assertThat(deployment.undeploy().cause().getMessage()).isEqualTo("testfailed");
 
         // undeploy hook should be called in any case, but not influence the original result on failure
@@ -151,12 +151,12 @@ class DeployablesTest {
         deployment = deployables.deploy(neonBeeMock, undeploymentResult -> {
             return succeededFuture();
         });
-        assertThat(deployment.succeeded()).isTrue();
+        assertThat(deployment.getDeployment().succeeded()).isTrue();
         assertThat(deployment.undeploy().cause().getMessage()).isEqualTo("undeployfailed");
         deployment = deployables.deploy(neonBeeMock, undeploymentResult -> {
             return failedFuture("testfailed");
         });
-        assertThat(deployment.succeeded()).isTrue();
+        assertThat(deployment.getDeployment().succeeded()).isTrue();
         assertThat(deployment.undeploy().cause().getMessage()).isEqualTo("undeployfailed");
 
         // keep partial deployments
@@ -164,7 +164,7 @@ class DeployablesTest {
         deployable1.deployFuture = failedFuture("fail");
         deployables.keepPartialDeployment();
         deployment = deployables.deploy(neonBeeMock);
-        assertThat(deployment.succeeded()).isFalse();
+        assertThat(deployment.getDeployment().succeeded()).isFalse();
         assertThat(deployable1.deploying).isTrue();
         assertThat(deployable2.deploying).isTrue();
         assertThat(deployable1.undeploying).isFalse();

--- a/src/test/java/io/neonbee/internal/deploy/PendingDeploymentTest.java
+++ b/src/test/java/io/neonbee/internal/deploy/PendingDeploymentTest.java
@@ -9,18 +9,12 @@ import static io.vertx.core.Future.succeededFuture;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +24,6 @@ import io.neonbee.internal.deploy.DeployableTest.DeployableThing;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.impl.future.FutureInternal;
 
 class PendingDeploymentTest {
     @Test
@@ -50,88 +43,7 @@ class PendingDeploymentTest {
     void getDeploymentIdTest() {
         String deploymentId = "Hodor";
         PendingDeployment deployment = new TestPendingDeployment(succeededFuture(deploymentId));
-        assertThat(deployment.getDeploymentId()).isEqualTo(deploymentId);
-    }
-
-    @Test
-    void setHandlerTest() {
-        Promise<String> deployPromise = Promise.promise();
-        PendingDeployment deployment = new TestPendingDeployment(deployPromise.future());
-        assertThat(deployment.isComplete()).isFalse();
-        deployPromise.complete("test");
-        assertThat(deployment.isComplete()).isTrue();
-        assertThat(deployment.succeeded()).isTrue();
-        assertThat(deployment.result().getDeploymentId()).isEqualTo("test");
-    }
-
-    @Test
-    @SuppressWarnings({ "unchecked", "deprecation" })
-    void testFutureInterface() {
-        FutureInternal<String> futureMock = mock(FutureInternal.class);
-        doReturn(futureMock).when(futureMock).map((Function<String, ?>) any());
-        doReturn(futureMock).when(futureMock).map((Supplier<String>) any());
-        doReturn(futureMock).when(futureMock).map((Deployable) any());
-        doReturn(futureMock).when(futureMock).onSuccess(any());
-        doReturn(futureMock).when(futureMock).onFailure(any());
-
-        PendingDeployment deployment = new TestPendingDeployment(futureMock);
-        verify(futureMock).map((Function<String, ?>) any());
-        verify(futureMock).onSuccess(any());
-        verify(futureMock).onFailure(any());
-
-        deployment.isComplete();
-        verify(futureMock).isComplete();
-
-        deployment.onComplete(null);
-        verify(futureMock).onComplete(any());
-
-        deployment.result();
-        verify(futureMock).succeeded();
-        clearInvocations(futureMock);
-
-        deployment.cause();
-        verify(futureMock).cause();
-
-        deployment.succeeded();
-        verify(futureMock).succeeded();
-
-        deployment.failed();
-        verify(futureMock).failed();
-
-        deployment.compose(null);
-        verify(futureMock).compose(any(), any());
-
-        deployment.transform(null);
-        verify(futureMock).transform(any());
-
-        deployment.eventually((Function) null);
-        verify(futureMock).eventually((Function) any());
-
-        deployment.eventually((Supplier) null);
-        verify(futureMock).eventually((Supplier) any());
-
-        clearInvocations(futureMock);
-        deployment.map((Function<String, ?>) null);
-        verify(futureMock, atLeastOnce()).map(any(Object.class));
-
-        clearInvocations(futureMock);
-        deployment.map((String) null);
-        verify(futureMock, atLeastOnce()).map(any(Object.class));
-
-        deployment.otherwise((Function<Throwable, Deployment>) null);
-        verify(futureMock).otherwise((Function<Throwable, String>) any());
-
-        deployment.otherwise((Deployment) null);
-        verify(futureMock).otherwise((String) any());
-
-        deployment.context();
-        verify(futureMock).context();
-
-        deployment.addListener(null);
-        verify(futureMock).addListener(any());
-
-        deployment.timeout(10, TimeUnit.SECONDS);
-        verify(futureMock).timeout(10, TimeUnit.SECONDS);
+        assertThat(deployment.getDeployment().result().getDeployable().getIdentifier()).isEqualTo(deploymentId);
     }
 
     @Test
@@ -186,7 +98,7 @@ class PendingDeploymentTest {
         }
 
         protected TestPendingDeployment(NeonBee neonBee, String deployableType, Future<String> deployFuture) {
-            super(neonBee, new DeployableThing("foo") {
+            super(neonBee, new DeployableThing("Hodor") {
                 @Override
                 public String getType() {
                     return deployableType == null ? super.getType() : deployableType;

--- a/src/test/java/io/neonbee/test/base/NeonBeeTestBase.java
+++ b/src/test/java/io/neonbee/test/base/NeonBeeTestBase.java
@@ -300,7 +300,7 @@ public class NeonBeeTestBase {
      */
     public Future<Deployment> deployVerticle(Verticle verticle) {
         return DeployableVerticle.fromVerticle(neonBee.getVertx(), verticle, null)
-                .compose(deployable -> deployable.deploy(neonBee))
+                .compose(deployable -> deployable.deploy(neonBee).getDeployment())
                 .onSuccess(result -> LOGGER.info("Successfully deployed verticle {}", verticle))
                 .onFailure(throwable -> LOGGER.error("Failed to deploy verticle {}", verticle, throwable));
     }
@@ -313,7 +313,7 @@ public class NeonBeeTestBase {
      * @return A succeeded future with the Deployment, or a failed future with the cause.
      */
     public Future<Deployment> deployVerticle(Verticle verticle, DeploymentOptions options) {
-        return new DeployableVerticle(verticle, options).deploy(neonBee)
+        return new DeployableVerticle(verticle, options).deploy(neonBee).getDeployment()
                 .onSuccess(result -> LOGGER.info("Successfully deployed verticle {}", verticle))
                 .onFailure(throwable -> LOGGER.error("Failed to deploy verticle {}", verticle, throwable));
     }
@@ -326,7 +326,7 @@ public class NeonBeeTestBase {
      */
     public Future<Deployment> deployVerticle(Class<? extends Verticle> verticleClass) {
         return DeployableVerticle.fromClass(neonBee.getVertx(), verticleClass, null)
-                .compose(deployable -> deployable.deploy(neonBee))
+                .compose(deployable -> deployable.deploy(neonBee).getDeployment())
                 .onSuccess(
                         result -> LOGGER.info("Successfully deployed verticle with class {}", verticleClass.getName()))
                 .onFailure(throwable -> LOGGER.error("Failed to deploy verticle with class {}", verticleClass.getName(),
@@ -341,7 +341,7 @@ public class NeonBeeTestBase {
      * @return A succeeded future with the Deployment, or a failed future with the cause.
      */
     public Future<Deployment> deployVerticle(Class<? extends Verticle> verticleClass, DeploymentOptions options) {
-        return new DeployableVerticle(verticleClass, options).deploy(neonBee)
+        return new DeployableVerticle(verticleClass, options).deploy(neonBee).getDeployment()
                 .onSuccess(
                         result -> LOGGER.info("Successfully deployed verticle with class {}", verticleClass.getName()))
                 .onFailure(throwable -> LOGGER.error("Failed to deploy verticle with class {}", verticleClass.getName(),


### PR DESCRIPTION

The Future implementation has been removed from PendingDeployment to support the migration from Vert.x 4 to Vert.x 5. The PendingDeployment class now returns objects directly, rather than Futures.
