### PR TITLE
fix: skips registration when collectClusteredResults false.

### DIFF
--- a/src/main/java/io/neonbee/internal/verticle/HealthCheckVerticle.java
+++ b/src/main/java/io/neonbee/internal/verticle/HealthCheckVerticle.java
@@ -43,7 +43,9 @@ public class HealthCheckVerticle extends DataVerticle<JsonArray> {
     @Override
     public void start(Promise<Void> promise) {
         Future.<Void>future(super::start).compose(v -> {
-            if (NeonBee.get(vertx).getOptions().isClustered()) {
+            NeonBee neonBee = NeonBee.get(vertx);
+            if (neonBee.getOptions().isClustered()
+                    && neonBee.getConfig().getHealthConfig().doCollectClusteredResults()) {
                 return register(vertx);
             }
             return Future.succeededFuture();


### PR DESCRIPTION
The change at HealthCheckVerticle.java:47-48 now skips the distributed lock registration when collectClusteredResults is false. 
Since no node will read the shared map in that configuration, there's no reason to write to it — and the startup lock contention is mitigated