### PR TITLE
fix: ClassPathScanner — Filter to NeonBee module JARs only

### DIFF
--- a/src/main/java/io/neonbee/internal/scanner/ClassPathScanner.java
+++ b/src/main/java/io/neonbee/internal/scanner/ClassPathScanner.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -69,6 +70,8 @@ public class ClassPathScanner {
      * The pattern which is used to separate values in the manifest.ml.
      */
     public static final Pattern SEPARATOR_PATTERN = Pattern.compile(";");
+
+    private static final String NEONBEE_MANIFEST_PREFIX = "NeonBee-";
 
     private final ClassLoader classLoader;
 
@@ -195,14 +198,15 @@ public class ClassPathScanner {
             ElementType... elementTypes) {
 
         Future<List<String>> classesFromDirectories = scanWithPredicate(vertx, ClassPathScanner::isClassFile);
-        Future<List<String>> classesFromJars = scanJarFilesWithPredicate(vertx, ClassPathScanner::isClassFile)
-                .map(uris -> {
-                    List<String> result = new ArrayList<>(uris.size());
-                    for (URI uri : uris) {
-                        result.add(JarHelper.extractFilePath(uri));
-                    }
-                    return result;
-                });
+        Future<List<String>> classesFromJars =
+                scanJarFilesWithPredicate(vertx, ClassPathScanner::isClassFile, ClassPathScanner::isNeonBeeJar)
+                        .map(uris -> {
+                            List<String> result = new ArrayList<>(uris.size());
+                            for (URI uri : uris) {
+                                result.add(JarHelper.extractFilePath(uri));
+                            }
+                            return result;
+                        });
 
         return Future.all(classesFromDirectories, classesFromJars).compose(v -> vertx.executeBlocking(() -> {
             List<AnnotationClassVisitor> classVisitors = new ArrayList<>(annotationClasses.size());
@@ -282,12 +286,16 @@ public class ClassPathScanner {
      * @return a future to a list of URIs representing the files which matches the given predicate
      */
     public Future<List<URI>> scanJarFilesWithPredicate(Vertx vertx, Predicate<String> predicate) {
+        return scanJarFilesWithPredicate(vertx, predicate, url -> true);
+    }
+
+    private Future<List<URI>> scanJarFilesWithPredicate(Vertx vertx, Predicate<String> predicate,
+            Predicate<URL> jarFilter) {
         return vertx.executeBlocking(() -> {
             List<URI> resources = new ArrayList<>();
             for (URL manifestResource : getManifestResourceURLs()) {
                 URI uri = manifestResource.toURI();
-                // filter for manifest files inside of jar files
-                if ("jar".equals(uri.getScheme())) {
+                if ("jar".equals(uri.getScheme()) && jarFilter.test(manifestResource)) {
                     try (FileSystem fileSystem = FileSystems.newFileSystem(uri, Map.of())) {
                         Path rootPath = fileSystem.getPath("/");
                         scanDirectoryWithPredicateRecursive(rootPath, predicate)
@@ -297,6 +305,21 @@ public class ClassPathScanner {
             }
             return resources;
         });
+    }
+
+    @SuppressWarnings("PMD.EmptyCatchBlock")
+    private static boolean isNeonBeeJar(URL manifestUrl) {
+        try (InputStream is = manifestUrl.openStream()) {
+            Manifest manifest = new Manifest(is);
+            Attributes attributes = manifest.getMainAttributes();
+            for (Object key : attributes.keySet()) {
+                if (key.toString().startsWith(NEONBEE_MANIFEST_PREFIX)) {
+                    return true;
+                }
+            }
+        } catch (IOException e) { // NOPMD
+        }
+        return false;
     }
 
     /**

--- a/src/test/java/io/neonbee/internal/scanner/AnnotatedClassTemplate.java
+++ b/src/test/java/io/neonbee/internal/scanner/AnnotatedClassTemplate.java
@@ -111,6 +111,7 @@ public class AnnotatedClassTemplate implements ClassTemplate {
     }
 
     public BasicJar asJar() throws IOException {
-        return new BasicJar(Map.of(BasicJar.getJarEntryName(getClassName()), compileToByteCode()));
+        return new BasicJar(Map.of("NeonBee-Module", "test"),
+                Map.of(BasicJar.getJarEntryName(getClassName()), compileToByteCode()));
     }
 }

--- a/src/test/java/io/neonbee/internal/scanner/ClassPathScannerTest.java
+++ b/src/test/java/io/neonbee/internal/scanner/ClassPathScannerTest.java
@@ -119,6 +119,22 @@ class ClassPathScannerTest {
     }
 
     @Test
+    @DisplayName("Should skip non-NeonBee JARs during annotation scanning")
+    void scanForAnnotationSkipsNonNeonBeeJars(Vertx vertx, VertxTestContext testContext) throws IOException {
+        BasicJar nonNeonBeeJar = new BasicJar(
+                Map.of(BasicJar.getJarEntryName("some.ThirdPartyClass"),
+                        new AnnotatedClassTemplate("ThirdPartyClass", "some")
+                                .setTypeAnnotation("@Deprecated").compileToByteCode()));
+
+        URLClassLoader urlc = new URLClassLoader(nonNeonBeeJar.writeToTempURL(), null);
+        new ClassPathScanner(urlc).scanForAnnotation(vertx, Deprecated.class)
+                .onComplete(testContext.succeeding(list -> testContext.verify(() -> {
+                    assertThat(list).isEmpty();
+                    testContext.completeNow();
+                })));
+    }
+
+    @Test
     @DisplayName("Should find classes which the class or any field or method within is annotated with a given annotation")
     void scanForAnnotation(Vertx vertx, VertxTestContext testContext) throws IOException {
         BasicJar jarWithTypeAnnotatedClass =


### PR DESCRIPTION
ClassPathScanner — Filter to NeonBee module JARs only

  Overview

  This change addresses a blocked thread issue in Kubernetes/Kyma environments where scanForAnnotation blocks a Vert.x worker thread for 87+ seconds reading all JARs on the classpath. The fix pre-filters JARs by checking their manifest for NeonBee-* attributes before doing the expensive filesystem walk.

  Correctness

  - Reading a small MANIFEST.MF is cheaper than opening a FileSystem and walking an entire JAR.
  - Public API preserved. scanJarFilesWithPredicate(Vertx, Predicate<String>) delegates with url -> true, so existing callers (including forJarFile) are unaffected.
  - One subtle issue: isNeonBeeJar reads the manifest via manifestUrl.openStream(), and then later in the loop, the same manifest URL is used to create a FileSystem. This means the manifest is read twice for NeonBee JARs (once in the filter, once when
  FileSystems.newFileSystem opens it). Not a correctness bug, but a minor inefficiency. Given the goal is to skip 100+ non-NeonBee JARs, the double-read of the few NeonBee JARs is negligible.

