### PR TITLE
fix(test): replace fragile instance-identity check in EntityModelLoadTest

### DIFF
--- a/src/test/java/io/neonbee/entity/EntityModelLoaderTest.java
+++ b/src/test/java/io/neonbee/entity/EntityModelLoaderTest.java
@@ -16,7 +16,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-import com.sap.cds.reflect.CdsModel;
+import com.sap.cds.reflect.CdsEntity;
+import com.sap.cds.reflect.CdsService;
 
 import io.neonbee.NeonBeeOptions;
 import io.neonbee.test.base.NeonBeeTestBase;
@@ -120,12 +121,14 @@ class EntityModelLoaderTest extends NeonBeeTestBase {
     @DisplayName("check if getting CSN Model works")
     void getCSNModelTest(Vertx vertx, VertxTestContext testContext) {
         EntityModelLoader loader = new EntityModelLoader(vertx);
-        Future<CdsModel> csnModelFuture = loader.readCsnModel(TEST_SERVICE_1_MODEL_PATH);
-        csnModelFuture.compose(v -> loader.loadModel(TEST_SERVICE_1_MODEL_PATH))
-                .onComplete(testContext.succeeding(result -> testContext.verify(() -> {
-                    CdsModel expectedCsnModel = csnModelFuture.result();
-                    EntityModel model = loader.models.get("io.neonbee.test1");
-                    assertThat(model.getCsnModel()).isEqualTo(expectedCsnModel);
+        loader.loadModel(TEST_SERVICE_1_MODEL_PATH)
+                .onComplete(testContext.succeeding(v -> testContext.verify(() -> {
+                    var csnModel = loader.models.get("io.neonbee.test1").getCsnModel();
+                    assertThat(csnModel.services().map(CdsService::getQualifiedName).toList())
+                            .containsExactly("io.neonbee.test1.TestService1");
+                    assertThat(csnModel.entities().map(CdsEntity::getQualifiedName).toList())
+                            .containsExactly("io.neonbee.test1.TestService1.AllPropertiesNullable",
+                                    "io.neonbee.test.TestService1.TestProducts");
                     testContext.completeNow();
                 })));
     }


### PR DESCRIPTION
The previous assertion relied on CdsModelReader's internal Caffeine weak-reference cache returning the same CdsModel instance for two separate readCsnModel calls on the same file. Under GC pressure on CI the weak reference is collected between the two calls, producing different instances and a spurious test failure.

Replace with a structural assertion on the qualified names of services and entities, which is stable, meaningful, and independent of caching behaviour.