### PR TITLE
fix: keep entity verticle requests local when a local instance exists

### DIFF
--- a/src/main/java/io/neonbee/entity/AbstractEntityVerticle.java
+++ b/src/main/java/io/neonbee/entity/AbstractEntityVerticle.java
@@ -9,6 +9,7 @@ import static io.vertx.core.Future.succeededFuture;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -101,6 +102,12 @@ public abstract class AbstractEntityVerticle<T> extends DataVerticle<T> {
             Pattern.compile("^/*((?:(.+/?)\\.)?([^/]+))/(([A-Za-z_]\\w+)[^/]*)(?:/(.*))?$");
 
     private static final LoggingFacade LOGGER = LoggingFacade.create();
+
+    /**
+     * The FQN consumer addresses ({@code EntityVerticle[<FQN>]}) this verticle registered, tracked so they can be
+     * registered as local consumers (to keep same-node requests local) and unregistered again on stop.
+     */
+    private final Set<String> registeredEntityAddresses = ConcurrentHashMap.newKeySet();
 
     /**
      * Create a new {@link DataVerticle}.
@@ -236,11 +243,17 @@ public abstract class AbstractEntityVerticle<T> extends DataVerticle<T> {
                 .map(names -> names != null ? names : Set.<FullQualifiedName>of())
                 .compose(names -> {
                     String ownAddress = getAddress();
+                    NeonBee neonBee = NeonBee.get(vertx);
                     List<Future<Void>> registrations = names.stream().map(fqn -> {
                         String fqnAddress = sharedEntityMapName(fqn);
                         return vertx.eventBus().<DataQuery>consumer(fqnAddress,
                                 msg -> vertx.eventBus().request(ownAddress, msg.body(),
-                                        new DeliveryOptions().setHeaders(msg.headers()))
+                                        // The FQN consumer only exists to hand the request to the co-located verticle
+                                        // instance. Force local-only delivery: ownAddress (DataVerticle[<name>]) is
+                                        // registered on every node running this verticle, so without this the inner
+                                        // hop round-robins across the cluster — defeating the whole point of routing to
+                                        // the local FQN consumer and forcing cross-node EntityWrapper serialization.
+                                        new DeliveryOptions().setHeaders(msg.headers()).setLocalOnly(true))
                                         .onSuccess(reply -> msg.reply(reply.body(),
                                                 new DeliveryOptions().setHeaders(reply.headers())))
                                         .onFailure(err -> msg.fail(
@@ -248,10 +261,30 @@ public abstract class AbstractEntityVerticle<T> extends DataVerticle<T> {
                                                         : INTERNAL_SERVER_ERROR.code(),
                                                 err.getMessage())))
                                 .completion()
-                                .<Void>mapEmpty();
+                                .<Void>mapEmpty()
+                                .onSuccess(nothing -> {
+                                    // Mark the FQN address as locally available so that (local-preferred) requests to
+                                    // this entity type resolve to the local instance instead of being round-robined
+                                    // across the cluster, which would force cross-node EntityWrapper serialization.
+                                    if (neonBee != null) {
+                                        neonBee.registerLocalConsumer(fqnAddress);
+                                        registeredEntityAddresses.add(fqnAddress);
+                                    }
+                                });
                     }).toList();
                     return Future.all(registrations).mapEmpty();
                 });
+    }
+
+    @Override
+    public void stop() throws Exception {
+        // Unregister the FQN addresses this verticle marked as local consumers in registerEntityTypeConsumers.
+        NeonBee neonBee = NeonBee.get(vertx);
+        if (neonBee != null) {
+            registeredEntityAddresses.forEach(neonBee::unregisterLocalConsumer);
+        }
+        registeredEntityAddresses.clear();
+        super.stop();
     }
 
     /**

--- a/src/test/java/io/neonbee/cluster/EntityVerticleLocalPreferredClusterTest.java
+++ b/src/test/java/io/neonbee/cluster/EntityVerticleLocalPreferredClusterTest.java
@@ -1,0 +1,119 @@
+package io.neonbee.cluster;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.neonbee.test.helper.DeploymentHelper.deployVerticle;
+import static io.neonbee.test.helper.DeploymentHelper.undeployAllVerticlesOfClass;
+import static io.vertx.core.Future.succeededFuture;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.olingo.commons.api.data.Entity;
+import org.apache.olingo.commons.api.data.Property;
+import org.apache.olingo.commons.api.data.ValueType;
+import org.apache.olingo.commons.api.edm.FullQualifiedName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.neonbee.NeonBee;
+import io.neonbee.NeonBeeDeployable;
+import io.neonbee.NeonBeeExtension;
+import io.neonbee.NeonBeeInstanceConfiguration;
+import io.neonbee.data.DataContext;
+import io.neonbee.data.DataQuery;
+import io.neonbee.data.DataRequest;
+import io.neonbee.data.internal.DataContextImpl;
+import io.neonbee.entity.EntityVerticle;
+import io.neonbee.entity.EntityWrapper;
+import io.neonbee.internal.cluster.ClusterHelper;
+import io.vertx.core.Future;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * Verifies the routing of entity verticle requests in a clustered setup using the in-JVM
+ * {@link io.vertx.test.fakecluster.FakeClusterManager} (so it needs no external infrastructure and is CI-safe).
+ * <p>
+ * Entity verticles register a consumer at the shared FQN address {@code EntityVerticle[<FQN>]} which forwards to the
+ * co-located {@code DataVerticle[<name>]} instance. When the same entity verticle is deployed on multiple nodes both
+ * the FQN address and the inner {@code DataVerticle[<name>]} address exist on every node. These tests assert that a
+ * request with a local instance available always resolves to the local instance and never round-robins across the
+ * cluster - covering both the outer FQN hop and the inner forward hop.
+ */
+class EntityVerticleLocalPreferredClusterTest extends NeonBeeExtension.TestBase {
+
+    static final FullQualifiedName ENTITY_FQN = new FullQualifiedName("cluster.test", "NodeTagged");
+
+    private static final String NODE_PROPERTY = "node";
+
+    private static final long REPETITION = 10L;
+
+    private NeonBee localNode;
+
+    @BeforeEach
+    @DisplayName("Set up two cluster nodes and deploy the entity verticle on both")
+    void setUp(@NeonBeeInstanceConfiguration(clustered = true, activeProfiles = {}) NeonBee localNode,
+            @NeonBeeInstanceConfiguration(clustered = true, activeProfiles = {}) NeonBee remoteNode,
+            VertxTestContext testContext) {
+        this.localNode = localNode;
+        deployVerticle(localNode.getVertx(), new NodeTaggingEntityVerticle())
+                .compose(v -> deployVerticle(remoteNode.getVertx(), new NodeTaggingEntityVerticle()))
+                .onComplete(testContext.succeedingThenComplete());
+    }
+
+    @Test
+    @DisplayName("entity requests with a local instance available always resolve locally (never round-robin)")
+    void testEntityRequestPrefersLocalInstance(VertxTestContext testContext) {
+        String localNodeId = ClusterHelper.getClusterNodeId(localNode.getVertx());
+        fireEntityRequests(localNode).onComplete(testContext.succeeding(responses -> {
+            testContext.verify(() -> {
+                // Every request must have been served by the local instance - proves neither the outer FQN hop nor
+                // the inner DataVerticle[<name>] forward round-robined to the remote node.
+                assertThat(responses).containsExactly(localNodeId, REPETITION);
+            });
+            testContext.completeNow();
+        }));
+    }
+
+    @Test
+    @DisplayName("the FQN address is registered and deregistered as a local consumer with the verticle lifecycle")
+    void testFqnAddressLocalConsumerRegistration(VertxTestContext testContext) {
+        String fqnAddress = "EntityVerticle[" + ENTITY_FQN.getFullQualifiedNameAsString() + "]";
+        assertThat(localNode.isLocalConsumerAvailable(fqnAddress)).isTrue();
+        undeployAllVerticlesOfClass(localNode.getVertx(), NodeTaggingEntityVerticle.class)
+                .onComplete(testContext.succeeding(v -> {
+                    testContext.verify(
+                            () -> assertThat(localNode.isLocalConsumerAvailable(fqnAddress)).isFalse());
+                    testContext.completeNow();
+                }));
+    }
+
+    private Future<Map<String, Long>> fireEntityRequests(NeonBee from) {
+        return Future.all(IntStream.rangeClosed(1, (int) REPETITION)
+                .mapToObj(i -> EntityVerticle.requestEntity(from.getVertx(),
+                        new DataRequest(ENTITY_FQN, new DataQuery()), new DataContextImpl()))
+                .toList())
+                .map(cf -> cf.<EntityWrapper>list().stream()
+                        .map(ew -> (String) ew.getEntities().get(0).getProperty(NODE_PROPERTY).getValue())
+                        .collect(Collectors.groupingBy(node -> node, Collectors.counting())));
+    }
+
+    @NeonBeeDeployable(namespace = "cluster", autoDeploy = false)
+    public static class NodeTaggingEntityVerticle extends EntityVerticle {
+        @Override
+        public Future<Set<FullQualifiedName>> entityTypeNames() {
+            return succeededFuture(Set.of(ENTITY_FQN));
+        }
+
+        @Override
+        public Future<EntityWrapper> retrieveData(DataQuery query, DataContext context) {
+            // Tag the response with the id of the node that actually served it, so the caller can assert routing.
+            Entity entity = new Entity();
+            entity.addProperty(new Property(null, NODE_PROPERTY, ValueType.PRIMITIVE,
+                    ClusterHelper.getClusterNodeId(vertx)));
+            return succeededFuture(new EntityWrapper(ENTITY_FQN, entity));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Entity verticles register a consumer at the shared FQN address `EntityVerticle[<FQN>]` which forwards to the co-located `DataVerticle[<name>]` instance. In a clustered setup where the same entity verticle runs on multiple nodes, **both** addresses are registered on every node, so a request could be round-robined to a remote instance.

When the remote instance replies with an `EntityWrapper` for an entity type whose OData model is **not buffered on the requesting node**, `EntityWrapperMessageCodec.encodeToWire` fails, the reply is never delivered, and the caller times out after 30s — surfacing as an intermittent **HTTP 500**.

This was observed in production on the `calendar` service: `TimelineEvents` intermittently 500'd because its nested `ProductMaping` entity request round-robined cross-node and the (unmodeled) `EntityWrapper` reply could not be serialized back.

## Fix

Two changes in `AbstractEntityVerticle`:

1. **Inner forward is local-only** — the FQN consumer forwards to `ownAddress` with `setLocalOnly(true)`. Its only job is to hand off to the co-located instance; it must never round-robin across the cluster.
2. **FQN address registered as a local consumer** — on deployment the `EntityVerticle[<FQN>]` address is added to NeonBee's local-consumer registry (and removed on `stop()`), so local-preferred requests resolve to the local instance.

## Test

`EntityVerticleLocalPreferredClusterTest` uses the in-JVM `FakeClusterManager` (no external infra, CI-safe). Deploys a node-tagging entity verticle on both nodes and asserts requests with a local instance always resolve locally. Verified it **fails without the fix** (30s reply timeout on `DataVerticle[...]`) and **passes with it**.